### PR TITLE
add validation for duration fields and omit empty values

### DIFF
--- a/litellm/resource_key.go
+++ b/litellm/resource_key.go
@@ -3,9 +3,11 @@ package litellm
 import (
 	"context"
 	"fmt"
+	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func resourceKey() *schema.Resource {
@@ -56,6 +58,10 @@ func resourceKey() *schema.Resource {
 			"budget_duration": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ValidateFunc: validation.StringMatch(
+					regexp.MustCompile(`^(\d+[smhd])$`),
+					"budget_duration must be a duration string like '30s', '30m', '30h', or '30d'",
+				),
 			},
 			"allowed_cache_controls": {
 				Type:     schema.TypeList,
@@ -70,11 +76,7 @@ func resourceKey() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"duration": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"aliases": {
+				"aliases": {
 				Type:     schema.TypeMap,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
@@ -197,7 +199,6 @@ func mapResourceDataToKey(d *schema.ResourceData, key *Key) {
 	key.AllowedCacheControls = expandStringList(d.Get("allowed_cache_controls").([]interface{}))
 	key.SoftBudget = d.Get("soft_budget").(float64)
 	key.KeyAlias = d.Get("key_alias").(string)
-	key.Duration = d.Get("duration").(string)
 	key.Aliases = d.Get("aliases").(map[string]interface{})
 	key.Config = d.Get("config").(map[string]interface{})
 	key.Permissions = d.Get("permissions").(map[string]interface{})
@@ -247,9 +248,6 @@ func mapKeyToResourceData(d *schema.ResourceData, key *Key) {
 	}
 	if key.KeyAlias != "" {
 		d.Set("key_alias", key.KeyAlias)
-	}
-	if key.Duration != "" {
-		d.Set("duration", key.Duration)
 	}
 	if key.Aliases != nil {
 		d.Set("aliases", key.Aliases)

--- a/litellm/resource_key.go
+++ b/litellm/resource_key.go
@@ -199,6 +199,7 @@ func mapResourceDataToKey(d *schema.ResourceData, key *Key) {
 	key.AllowedCacheControls = expandStringList(d.Get("allowed_cache_controls").([]interface{}))
 	key.SoftBudget = d.Get("soft_budget").(float64)
 	key.KeyAlias = d.Get("key_alias").(string)
+	key.Duration = d.Get("duration").(string)
 	key.Aliases = d.Get("aliases").(map[string]interface{})
 	key.Config = d.Get("config").(map[string]interface{})
 	key.Permissions = d.Get("permissions").(map[string]interface{})

--- a/litellm/resource_key.go
+++ b/litellm/resource_key.go
@@ -258,6 +258,9 @@ func mapKeyToResourceData(d *schema.ResourceData, key *Key) {
 	if key.KeyAlias != "" {
 		d.Set("key_alias", key.KeyAlias)
 	}
+	if key.Duration != "" {
+		d.Set("duration", key.Duration)
+	}
 	if key.Aliases != nil {
 		d.Set("aliases", key.Aliases)
 	}

--- a/litellm/resource_key.go
+++ b/litellm/resource_key.go
@@ -76,7 +76,15 @@ func resourceKey() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-				"aliases": {
+			"duration": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringMatch(
+					regexp.MustCompile(`^(\d+[smhd])$`),
+					"duration must be a duration string like '30s', '30m', '30h', or '30d'",
+				),
+			},
+			"aliases": {
 				Type:     schema.TypeMap,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},

--- a/litellm/resource_key_schema.go
+++ b/litellm/resource_key_schema.go
@@ -1,7 +1,10 @@
 package litellm
 
-import (
+import (	
+	"regexp"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func resourceKeySchema() map[string]*schema.Schema {
@@ -52,6 +55,10 @@ func resourceKeySchema() map[string]*schema.Schema {
 		"budget_duration": {
 			Type:     schema.TypeString,
 			Optional: true,
+			ValidateFunc: validation.StringMatch(
+				regexp.MustCompile(`^(\d+[smhd])$`),
+				"budget_duration must be a duration string like '30s', '30m', '30h', or '30d'",
+			),
 		},
 		"allowed_cache_controls": {
 			Type:     schema.TypeList,
@@ -69,6 +76,10 @@ func resourceKeySchema() map[string]*schema.Schema {
 		"duration": {
 			Type:     schema.TypeString,
 			Optional: true,
+			ValidateFunc: validation.StringMatch(
+				regexp.MustCompile(`^(\d+[smhd])$`),
+				"duration must be a duration string like '30s', '30m', '30h', or '30d'",
+			),
 		},
 		"aliases": {
 			Type:     schema.TypeMap,

--- a/litellm/resource_team.go
+++ b/litellm/resource_team.go
@@ -6,9 +6,11 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"regexp"
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 const (
@@ -54,6 +56,10 @@ func ResourceLiteLLMTeam() *schema.Resource {
 			"budget_duration": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ValidateFunc: validation.StringMatch(
+					regexp.MustCompile(`^(\d+[smhd])$`),
+					"budget_duration must be a duration string like '30s', '30m', '30h', or '30d'",
+				),
 			},
 			"models": {
 				Type:     schema.TypeList,

--- a/litellm/types.go
+++ b/litellm/types.go
@@ -90,7 +90,7 @@ type Key struct {
 	Metadata             map[string]interface{} `json:"metadata,omitempty"`
 	TPMLimit             int                    `json:"tpm_limit,omitempty"`
 	RPMLimit             int                    `json:"rpm_limit,omitempty"`
-	BudgetDuration       string                 `json:"budget_duration"`
+	BudgetDuration       string                 `json:"budget_duration,omitempty"`
 	AllowedCacheControls []string               `json:"allowed_cache_controls,omitempty"`
 	SoftBudget           float64                `json:"soft_budget,omitempty"`
 	KeyAlias             string                 `json:"key_alias,omitempty"`


### PR DESCRIPTION
Hi,

I've encountered an issue with `budget_duration`.
After digging through the source code and adding some more logging, I discovered that the request payload for `key/new` is invalid:
```
{"models":["gemini/gemini-2.5-pro","gemini/gemini-2.0-flash"],"team_id":"f05f00ab-7d44-4f3d-8216-f7fb14f8388c","budget_duration":"","blocked":false}
```
Turns out that `omitempty` was missing.

I've also added some validation for durations (my error but the validation should help).
![image](https://github.com/user-attachments/assets/ec6f94d2-3621-4cd8-8e93-7b3104a9da3a)

This is my first experience with go, hope it is right.
It does compile and work locally.

Best regards,

Gitii
