### PR TITLE
Improvement security in generate Key and Validation in the update key

### DIFF
--- a/litellm/client.go
+++ b/litellm/client.go
@@ -64,30 +64,62 @@ func (c *Client) GetKey(keyID string) (*Key, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	return c.parseKeyResponse(resp)
 }
 
 func (c *Client) UpdateKey(key *Key) (*Key, error) {
 	// Create a new map with only the fields that can be updated
-	updateData := map[string]interface{}{
-		"key":                   key.Key,
-		"models":                key.Models,
-		"max_budget":            key.MaxBudget,
-		"team_id":               key.TeamID,
-		"max_parallel_requests": key.MaxParallelRequests,
-		"metadata":              key.Metadata,
-		"tpm_limit":             key.TPMLimit,
-		"rpm_limit":             key.RPMLimit,
-		"budget_duration":       key.BudgetDuration,
-		"key_alias":             key.KeyAlias,
-		"aliases":               key.Aliases,
-		"permissions":           key.Permissions,
-		"model_max_budget":      key.ModelMaxBudget,
-		"model_rpm_limit":       key.ModelRPMLimit,
-		"model_tpm_limit":       key.ModelTPMLimit,
-		"guardrails":            key.Guardrails,
-		"blocked":               key.Blocked,
+	updateData := make(map[string]interface{})
+	updateData["key"] = key.Key
+	updateData["blocked"] = key.Blocked
+
+	if len(key.Models) > 0 {
+		updateData["models"] = key.Models
+	}
+	if key.MaxBudget != 0 {
+		updateData["max_budget"] = key.MaxBudget
+	}
+	if key.TeamID != "" {
+		updateData["team_id"] = key.TeamID
+	}
+	if key.MaxParallelRequests != 0 {
+		updateData["max_parallel_requests"] = key.MaxParallelRequests
+	}
+	if key.Metadata != nil {
+		updateData["metadata"] = key.Metadata
+	}
+	if key.TPMLimit != 0 {
+		updateData["tpm_limit"] = key.TPMLimit
+	}
+	if key.RPMLimit != 0 {
+		updateData["rpm_limit"] = key.RPMLimit
+	}
+	if key.BudgetDuration != "" {
+		updateData["budget_duration"] = key.BudgetDuration
+	}
+	if key.KeyAlias != "" {
+		updateData["key_alias"] = key.KeyAlias
+	}
+	if key.Aliases != nil {
+		updateData["aliases"] = key.Aliases
+	}
+	if key.Permissions != nil {
+		updateData["permissions"] = key.Permissions
+	}
+	if key.ModelMaxBudget != nil {
+		updateData["model_max_budget"] = key.ModelMaxBudget
+	}
+	if key.ModelRPMLimit != nil {
+		updateData["model_rpm_limit"] = key.ModelRPMLimit
+	}
+	if key.ModelTPMLimit != nil {
+		updateData["model_tpm_limit"] = key.ModelTPMLimit
+	}
+	if len(key.Guardrails) > 0 {
+		updateData["guardrails"] = key.Guardrails
+	}
+	if len(key.Tags) > 0 {
+		updateData["tags"] = key.Tags
 	}
 
 	resp, err := c.sendRequest("POST", "/key/update", updateData)

--- a/litellm/resource_key.go
+++ b/litellm/resource_key.go
@@ -136,15 +136,18 @@ func resourceKeyCreate(ctx context.Context, d *schema.ResourceData, m interface{
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error creating key: %s", err))
 	}
-
-	d.SetId(createdKey.Key)
+	d.SetId(createdKey.KeyAlias)
+	d.Set("key", createdKey.Key)
 	return resourceKeyRead(ctx, d, m)
 }
 
 func resourceKeyRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	c := m.(*Client)
 
-	key, err := c.GetKey(d.Id())
+	// Using tag "key" for ommiter id value in plan and in apply terraform
+	keyValue := d.Get("key").(string)
+
+	key, err := c.GetKey(keyValue)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error reading key: %s", err))
 	}
@@ -161,7 +164,10 @@ func resourceKeyRead(ctx context.Context, d *schema.ResourceData, m interface{})
 func resourceKeyUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	c := m.(*Client)
 
-	key := &Key{Key: d.Id()}
+	// Using tag "key" for ommiter id value in plan and in apply terraform
+	keyValue := d.Get("key").(string)
+
+	key := &Key{Key: keyValue}
 	mapResourceDataToKey(d, key)
 
 	_, err := c.UpdateKey(key)
@@ -175,7 +181,10 @@ func resourceKeyUpdate(ctx context.Context, d *schema.ResourceData, m interface{
 func resourceKeyDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	c := m.(*Client)
 
-	err := c.DeleteKey(d.Id())
+	// Using tag "key" for ommiter id value in plan and in apply terraform
+	keyValue := d.Get("key").(string)
+
+	err := c.DeleteKey(keyValue)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error deleting key: %s", err))
 	}

--- a/litellm/resource_key.go
+++ b/litellm/resource_key.go
@@ -16,8 +16,9 @@ func resourceKey() *schema.Resource {
 		DeleteContext: resourceKeyDelete,
 		Schema: map[string]*schema.Schema{
 			"key": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
 			},
 			"models": {
 				Type:     schema.TypeList,

--- a/litellm/types.go
+++ b/litellm/types.go
@@ -90,7 +90,7 @@ type Key struct {
 	Metadata             map[string]interface{} `json:"metadata,omitempty"`
 	TPMLimit             int                    `json:"tpm_limit,omitempty"`
 	RPMLimit             int                    `json:"rpm_limit,omitempty"`
-	BudgetDuration       string                 `json:"budget_duration"`
+	BudgetDuration       string                 `json:"budget_duration,omitempty"`
 	AllowedCacheControls []string               `json:"allowed_cache_controls,omitempty"`
 	SoftBudget           float64                `json:"soft_budget,omitempty"`
 	KeyAlias             string                 `json:"key_alias,omitempty"`


### PR DESCRIPTION
## Improvement security in generate Key:

### Set the KeyAlias generated in LiteLLM as the resource ID. This way, the Key value is not exposed during the Plan and Apply of the terraform recipe. The generateKey, updateKey, and deleteKey functions needed to be modified to accommodate this adjustment.

- Before** (The generated key exposed in multiple locations during plan/apply):

![Captura de Tela 2025-05-22 às 00 52 46](https://github.com/user-attachments/assets/0338e2e2-4f37-4da8-87dd-ec627c1f7681)
![Captura de Tela 2025-05-22 às 00 55 03](https://github.com/user-attachments/assets/b40b09bd-3bc6-4c45-911d-22de2a3d157f)
![Captura de Tela 2025-05-22 às 00 57 12](https://github.com/user-attachments/assets/28068661-4c37-4630-92ff-68dc26b37dae)

- After (Sensitive key values generated in liteLLM were hidden in plan/apply)
- Note: The "nonsensitive" method can be used in the component's output to display the generated key!

![Captura de Tela 2025-05-22 às 01 02 17](https://github.com/user-attachments/assets/371566b4-6f51-46cc-b7a7-de84a3702cfd)
![Captura de Tela 2025-05-22 às 01 03 22](https://github.com/user-attachments/assets/277d48cd-faee-4a2d-ad1d-dec7b0baa723)
![Captura de Tela 2025-05-22 às 01 04 11](https://github.com/user-attachments/assets/7ff09f0c-6b5d-4c3c-bf47-60a63c9a68fc)


## Validation in the update key:

### Added validation for each parameter within the key update, as maxBudget, TPM, RPM, and other values were becoming zero, thus rendering the key unusable.
With the fix, there is no risk of changing values to zero, as everything will be validated before being posted to the LiteLLM API.

- Before (When updating the key, values were being set to zero)
![Captura de Tela 2025-05-22 às 01 12 17](https://github.com/user-attachments/assets/18b392db-1670-433d-ab4a-667fb8e5d1a1)
![Captura de Tela 2025-05-22 às 01 12 36](https://github.com/user-attachments/assets/461b6db8-3d9e-4fa3-95b8-1302dab0885a)

- After (Following the update, values remain the same if they are not changed in the data input)

![Captura de Tela 2025-05-22 às 01 15 54](https://github.com/user-attachments/assets/ffa2dfa2-f10a-4205-a519-64adb3b901e3)
![Captura de Tela 2025-05-22 às 01 16 10](https://github.com/user-attachments/assets/f1011ac2-df21-4d4e-9489-117bbfadae8d)

- The omitempty tag was added to the BudgetDuration variable to allow passing an empty value (equivalent to unlimited in liteLLM).