### PR TITLE
fix: check for missing keys before retrieving them

### DIFF
--- a/litellm/resource_key.go
+++ b/litellm/resource_key.go
@@ -185,28 +185,72 @@ func resourceKeyDelete(ctx context.Context, d *schema.ResourceData, m interface{
 }
 
 func mapResourceDataToKey(d *schema.ResourceData, key *Key) {
-	key.Models = expandStringList(d.Get("models").([]interface{}))
-	key.MaxBudget = d.Get("max_budget").(float64)
-	key.UserID = d.Get("user_id").(string)
-	key.TeamID = d.Get("team_id").(string)
-	key.MaxParallelRequests = d.Get("max_parallel_requests").(int)
-	key.Metadata = d.Get("metadata").(map[string]interface{})
-	key.TPMLimit = d.Get("tpm_limit").(int)
-	key.RPMLimit = d.Get("rpm_limit").(int)
-	key.BudgetDuration = d.Get("budget_duration").(string)
-	key.AllowedCacheControls = expandStringList(d.Get("allowed_cache_controls").([]interface{}))
-	key.SoftBudget = d.Get("soft_budget").(float64)
-	key.KeyAlias = d.Get("key_alias").(string)
-	key.Duration = d.Get("duration").(string)
-	key.Aliases = d.Get("aliases").(map[string]interface{})
-	key.Config = d.Get("config").(map[string]interface{})
-	key.Permissions = d.Get("permissions").(map[string]interface{})
-	key.ModelMaxBudget = d.Get("model_max_budget").(map[string]interface{})
-	key.ModelRPMLimit = d.Get("model_rpm_limit").(map[string]interface{})
-	key.ModelTPMLimit = d.Get("model_tpm_limit").(map[string]interface{})
-	key.Guardrails = expandStringList(d.Get("guardrails").([]interface{}))
-	key.Blocked = d.Get("blocked").(bool)
-	key.Tags = expandStringList(d.Get("tags").([]interface{}))
+	if v, ok := d.GetOk("models"); ok {
+		key.Models = expandStringList(v.([]interface{}))
+	}
+	if v, ok := d.GetOk("max_budget"); ok {
+		key.MaxBudget = v.(float64)
+	}
+	if v, ok := d.GetOk("user_id"); ok {
+		key.UserID = v.(string)
+	}
+	if v, ok := d.GetOk("team_id"); ok {
+		key.TeamID = v.(string)
+	}
+	if v, ok := d.GetOk("max_parallel_requests"); ok {
+		key.MaxParallelRequests = v.(int)
+	}
+	if v, ok := d.GetOk("metadata"); ok {
+		key.Metadata = v.(map[string]interface{})
+	}
+	if v, ok := d.GetOk("tpm_limit"); ok {
+		key.TPMLimit = v.(int)
+	}
+	if v, ok := d.GetOk("rpm_limit"); ok {
+		key.RPMLimit = v.(int)
+	}
+	if v, ok := d.GetOk("budget_duration"); ok {
+		key.BudgetDuration = v.(string)
+	}
+	if v, ok := d.GetOk("allowed_cache_controls"); ok {
+		key.AllowedCacheControls = expandStringList(v.([]interface{}))
+	}
+	if v, ok := d.GetOk("soft_budget"); ok {
+		key.SoftBudget = v.(float64)
+	}
+	if v, ok := d.GetOk("key_alias"); ok {
+		key.KeyAlias = v.(string)
+	}
+	if v, ok := d.GetOk("duration"); ok {
+		key.Duration = v.(string)
+	}
+	if v, ok := d.GetOk("aliases"); ok {
+		key.Aliases = v.(map[string]interface{})
+	}
+	if v, ok := d.GetOk("config"); ok {
+		key.Config = v.(map[string]interface{})
+	}
+	if v, ok := d.GetOk("permissions"); ok {
+		key.Permissions = v.(map[string]interface{})
+	}
+	if v, ok := d.GetOk("model_max_budget"); ok {
+		key.ModelMaxBudget = v.(map[string]interface{})
+	}
+	if v, ok := d.GetOk("model_rpm_limit"); ok {
+		key.ModelRPMLimit = v.(map[string]interface{})
+	}
+	if v, ok := d.GetOk("model_tpm_limit"); ok {
+		key.ModelTPMLimit = v.(map[string]interface{})
+	}
+	if v, ok := d.GetOk("guardrails"); ok {
+		key.Guardrails = expandStringList(v.([]interface{}))
+	}
+	if v, ok := d.GetOk("blocked"); ok {
+		key.Blocked = v.(bool)
+	}
+	if v, ok := d.GetOk("tags"); ok {
+		key.Tags = expandStringList(v.([]interface{}))
+	}
 }
 
 func mapKeyToResourceData(d *schema.ResourceData, key *Key) {


### PR DESCRIPTION
Hi,

when trying to create an api key, I suddenly got this error:
```
panic: interface conversion: interface {} is nil, not string

  goroutine 24 [running]:
  github.com/nicholas-cecere/terraform-provider-litellm/litellm.mapResourceDataToKey(0xc00001a980, 0xc000225680)
        ../../../../terraform-provider-litellm/litellm/resource_key.go:202 +0x9a5
  github.com/nicholas-cecere/terraform-provider-litellm/litellm.resourceKeyCreate({0xe5b320, 0xc0000f2620}, 0xc00001a980, {0xcdcfc0, 0xc000358b70})
        ../../../../terraform-provider-litellm/litellm/resource_key.go:135 +0x77
  github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).create(0xc000181420, {0xe5b278, 0xc000283e30}, 0xc00001a980, {0xcdcfc0, 0xc000358b70})
        ../../../../../go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.34.0/helper/schema/resource.go:806 +0x119
```

Based on the stack trace, it looks like not all keys in `ResourceData` are present, the result is `nil` and the conversion fails.
I've added checks that make sure that only keys are mapped that actually exist.

```hcl
resource "litellm_key" "api_keys" {
  for_each = { for k in var.api_keys : k.team_name => k }
  team_id  = litellm_team.teams[each.value.team_name].id

  key_alias = each.value.team_name

  depends_on = [litellm_team.teams]
}
```

Strangely enough this worked before, so there might be more to this then I can see.

Best regards,

Gitii