### PR TITLE
[Feat] Allow setting team_id when adding a new model

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This Terraform provider allows you to manage LiteLLM resources through Infrastru
 ## Features
 
 - Manage LiteLLM model configurations
+- Associate models with specific teams
 - Create and manage teams
 - Configure team members and their permissions
 - Set usage limits and budgets

--- a/docs/resources/model.md
+++ b/docs/resources/model.md
@@ -13,6 +13,7 @@ resource "litellm_model" "gpt4" {
   api_version         = "2023-05-15"
   base_model          = "gpt-4"
   tier                = "paid"
+  team_id             = "team-123"
   mode                = "completion"
   reasoning_effort    = "medium"
   thinking_enabled    = true
@@ -49,6 +50,8 @@ The following arguments are supported:
 * `base_model` - (Required) The actual model identifier from the provider (e.g., "gpt-4", "claude-2").
 
 * `tier` - (Optional) The usage tier for this model. Valid values are "free" or "paid". Default is "free".
+
+* `team_id` - (Optional) Associate the model with a specific team.
 
 * `mode` - (Optional) The intended use of the model. Valid values are:
   * `completion`

--- a/litellm/resource_model.go
+++ b/litellm/resource_model.go
@@ -78,6 +78,10 @@ func resourceLiteLLMModel() *schema.Resource {
 				Optional: true,
 				Default:  "free",
 			},
+			"team_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"mode": {
 				Type:     schema.TypeString,
 				Optional: true,

--- a/litellm/resource_model_crud.go
+++ b/litellm/resource_model_crud.go
@@ -115,6 +115,7 @@ func createOrUpdateModel(d *schema.ResourceData, m interface{}, isUpdate bool) e
 			BaseModel: baseModel,
 			Tier:      d.Get("tier").(string),
 			Mode:      d.Get("mode").(string),
+			TeamID:    d.Get("team_id").(string),
 		},
 		Additional: make(map[string]interface{}),
 	}
@@ -180,6 +181,7 @@ func resourceLiteLLMModelRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("base_model", GetStringValue(modelResp.ModelInfo.BaseModel, d.Get("base_model").(string)))
 	d.Set("tier", GetStringValue(modelResp.ModelInfo.Tier, d.Get("tier").(string)))
 	d.Set("mode", GetStringValue(modelResp.ModelInfo.Mode, d.Get("mode").(string)))
+	d.Set("team_id", GetStringValue(modelResp.ModelInfo.TeamID, d.Get("team_id").(string)))
 
 	// Store sensitive information
 	d.Set("model_api_key", d.Get("model_api_key"))

--- a/litellm/types.go
+++ b/litellm/types.go
@@ -76,6 +76,7 @@ type ModelInfo struct {
 	BaseModel string `json:"base_model"`
 	Tier      string `json:"tier"`
 	Mode      string `json:"mode"`
+	TeamID    string `json:"team_id,omitempty"`
 }
 
 // Key represents a LiteLLM API key.


### PR DESCRIPTION
[Feat] Allow setting team_id when adding a new model

This allow adding team BYOK models on LiteLLM. 

This this you can set team_id under model_info, when set LiteLLM treats that model as model owned by that specified team_id 
