### PR TITLE
feat: Add additional AWS params to model def

### DIFF
--- a/docs/resources/model.md
+++ b/docs/resources/model.md
@@ -29,7 +29,9 @@ resource "litellm_model" "gpt4" {
   # AWS-specific configuration (if applicable)
   aws_access_key_id     = var.aws_access_key_id
   aws_secret_access_key = var.aws_secret_access_key
+  aws_session_name      = var.aws_session_name
   aws_region_name       = var.aws_region
+  aws_role_name         = var.aws_role_name
 }
 ```
 
@@ -86,7 +88,11 @@ The following arguments are supported:
 
 * `aws_secret_access_key` - (Optional) AWS secret access key for AWS-based models.
 
+* `aws_session_name` - (Optional) AWS session name for AWS-based models.
+
 * `aws_region_name` - (Optional) AWS region name for AWS-based models.
+
+* `aws_role_name` - (Optional) AWS role name for AWS-based models.
 
 ## Attribute Reference
 

--- a/example_model_with_additional_params.tf
+++ b/example_model_with_additional_params.tf
@@ -49,7 +49,9 @@ resource "litellm_model" "bedrock_model" {
   # Standard AWS parameters
   aws_access_key_id     = var.aws_access_key_id
   aws_secret_access_key = var.aws_secret_access_key
+  aws_session_name      = "litellm"
   aws_region_name       = "us-east-1"
+  aws_role_name         = "arn:aws:iam::123456789000:role/bedrock"
   
   # Additional custom parameters for Bedrock
   additional_litellm_params = {

--- a/litellm/resource_model.go
+++ b/litellm/resource_model.go
@@ -128,7 +128,15 @@ func resourceLiteLLMModel() *schema.Resource {
 				Optional:  true,
 				Sensitive: true,
 			},
+			"aws_session_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"aws_region_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"aws_role_name": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},

--- a/litellm/resource_model_crud.go
+++ b/litellm/resource_model_crud.go
@@ -127,8 +127,14 @@ func createOrUpdateModel(d *schema.ResourceData, m interface{}, isUpdate bool) e
 	if awsSecretAccessKey := d.Get("aws_secret_access_key").(string); awsSecretAccessKey != "" {
 		litellmParams["aws_secret_access_key"] = awsSecretAccessKey
 	}
+	if awsSessionName := d.Get("aws_session_name").(string); awsSessionName != "" {
+		litellmParams["aws_session_name"] = awsSessionName
+	}
 	if awsRegionName := d.Get("aws_region_name").(string); awsRegionName != "" {
 		litellmParams["aws_region_name"] = awsRegionName
+	}
+	if awsRoleName := d.Get("aws_role_name").(string); awsRoleName != "" {
+		litellmParams["aws_role_name"] = awsRoleName
 	}
 	if vertexProject := d.Get("vertex_project").(string); vertexProject != "" {
 		litellmParams["vertex_project"] = vertexProject
@@ -254,7 +260,9 @@ func resourceLiteLLMModelRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("model_api_key", d.Get("model_api_key"))
 	d.Set("aws_access_key_id", d.Get("aws_access_key_id"))
 	d.Set("aws_secret_access_key", d.Get("aws_secret_access_key"))
+	d.Set("aws_session_name", d.Get("aws_session_name"))
 	d.Set("aws_region_name", GetStringValue(modelResp.LiteLLMParams.AWSRegionName, d.Get("aws_region_name").(string)))
+	d.Set("aws_role_name", d.Get("aws_role_name"))
 
 	// Store cost information
 	d.Set("input_cost_per_million_tokens", d.Get("input_cost_per_million_tokens"))

--- a/openapi.json
+++ b/openapi.json
@@ -29403,6 +29403,17 @@
             ],
             "title": "Aws Secret Access Key"
           },
+          "aws_session_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Aws Session Name"
+          },
           "aws_region_name": {
             "anyOf": [
               {
@@ -29413,6 +29424,17 @@
               }
             ],
             "title": "Aws Region Name"
+          },
+          "aws_role_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Aws Role Name"
           },
           "watsonx_region_name": {
             "anyOf": [
@@ -39865,6 +39887,17 @@
             ],
             "title": "Aws Secret Access Key"
           },
+          "aws_session_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Aws Session Name"
+          },
           "aws_region_name": {
             "anyOf": [
               {
@@ -39875,6 +39908,17 @@
               }
             ],
             "title": "Aws Region Name"
+          },
+          "aws_role_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Aws Role Name"
           },
           "watsonx_region_name": {
             "anyOf": [


### PR DESCRIPTION
This pull request adds support for two missing [AWS configuration parameters](https://docs.litellm.ai/docs/proxy/config_settings)—`aws_session_name` and `aws_role_name`—across the Terraform provider, documentation, and OpenAPI schema. These parameters allow users to specify an AWS session name and IAM role when configuring AWS-based models, improving flexibility for authentication and authorization.

**Provider and CRUD logic updates:**

* Added `aws_session_name` and `aws_role_name` as optional string fields to the Terraform schema for the `litellm_model` resource, enabling their use in resource configuration.
* Updated the resource create/update logic to include `aws_session_name` and `aws_role_name` in the parameters sent to LiteLLM if they are set by the user.
* Ensured that `aws_session_name` and `aws_role_name` are stored and retrieved correctly in the resource read logic.

**Documentation and example updates:**

* Updated `docs/resources/model.md` to document the new `aws_session_name` and `aws_role_name` arguments, including example usage in resource blocks and argument descriptions. [[1]](diffhunk://#diff-9e4b5da6648b4e53664f28e22322f50d3e1da27cd4ffba63727797340e20ddfaR32-R34) [[2]](diffhunk://#diff-9e4b5da6648b4e53664f28e22322f50d3e1da27cd4ffba63727797340e20ddfaR91-R96)
* Updated `example_model_with_additional_params.tf` to demonstrate usage of the new AWS parameters in a resource example.

**OpenAPI schema updates:**

* Added `aws_session_name` and `aws_role_name` as optional string fields to the OpenAPI schema for model creation and configuration, ensuring API clients are aware of the new options. [[1]](diffhunk://#diff-a9865368a7fc7fa33065e35b2343f10d08fb79d65205435403d0a163a3044713R29406-R29416) [[2]](diffhunk://#diff-a9865368a7fc7fa33065e35b2343f10d08fb79d65205435403d0a163a3044713R29428-R29438) [[3]](diffhunk://#diff-a9865368a7fc7fa33065e35b2343f10d08fb79d65205435403d0a163a3044713R39890-R39900) [[4]](diffhunk://#diff-a9865368a7fc7fa33065e35b2343f10d08fb79d65205435403d0a163a3044713R39912-R39922)