### PR TITLE
Do not set value to 0 for `null` integers

### DIFF
--- a/litellm/resource_key.go
+++ b/litellm/resource_key.go
@@ -27,6 +27,7 @@ func resourceKey() *schema.Resource {
 			"max_budget": {
 				Type:     schema.TypeFloat,
 				Optional: true,
+				Computed: true,
 			},
 			"user_id": {
 				Type:     schema.TypeString,
@@ -68,6 +69,7 @@ func resourceKey() *schema.Resource {
 			"soft_budget": {
 				Type:     schema.TypeFloat,
 				Optional: true,
+				Computed: true,
 			},
 			"key_alias": {
 				Type:     schema.TypeString,
@@ -95,7 +97,7 @@ func resourceKey() *schema.Resource {
 			"model_max_budget": {
 				Type:     schema.TypeMap,
 				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeFloat},
+				Elem:     &schema.Schema{Type: schema.TypeFloat, Computed: true},
 			},
 			"model_rpm_limit": {
 				Type:     schema.TypeMap,


### PR DESCRIPTION
Currently when creating litellm keys the provider will set the values for any integers to be 0 which means the keys cannot make any requests at all.

Passing in `null` directly also does not work.

Adding `Computed: true` to each of the integers will mean they only get set to a value when one is defined.

Related issue -> https://github.com/ncecere/terraform-provider-litellm/issues/31


Testing: I built the provider locally and did a development override to confirm when nothing is set the value is `Unlimited`