### PR TITLE
fix: missing code fence

### DIFF
--- a/docs/resources/team_member_add.md
+++ b/docs/resources/team_member_add.md
@@ -159,3 +159,4 @@ Team members can be imported using a composite ID of the team ID and user ID:
 
 ```shell
 terraform import litellm_team_member_add.example team-123:user-456
+```


### PR DESCRIPTION
Code fence was missing.
It looks no problem on GitHub, but it is broken on terraform provider site as follows.

https://registry.terraform.io/providers/ncecere/litellm/0.3.15/docs/resources/team_member_add
<img width="705" height="176" alt="image" src="https://github.com/user-attachments/assets/195864fa-1f50-4b3c-949e-f6aedfea13bb" />
