### PR TITLE
Adding sensitive attribute to key

### DIFF
--- a/litellm/resource_key.go
+++ b/litellm/resource_key.go
@@ -18,7 +18,7 @@ func resourceKey() *schema.Resource {
 			"key": {
 				Type:      schema.TypeString,
 				Computed:  true,
-				Sensitive: true
+				Sensitive: true,
 			},
 			"models": {
 				Type:     schema.TypeList,


### PR DESCRIPTION
Adding the `sensitive` attribute to the `resourceKey` schema to prevent leaking the keys as much as possible throughout the Terraform ecosystem.