### PR TITLE
Add team_id to team resource

### DIFF
--- a/docs/resources/team.md
+++ b/docs/resources/team.md
@@ -14,6 +14,15 @@ resource "litellm_team" "minimal" {
 }
 ```
 
+### With Explicit Team ID
+
+```hcl
+resource "litellm_team" "deterministic" {
+  team_alias = "my-team"
+  team_id    = "my-stable-team-id"
+}
+```
+
 ### Full
 
 ```hcl
@@ -58,6 +67,7 @@ resource "litellm_team" "full" {
 
 The following arguments are supported:
 
+* `team_id` - (Optional) The ID for the team. If not specified, one will be generated. Changing this value forces the resource to be destroyed and recreated.
 * `team_alias` - (Required) A human-readable alias for the team.
 * `organization_id` - (Optional) The ID of the organization this team belongs to.
 * `max_budget` - (Optional) Maximum budget allocated to the team.
@@ -84,10 +94,11 @@ The following arguments are supported:
 
 In addition to the arguments above, the following attributes are exported:
 
-* `id` - The unique identifier of the team.
+* `id` - The unique identifier of the team. Always equal to `team_id`.
 
 The following attributes are both Optional and Computed (they are read back from the API if not explicitly set):
 
+* `team_id`
 * `metadata`
 * `models`
 * `model_aliases`
@@ -101,7 +112,7 @@ The following attributes are both Optional and Computed (they are read back from
 
 ## Import
 
-Teams can be imported using the team ID:
+Teams can be imported using the team ID. After import, both `id` and `team_id` will reflect the imported team's ID:
 
 ```shell
 terraform import litellm_team.example <team-id>


### PR DESCRIPTION
  Exposes team_id as an optional, user-specifiable field on the litellm_team resource (both the Plugin Framework and
  SDKv2 implementations), mirroring the organization_id pattern from litellm_organization.

  Changes:
  - team_id is Optional + Computed — users can provide a custom ID or let the API generate one
  - Changing team_id forces resource recreation (ForceNew / RequiresReplace)
  - The API response is captured on create to extract the generated team_id
  - id and team_id always reflect the same value