### PR TITLE
fix(model): resolve Unknown `mode` for wildcard routes in readModel

### DIFF
--- a/internal/provider/resource_model.go
+++ b/internal/provider/resource_model.go
@@ -706,6 +706,15 @@ func (r *ModelResource) readModel(ctx context.Context, data *ModelResourceModel)
 		data.AccessGroups, _ = types.ListValue(types.StringType, []attr.Value{})
 	}
 
+	// Ensure mode is never Unknown after a Read. Terraform requires all
+	// Computed attributes to resolve to a known (or null) value after apply.
+	// Wildcard routes (e.g. openai/*) may not have a mode set in the API
+	// response, which would leave the attribute Unknown and cause:
+	//   "provider still indicated an unknown value for litellm_model.*.mode"
+	if data.Mode.IsUnknown() {
+		data.Mode = types.StringNull()
+	}
+
 	return nil
 }
 

--- a/internal/provider/resource_model_test.go
+++ b/internal/provider/resource_model_test.go
@@ -59,6 +59,69 @@ func TestReadModelResolvesUnknownOptionalComputedCollections(t *testing.T) {
 	}
 }
 
+// TestReadModelResolvesUnknownModeForWildcardRouting verifies that when the
+// LiteLLM API does not return a "mode" value (e.g. for wildcard routes like
+// openai/*), readModel resolves the Unknown mode to Null rather than leaving
+// it Unknown. Terraform requires all Computed attributes to be known (or null)
+// after apply, so leaving it Unknown causes:
+//
+//	"provider still indicated an unknown value for litellm_model.*.mode"
+func TestReadModelResolvesUnknownModeForWildcardRouting(t *testing.T) {
+	t.Parallel()
+
+	// Simulate LiteLLM returning a model with no "mode" in model_info,
+	// which happens for wildcard routes (e.g. openai/*).
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": []interface{}{
+				map[string]interface{}{
+					"model_name": "openai/*",
+					"litellm_params": map[string]interface{}{
+						"custom_llm_provider": "openai",
+						"model":               "openai/openai/*",
+					},
+					"model_info": map[string]interface{}{
+						"base_model": "openai/*",
+						// "mode" is intentionally absent – wildcard routes have no mode
+					},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	r := &ModelResource{
+		client: &Client{
+			APIBase:    server.URL,
+			APIKey:     "test-key",
+			HTTPClient: server.Client(),
+		},
+	}
+
+	// Simulate the state that Terraform builds from the plan when mode is not
+	// specified in config: Computed+Optional means mode is Unknown pre-apply.
+	data := ModelResourceModel{
+		ID:                      types.StringValue("wildcard-model-123"),
+		Mode:                    types.StringUnknown(),
+		AccessGroups:            types.ListUnknown(types.StringType),
+		AdditionalLiteLLMParams: types.MapUnknown(types.StringType),
+	}
+
+	if err := r.readModel(context.Background(), &data); err != nil {
+		t.Fatalf("readModel returned error: %v", err)
+	}
+
+	if data.Mode.IsUnknown() {
+		t.Fatal("mode must not be Unknown after read (would cause 'provider returned unknown value after apply' error)")
+	}
+	// When no mode is returned by the API, the attribute should be null
+	// (not an empty string – that would be a non-null known value).
+	if !data.Mode.IsNull() {
+		t.Fatalf("mode should be null when API returns no mode, got %q", data.Mode.ValueString())
+	}
+}
+
 func TestConvertStringValue(t *testing.T) {
 	t.Parallel()
 

--- a/internal_testing/README.md
+++ b/internal_testing/README.md
@@ -77,6 +77,7 @@ internal_testing/
   resources/                   # one file per resource, minimal + full variants
     model_minimal.tf
     model_full.tf
+    model_wildcard.tf
     key_minimal.tf
     key_full.tf
     key_block_minimal.tf       # blocks the minimal key (destructive)

--- a/internal_testing/resources/model_wildcard.tf
+++ b/internal_testing/resources/model_wildcard.tf
@@ -1,0 +1,18 @@
+# litellm_model - Wildcard routing
+# Verifies that provider-specific wildcard routing (openai/*) applies without
+# errors. On first apply the API returns no "mode" value; the provider must
+# resolve the Computed mode attribute to null rather than leaving it unknown,
+# otherwise Terraform errors with:
+#   "provider still indicated an unknown value for litellm_model.*.mode"
+
+resource "litellm_model" "wildcard" {
+  model_name          = "openai/*"
+  base_model          = "*"
+  custom_llm_provider = "openai"
+  model_api_key       = "sk-fake-wildcard-key"
+}
+
+output "model_wildcard_id" {
+  value = litellm_model.wildcard.id
+}
+


### PR DESCRIPTION
Ensure mode is never Unknown after a Read. Terraform requires all Computed attributes to resolve to a known (or null) value after apply. Wildcard routes (e.g. `openai/*`) may not have a mode set in the API response, which would leave the attribute Unknown and cause: "provider still indicated an unknown value for `litellm_model.*.mode`"

Resolves ncecere/terraform-provider-litellm#70