### PR TITLE
fix(key): ensure special characters in key are URL-encoded in requests

### DIFF
--- a/internal/provider/resource_key.go
+++ b/internal/provider/resource_key.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"net/url"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -673,7 +674,10 @@ func (r *KeyResource) readKey(ctx context.Context, data *KeyResourceModel) error
 		return fmt.Errorf("key value is empty, cannot read key info")
 	}
 
-	endpoint := fmt.Sprintf("/key/info?key=%s", keyVal)
+	// url.QueryEscape ensures special characters in the key (e.g. '#') are
+	// percent-encoded and not interpreted as a URL fragment, which would
+	// silently truncate the key value before it reaches the server.
+	endpoint := fmt.Sprintf("/key/info?key=%s", url.QueryEscape(keyVal))
 
 	var result map[string]interface{}
 	if err := r.client.DoRequestWithResponse(ctx, "GET", endpoint, nil, &result); err != nil {

--- a/internal/provider/resource_key_test.go
+++ b/internal/provider/resource_key_test.go
@@ -655,3 +655,72 @@ func TestReadKeyTagsNoTagsAnywhere(t *testing.T) {
 		t.Fatalf("expected 0 tags, got %d", len(data.Tags.Elements()))
 	}
 }
+
+// TestReadKeyURLEncodesSpecialChars verifies that special characters in a key
+// value (e.g. '#') are percent-encoded when the key is placed in the
+// /key/info query string.  Without url.QueryEscape the '#' character is
+// interpreted as a URL fragment delimiter and silently truncates the key,
+// causing the server to return 404 "Key not found in database".
+func TestReadKeyURLEncodesSpecialChars(t *testing.T) {
+	t.Parallel()
+
+	// Key that contains URL-special characters: '!' and '#'.
+	// '#' is the critical one: without encoding it acts as a fragment
+	// delimiter and everything from '#' onward is stripped before the
+	// HTTP request is sent.
+	const keyWithSpecialChars = "sk-unit-test#special!chars"
+
+	var receivedKeyParam string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Capture the raw, server-decoded value of the "key" query parameter.
+		receivedKeyParam = r.URL.Query().Get("key")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"key": keyWithSpecialChars,
+			"info": map[string]interface{}{
+				"token": keyWithSpecialChars,
+			},
+		})
+	}))
+	defer server.Close()
+
+	r := &KeyResource{
+		client: &Client{
+			APIBase:    server.URL,
+			APIKey:     "test-key",
+			HTTPClient: server.Client(),
+		},
+	}
+
+	data := &KeyResourceModel{
+		Key:                      types.StringValue(keyWithSpecialChars),
+		Models:                   types.ListNull(types.StringType),
+		AllowedRoutes:            types.ListNull(types.StringType),
+		AllowedPassthroughRoutes: types.ListNull(types.StringType),
+		AllowedCacheControls:     types.ListNull(types.StringType),
+		Guardrails:               types.ListNull(types.StringType),
+		Prompts:                  types.ListNull(types.StringType),
+		EnforcedParams:           types.ListNull(types.StringType),
+		Tags:                     types.ListNull(types.StringType),
+		Metadata:                 types.MapNull(types.StringType),
+		Aliases:                  types.MapNull(types.StringType),
+		Config:                   types.MapNull(types.StringType),
+		Permissions:              types.MapNull(types.StringType),
+		ModelMaxBudget:           types.MapNull(types.Float64Type),
+		ModelRPMLimit:            types.MapNull(types.Int64Type),
+		ModelTPMLimit:            types.MapNull(types.Int64Type),
+	}
+
+	if err := r.readKey(context.Background(), data); err != nil {
+		t.Fatalf("readKey failed: %v", err)
+	}
+
+	// The server must receive the complete key, including the '#special!chars' suffix.
+	// Without url.QueryEscape the Go HTTP client strips everything from '#'
+	// onward (URL fragment), so the server would receive "sk-unit-test#special!chars".
+	if receivedKeyParam != keyWithSpecialChars {
+		t.Fatalf("server received key param %q, want %q\n"+
+			"hint: '#' was likely not percent-encoded, causing URL fragment truncation",
+			receivedKeyParam, keyWithSpecialChars)
+	}
+}

--- a/internal_testing/resources/key_full.tf
+++ b/internal_testing/resources/key_full.tf
@@ -1,7 +1,11 @@
 # litellm_key - Full
-# All attributes populated
+# All attributes populated, including a key value with URL-special characters
+# ('#', '!') to guard against the regression where '#' was interpreted as a
+# URL fragment delimiter in /key/info?key=..., silently truncating the value
+# and causing a 404 on read-back after creation.
 
 resource "litellm_key" "full" {
+  key                   = "sk-smoke-test#special!chars"
   key_alias             = "test-key-full"
   models                = ["gpt-4o", "gpt-4o-mini"]
   max_budget            = 100.0
@@ -51,9 +55,4 @@ resource "litellm_key" "full" {
 
 output "key_full_id" {
   value = litellm_key.full.id
-}
-
-output "key_full_key" {
-  value     = litellm_key.full.key
-  sensitive = true
 }


### PR DESCRIPTION
`url.QueryEscape` ensures special characters in the key (e.g. '#') are percent-encoded and not interpreted as a URL fragment, which would silently truncate the key value before it reaches the server.

Resolves ncecere/terraform-provider-litellm#73