### PR TITLE
fix(key): add `computed` attribute to `key_alias` for `service_account_id` usage

### DIFF
--- a/internal/provider/resource_key.go
+++ b/internal/provider/resource_key.go
@@ -185,8 +185,12 @@ func (r *KeyResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 				Computed:    true,
 			},
 			"key_alias": schema.StringAttribute{
-				Description: "User-friendly alias for the key.",
+				Description: "User-friendly alias for the key. When service_account_id is set and key_alias is omitted, the provider defaults key_alias to the service_account_id value.",
 				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"duration": schema.StringAttribute{
 				Description: "Key validity duration.",
@@ -732,6 +736,8 @@ func (r *KeyResource) readKey(ctx context.Context, data *KeyResourceModel) error
 	}
 	if keyAlias, ok := info["key_alias"].(string); ok && keyAlias != "" {
 		data.KeyAlias = types.StringValue(keyAlias)
+	} else if data.KeyAlias.IsUnknown() {
+		data.KeyAlias = types.StringNull()
 	}
 	if duration, ok := info["duration"].(string); ok && duration != "" {
 		data.Duration = types.StringValue(duration)

--- a/internal/provider/resource_key_test.go
+++ b/internal/provider/resource_key_test.go
@@ -611,6 +611,221 @@ func TestReadKeyTagsFromMetadata(t *testing.T) {
 	}
 }
 
+// TestServiceAccountIDDefaultsKeyAlias verifies that when service_account_id is
+// set but key_alias is omitted, buildKeyRequest populates key_alias with the
+// service_account_id value — matching the documented behaviour.
+// TestMinimalKeyNoKeyAliasNoServiceAccountID verifies the plain minimal case:
+// neither key_alias nor service_account_id is configured.
+//
+//  resource "litellm_key" "minimal" {}
+//
+// Expected behaviour:
+//  - buildKeyRequest must NOT include "key_alias" in the payload.
+//  - readKey with an Unknown key_alias (Computed, unresolved) and an API
+//    response that contains no key_alias must resolve the field to null —
+//    i.e. no "inconsistent result after apply" error and no perpetual
+//    "(known after apply)" on subsequent plans.
+func TestMinimalKeyNoKeyAliasNoServiceAccountID(t *testing.T) {
+	t.Parallel()
+
+	r := &KeyResource{}
+
+	// Simulate the plan-time model: everything is null/unknown.
+	data := &KeyResourceModel{
+		// key_alias is Unknown because it is Computed and the user did not set it.
+		KeyAlias: types.StringUnknown(),
+		// service_account_id is null because the user did not set it.
+		ServiceAccountID: types.StringNull(),
+	}
+
+	// 1. buildKeyRequest must NOT include key_alias when neither field is set.
+	keyReq := r.buildKeyRequest(context.Background(), data)
+	if _, exists := keyReq["key_alias"]; exists {
+		t.Errorf("key_alias must not appear in request when neither key_alias nor service_account_id is configured, got %v", keyReq["key_alias"])
+	}
+
+	// 2. readKey with an API that returns no key_alias must resolve Unknown → null.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"key": "sk-minimal-key-xyz",
+			"info": map[string]interface{}{
+				"token": "sk-minimal-key-xyz",
+				// key_alias deliberately absent — API never set one
+			},
+		})
+	}))
+	defer server.Close()
+
+	rc := &KeyResource{
+		client: &Client{
+			APIBase:    server.URL,
+			APIKey:     "test-key",
+			HTTPClient: server.Client(),
+		},
+	}
+
+	readData := KeyResourceModel{
+		ID:       types.StringValue(hashKeyForID("sk-minimal-key-xyz")),
+		Key:      types.StringValue("sk-minimal-key-xyz"),
+		KeyAlias: types.StringUnknown(), // Unknown = Computed, not yet resolved
+	}
+
+	if err := rc.readKey(context.Background(), &readData); err != nil {
+		t.Fatalf("readKey returned error: %v", err)
+	}
+
+	// Must not be Unknown (would cause "inconsistent result after apply").
+	if readData.KeyAlias.IsUnknown() {
+		t.Fatal("key_alias must not remain Unknown after readKey — this would cause 'inconsistent result after apply'")
+	}
+	// Must be null (not some unexpected string).
+	if !readData.KeyAlias.IsNull() {
+		t.Errorf("key_alias should be null when API returns no alias, got %q", readData.KeyAlias.ValueString())
+	}
+}
+
+func TestServiceAccountIDDefaultsKeyAlias(t *testing.T) {
+	t.Parallel()
+
+	r := &KeyResource{}
+	data := &KeyResourceModel{
+		ServiceAccountID: types.StringValue("github-ci"),
+		TeamID:           types.StringValue("team456"),
+		// key_alias deliberately omitted / null
+		KeyAlias: types.StringNull(),
+	}
+
+	keyReq := r.buildKeyRequest(context.Background(), data)
+
+	if keyReq["key_alias"] != "github-ci" {
+		t.Errorf("expected key_alias 'github-ci', got %v", keyReq["key_alias"])
+	}
+	if keyReq["team_id"] != "team456" {
+		t.Errorf("expected team_id 'team456', got %v", keyReq["team_id"])
+	}
+	// service_account_id should be stored in metadata, not as a top-level field
+	meta, ok := keyReq["metadata"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected metadata map in request")
+	}
+	if meta["service_account_id"] != "github-ci" {
+		t.Errorf("expected metadata.service_account_id 'github-ci', got %v", meta["service_account_id"])
+	}
+}
+
+// TestServiceAccountIDKeyAliasExplicitOverride verifies that an explicit
+// key_alias takes precedence over the service_account_id default.
+func TestServiceAccountIDKeyAliasExplicitOverride(t *testing.T) {
+	t.Parallel()
+
+	r := &KeyResource{}
+	data := &KeyResourceModel{
+		ServiceAccountID: types.StringValue("github-ci"),
+		KeyAlias:         types.StringValue("my-custom-alias"),
+	}
+
+	keyReq := r.buildKeyRequest(context.Background(), data)
+
+	if keyReq["key_alias"] != "my-custom-alias" {
+		t.Errorf("expected explicit key_alias 'my-custom-alias', got %v", keyReq["key_alias"])
+	}
+}
+
+// TestReadKeyKeyAliasFromServiceAccount verifies that when service_account_id
+// is set without key_alias, the provider successfully reads back the key_alias
+// that the API sets (previously caused "inconsistent result after apply" because
+// key_alias was Optional-only, not Optional+Computed).
+func TestReadKeyKeyAliasFromServiceAccount(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"key": "sk-svc-key-abc",
+			"info": map[string]interface{}{
+				"token":     "sk-svc-key-abc",
+				"key_alias": "github-ci",
+				"team_id":   "team456",
+			},
+		})
+	}))
+	defer server.Close()
+
+	r := &KeyResource{
+		client: &Client{
+			APIBase:    server.URL,
+			APIKey:     "test-key",
+			HTTPClient: server.Client(),
+		},
+	}
+
+	// Simulate the state after Create: key is known, key_alias is Unknown
+	// (Computed field not yet resolved).
+	data := KeyResourceModel{
+		ID:               types.StringValue(hashKeyForID("sk-svc-key-abc")),
+		Key:              types.StringValue("sk-svc-key-abc"),
+		ServiceAccountID: types.StringValue("github-ci"),
+		KeyAlias:         types.StringUnknown(), // Unknown = Computed, not yet set
+	}
+
+	if err := r.readKey(context.Background(), &data); err != nil {
+		t.Fatalf("readKey returned error: %v", err)
+	}
+
+	// After readKey the Unknown must be resolved — this is what was failing before the fix.
+	if data.KeyAlias.IsUnknown() {
+		t.Fatal("key_alias must not be Unknown after readKey")
+	}
+	if data.KeyAlias.ValueString() != "github-ci" {
+		t.Errorf("expected key_alias 'github-ci', got '%s'", data.KeyAlias.ValueString())
+	}
+}
+
+// TestReadKeyKeyAliasUnknownResolvesToNullWhenMissing verifies that an Unknown
+// key_alias is resolved to null (not left Unknown) when the API response does
+// not include a key_alias value.
+func TestReadKeyKeyAliasUnknownResolvesToNullWhenMissing(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"key": "sk-no-alias-key",
+			"info": map[string]interface{}{
+				"token": "sk-no-alias-key",
+				// key_alias intentionally absent
+			},
+		})
+	}))
+	defer server.Close()
+
+	r := &KeyResource{
+		client: &Client{
+			APIBase:    server.URL,
+			APIKey:     "test-key",
+			HTTPClient: server.Client(),
+		},
+	}
+
+	data := KeyResourceModel{
+		ID:       types.StringValue(hashKeyForID("sk-no-alias-key")),
+		Key:      types.StringValue("sk-no-alias-key"),
+		KeyAlias: types.StringUnknown(),
+	}
+
+	if err := r.readKey(context.Background(), &data); err != nil {
+		t.Fatalf("readKey returned error: %v", err)
+	}
+
+	if data.KeyAlias.IsUnknown() {
+		t.Fatal("key_alias must not remain Unknown after readKey when API returns no alias")
+	}
+	if !data.KeyAlias.IsNull() {
+		t.Errorf("expected key_alias to be null when API returns nothing, got '%s'", data.KeyAlias.ValueString())
+	}
+}
+
 func TestReadKeyTagsNoTagsAnywhere(t *testing.T) {
 	t.Parallel()
 

--- a/internal_testing/README.md
+++ b/internal_testing/README.md
@@ -79,6 +79,7 @@ internal_testing/
     model_full.tf
     key_minimal.tf
     key_full.tf
+    key_service_account.tf
     key_block_minimal.tf       # blocks the minimal key (destructive)
     team_minimal.tf
     team_full.tf

--- a/internal_testing/resources/key_service_account.tf
+++ b/internal_testing/resources/key_service_account.tf
@@ -1,0 +1,42 @@
+# litellm_key - Service Account
+#
+# Regression test for: https://github.com/ncecere/terraform-provider-litellm/issues/76
+#
+# Verifies that creating a key with service_account_id but WITHOUT an explicit
+# key_alias does NOT raise:
+#   "Provider produced inconsistent result after apply: .key_alias was null,
+#    but now cty.StringVal(...)"
+#
+# The provider must automatically default key_alias to the service_account_id
+# value (both in the API request and by reading it back as a Computed field),
+# so Terraform never sees a null→value mismatch after apply.
+#
+# Note: the LiteLLM API requires team_id for service account keys, so a team
+# is created inline to keep this fixture self-contained.
+
+resource "litellm_team" "service_account_team" {
+  team_alias = "test-team-service-account"
+}
+
+resource "litellm_key" "service_account" {
+  service_account_id = "github-ci"
+  team_id            = litellm_team.service_account_team.id
+  # key_alias is intentionally omitted — the provider must default it to
+  # "github-ci" without requiring the caller to set it explicitly.
+}
+
+output "key_service_account_id" {
+  value = litellm_key.service_account.id
+}
+
+output "key_service_account_key" {
+  value     = litellm_key.service_account.key
+  sensitive = true
+}
+
+# This output must equal "github-ci" after apply — confirming the provider
+# defaulted key_alias from service_account_id and stored it in state.
+output "key_service_account_alias" {
+  value       = litellm_key.service_account.key_alias
+  description = "Must equal 'github-ci' — automatically defaulted from service_account_id."
+}


### PR DESCRIPTION
When `service_account_id` is set and key_alias is omitted, the provider defaults `key_alias` to the `service_account_id` value. 
However, the `key_alias` attribute is declared as `Optional`-only in the schema — not `Computed`, Terraform then sees a mismatch between the planned value (`null`) and the actual post-apply value and raises an error.

Resolves ncecere/terraform-provider-litellm#76