### PR TITLE
feat: add send_invite_email to key and user resources

### DIFF
--- a/docs/resources/key.md
+++ b/docs/resources/key.md
@@ -172,6 +172,8 @@ The following arguments are supported:
 
 * `blocked` - (Optional) Whether this key is blocked.
 
+* `send_invite_email` - (Optional) Whether to send an invite email when the key is created. Only affects creation; ignored on subsequent reads and updates.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -51,6 +51,7 @@ The following arguments are supported:
 * `teams` - (Optional) List of team IDs the user belongs to.
 * `models` - (Optional) List of model names the user is allowed to use.
 * `metadata` - (Optional) A map of key-value metadata pairs for the user.
+* `send_invite_email` - (Optional) Whether to send an invite email when the user is created. Only affects creation; ignored on subsequent reads and updates.
 
 ## Attribute Reference
 

--- a/internal/provider/resource_key.go
+++ b/internal/provider/resource_key.go
@@ -71,6 +71,7 @@ type KeyResourceModel struct {
 	EnforcedParams           types.List    `tfsdk:"enforced_params"`
 	Tags                     types.List    `tfsdk:"tags"`
 	Blocked                  types.Bool    `tfsdk:"blocked"`
+	SendInviteEmail          types.Bool    `tfsdk:"send_invite_email"`
 }
 
 func (r *KeyResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -261,6 +262,10 @@ func (r *KeyResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 				Description: "Whether the key is blocked.",
 				Optional:    true,
 				Computed:    true,
+			},
+			"send_invite_email": schema.BoolAttribute{
+				Description: "Whether to send an invite email when the key is created. Only affects creation; ignored on read.",
+				Optional:    true,
 			},
 		},
 	}
@@ -525,6 +530,9 @@ func (r *KeyResource) buildKeyRequest(ctx context.Context, data *KeyResourceMode
 	// Boolean fields - check IsNull and IsUnknown
 	if !data.Blocked.IsNull() && !data.Blocked.IsUnknown() {
 		keyReq["blocked"] = data.Blocked.ValueBool()
+	}
+	if !data.SendInviteEmail.IsNull() && !data.SendInviteEmail.IsUnknown() {
+		keyReq["send_invite_email"] = data.SendInviteEmail.ValueBool()
 	}
 
 	// Models list - special handling for team models

--- a/internal/provider/resource_key_test.go
+++ b/internal/provider/resource_key_test.go
@@ -761,14 +761,14 @@ func TestReadKeyTagsFromMetadata(t *testing.T) {
 // TestMinimalKeyNoKeyAliasNoServiceAccountID verifies the plain minimal case:
 // neither key_alias nor service_account_id is configured.
 //
-//  resource "litellm_key" "minimal" {}
+//	resource "litellm_key" "minimal" {}
 //
 // Expected behaviour:
-//  - buildKeyRequest must NOT include "key_alias" in the payload.
-//  - readKey with an Unknown key_alias (Computed, unresolved) and an API
-//    response that contains no key_alias must resolve the field to null —
-//    i.e. no "inconsistent result after apply" error and no perpetual
-//    "(known after apply)" on subsequent plans.
+//   - buildKeyRequest must NOT include "key_alias" in the payload.
+//   - readKey with an Unknown key_alias (Computed, unresolved) and an API
+//     response that contains no key_alias must resolve the field to null —
+//     i.e. no "inconsistent result after apply" error and no perpetual
+//     "(known after apply)" on subsequent plans.
 func TestMinimalKeyNoKeyAliasNoServiceAccountID(t *testing.T) {
 	t.Parallel()
 
@@ -1108,8 +1108,8 @@ func TestReadKeyPreservesUserProvidedKey(t *testing.T) {
 			// be hashed; simulate that here.
 			"key": hashedToken,
 			"info": map[string]interface{}{
-				"token":     hashedToken,
-				"key_alias": "my-alias",
+				"token":      hashedToken,
+				"key_alias":  "my-alias",
 				"max_budget": 50.0,
 			},
 		})
@@ -1234,4 +1234,37 @@ func TestReadKeyPopulatesUnknownKey(t *testing.T) {
 	if data.Key.ValueString() != apiReturnedKey {
 		t.Errorf("key should remain %q, got %q", apiReturnedKey, data.Key.ValueString())
 	}
+}
+
+// TestSendInviteEmailInBuildKeyRequest verifies that send_invite_email is
+// included in the API request when explicitly set (true or false), and omitted
+// when null — ensuring it is not sent on update calls when unconfigured.
+func TestSendInviteEmailInBuildKeyRequest(t *testing.T) {
+	t.Parallel()
+
+	r := &KeyResource{}
+
+	t.Run("included when true", func(t *testing.T) {
+		data := &KeyResourceModel{SendInviteEmail: types.BoolValue(true)}
+		req := r.buildKeyRequest(context.Background(), data)
+		if v, ok := req["send_invite_email"]; !ok || v != true {
+			t.Errorf("expected send_invite_email=true in request, got %v (ok=%v)", v, ok)
+		}
+	})
+
+	t.Run("included when false", func(t *testing.T) {
+		data := &KeyResourceModel{SendInviteEmail: types.BoolValue(false)}
+		req := r.buildKeyRequest(context.Background(), data)
+		if v, ok := req["send_invite_email"]; !ok || v != false {
+			t.Errorf("expected send_invite_email=false in request, got %v (ok=%v)", v, ok)
+		}
+	})
+
+	t.Run("omitted when null", func(t *testing.T) {
+		data := &KeyResourceModel{SendInviteEmail: types.BoolNull()}
+		req := r.buildKeyRequest(context.Background(), data)
+		if _, ok := req["send_invite_email"]; ok {
+			t.Error("send_invite_email must not appear in request when null")
+		}
+	})
 }

--- a/internal/provider/resource_user.go
+++ b/internal/provider/resource_user.go
@@ -28,20 +28,21 @@ type UserResource struct {
 }
 
 type UserResourceModel struct {
-	ID             types.String  `tfsdk:"id"`
-	UserID         types.String  `tfsdk:"user_id"`
-	UserAlias      types.String  `tfsdk:"user_alias"`
-	UserEmail      types.String  `tfsdk:"user_email"`
-	UserRole       types.String  `tfsdk:"user_role"`
-	Teams          types.List    `tfsdk:"teams"`
-	Models         types.List    `tfsdk:"models"`
-	MaxBudget      types.Float64 `tfsdk:"max_budget"`
-	BudgetDuration types.String  `tfsdk:"budget_duration"`
-	TPMLimit       types.Int64   `tfsdk:"tpm_limit"`
-	RPMLimit       types.Int64   `tfsdk:"rpm_limit"`
-	AutoCreateKey  types.Bool    `tfsdk:"auto_create_key"`
-	Metadata       types.Map     `tfsdk:"metadata"`
-	Key            types.String  `tfsdk:"key"`
+	ID              types.String  `tfsdk:"id"`
+	UserID          types.String  `tfsdk:"user_id"`
+	UserAlias       types.String  `tfsdk:"user_alias"`
+	UserEmail       types.String  `tfsdk:"user_email"`
+	UserRole        types.String  `tfsdk:"user_role"`
+	Teams           types.List    `tfsdk:"teams"`
+	Models          types.List    `tfsdk:"models"`
+	MaxBudget       types.Float64 `tfsdk:"max_budget"`
+	BudgetDuration  types.String  `tfsdk:"budget_duration"`
+	TPMLimit        types.Int64   `tfsdk:"tpm_limit"`
+	RPMLimit        types.Int64   `tfsdk:"rpm_limit"`
+	AutoCreateKey   types.Bool    `tfsdk:"auto_create_key"`
+	Metadata        types.Map     `tfsdk:"metadata"`
+	Key             types.String  `tfsdk:"key"`
+	SendInviteEmail types.Bool    `tfsdk:"send_invite_email"`
 }
 
 func (r *UserResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -137,6 +138,10 @@ func (r *UserResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
+			},
+			"send_invite_email": schema.BoolAttribute{
+				Description: "Whether to send an invite email when the user is created. Only affects creation; ignored on read.",
+				Optional:    true,
 			},
 		},
 	}
@@ -308,6 +313,9 @@ func (r *UserResource) buildUserRequest(ctx context.Context, data *UserResourceM
 	// Boolean fields - check IsNull and IsUnknown (auto_create_key has default)
 	if !data.AutoCreateKey.IsNull() && !data.AutoCreateKey.IsUnknown() {
 		userReq["auto_create_key"] = data.AutoCreateKey.ValueBool()
+	}
+	if !data.SendInviteEmail.IsNull() && !data.SendInviteEmail.IsUnknown() {
+		userReq["send_invite_email"] = data.SendInviteEmail.ValueBool()
 	}
 
 	// List fields - check IsNull, IsUnknown, and len > 0

--- a/internal/provider/resource_user_test.go
+++ b/internal/provider/resource_user_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"context"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -214,5 +215,38 @@ func TestOldBehaviorWouldFail(t *testing.T) {
 			t.Errorf("old behavior created list with %d elements, expected 0", len(oldBehaviorResult.Elements()))
 		}
 		// This empty list != null, which is what Terraform would detect as inconsistent
+	})
+}
+
+// TestSendInviteEmailInBuildUserRequest verifies that send_invite_email is
+// included in the API request when explicitly set (true or false), and omitted
+// when null — ensuring it is not sent on update calls when unconfigured.
+func TestSendInviteEmailInBuildUserRequest(t *testing.T) {
+	t.Parallel()
+
+	r := &UserResource{}
+
+	t.Run("included when true", func(t *testing.T) {
+		data := &UserResourceModel{SendInviteEmail: types.BoolValue(true)}
+		req := r.buildUserRequest(context.Background(), data)
+		if v, ok := req["send_invite_email"]; !ok || v != true {
+			t.Errorf("expected send_invite_email=true in request, got %v (ok=%v)", v, ok)
+		}
+	})
+
+	t.Run("included when false", func(t *testing.T) {
+		data := &UserResourceModel{SendInviteEmail: types.BoolValue(false)}
+		req := r.buildUserRequest(context.Background(), data)
+		if v, ok := req["send_invite_email"]; !ok || v != false {
+			t.Errorf("expected send_invite_email=false in request, got %v (ok=%v)", v, ok)
+		}
+	})
+
+	t.Run("omitted when null", func(t *testing.T) {
+		data := &UserResourceModel{SendInviteEmail: types.BoolNull()}
+		req := r.buildUserRequest(context.Background(), data)
+		if _, ok := req["send_invite_email"]; ok {
+			t.Error("send_invite_email must not appear in request when null")
+		}
 	})
 }


### PR DESCRIPTION
Add optional send_invite_email field to litellm_key and litellm_user resources. The field is write-only — sent to the API on create/update when explicitly set, and never read back from the API response.

Also adds unit tests covering true/false/null request behaviour and updates docs for both resources.