### PR TITLE
feat: Consolidate resource retry logic into generic RetryOnNotFound helper

### DIFF
--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 )
 
 // APIError represents a structured API error with HTTP status code.
@@ -26,6 +27,35 @@ func IsNotFoundError(err error) bool {
 	}
 	apiErr, ok := err.(*APIError)
 	return ok && apiErr.StatusCode == http.StatusNotFound
+}
+
+// RetryOnNotFound retries a function up to maxRetries times if it returns a 404,
+// with exponential backoff. This handles eventual consistency after resource creation.
+func RetryOnNotFound(ctx context.Context, fn func() error, maxRetries int) error {
+	var err error
+	delay := 1 * time.Second
+	maxDelay := 10 * time.Second
+
+	for i := 0; i < maxRetries; i++ {
+		err = fn()
+		if err == nil || !IsNotFoundError(err) {
+			return err
+		}
+
+		if i < maxRetries-1 {
+			select {
+			case <-time.After(delay):
+				delay *= 2
+				if delay > maxDelay {
+					delay = maxDelay
+				}
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+	}
+
+	return err
 }
 
 // DoRequest performs an HTTP request with context and standard headers.

--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -9,6 +9,25 @@ import (
 	"net/http"
 )
 
+// APIError represents a structured API error with HTTP status code.
+type APIError struct {
+	StatusCode int
+	Message    string
+}
+
+func (e *APIError) Error() string {
+	return fmt.Sprintf("API request failed with status %d: %s", e.StatusCode, e.Message)
+}
+
+// IsNotFoundError checks if an error is specifically a 404 Not Found.
+func IsNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+	apiErr, ok := err.(*APIError)
+	return ok && apiErr.StatusCode == http.StatusNotFound
+}
+
 // DoRequest performs an HTTP request with context and standard headers.
 func (c *Client) DoRequest(ctx context.Context, method, path string, body interface{}) (*http.Response, error) {
 	url := c.APIBase + path
@@ -58,7 +77,10 @@ func (c *Client) DoRequestWithResponse(ctx context.Context, method, path string,
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(bodyBytes))
+		return &APIError{
+			StatusCode: resp.StatusCode,
+			Message:    string(bodyBytes),
+		}
 	}
 
 	// If no result expected, return early
@@ -78,26 +100,4 @@ func (c *Client) DoRequestWithResponse(ctx context.Context, method, path string,
 	return nil
 }
 
-// IsNotFoundError checks if the error message indicates a not found condition.
-func IsNotFoundError(err error) bool {
-	if err == nil {
-		return false
-	}
-	errStr := err.Error()
-	return contains(errStr, "not found") ||
-		contains(errStr, "404") ||
-		contains(errStr, "does not exist")
-}
 
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsImpl(s, substr))
-}
-
-func containsImpl(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
-}

--- a/internal/provider/client_test.go
+++ b/internal/provider/client_test.go
@@ -1,0 +1,230 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestIsNotFoundError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "404 APIError",
+			err:      &APIError{StatusCode: http.StatusNotFound, Message: "not found"},
+			expected: true,
+		},
+		{
+			name:     "500 APIError",
+			err:      &APIError{StatusCode: http.StatusInternalServerError, Message: "server error"},
+			expected: false,
+		},
+		{
+			name:     "502 APIError",
+			err:      &APIError{StatusCode: http.StatusBadGateway, Message: "bad gateway"},
+			expected: false,
+		},
+		{
+			name:     "503 APIError",
+			err:      &APIError{StatusCode: http.StatusServiceUnavailable, Message: "service unavailable"},
+			expected: false,
+		},
+		{
+			name:     "non-APIError",
+			err:      fmt.Errorf("some other error"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsNotFoundError(tt.err)
+			if got != tt.expected {
+				t.Errorf("IsNotFoundError() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestRetryOnNotFound_Success(t *testing.T) {
+	callCount := 0
+	fn := func() error {
+		callCount++
+		if callCount < 3 {
+			return &APIError{StatusCode: http.StatusNotFound, Message: "not found yet"}
+		}
+		return nil
+	}
+
+	ctx := context.Background()
+	err := RetryOnNotFound(ctx, fn, 5)
+
+	if err != nil {
+		t.Errorf("RetryOnNotFound() returned error: %v", err)
+	}
+	if callCount != 3 {
+		t.Errorf("expected 3 calls, got %d", callCount)
+	}
+}
+
+func TestRetryOnNotFound_MaxRetriesExceeded(t *testing.T) {
+	callCount := 0
+	fn := func() error {
+		callCount++
+		return &APIError{StatusCode: http.StatusNotFound, Message: "not found"}
+	}
+
+	ctx := context.Background()
+	err := RetryOnNotFound(ctx, fn, 3)
+
+	if err == nil {
+		t.Error("RetryOnNotFound() expected error, got nil")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("RetryOnNotFound() error should be 404, got: %v", err)
+	}
+	if callCount != 3 {
+		t.Errorf("expected 3 calls, got %d", callCount)
+	}
+}
+
+func TestRetryOnNotFound_NonNotFoundError(t *testing.T) {
+	callCount := 0
+	fn := func() error {
+		callCount++
+		return &APIError{StatusCode: http.StatusInternalServerError, Message: "server error"}
+	}
+
+	ctx := context.Background()
+	err := RetryOnNotFound(ctx, fn, 5)
+
+	if err == nil {
+		t.Error("RetryOnNotFound() expected error, got nil")
+	}
+	if IsNotFoundError(err) {
+		t.Error("RetryOnNotFound() should not return 404 for 500 error")
+	}
+	if callCount != 1 {
+		t.Errorf("expected 1 call (fail fast), got %d", callCount)
+	}
+}
+
+func TestRetryOnNotFound_ContextCancellation(t *testing.T) {
+	callCount := 0
+	fn := func() error {
+		callCount++
+		return &APIError{StatusCode: http.StatusNotFound, Message: "not found"}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Cancel context after a short delay to test cancellation during retry
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	err := RetryOnNotFound(ctx, fn, 10)
+
+	if err == nil {
+		t.Error("RetryOnNotFound() expected error from context cancellation")
+	}
+	if err != context.Canceled {
+		t.Errorf("expected context.Canceled, got: %v", err)
+	}
+	// Should have attempted at least once before cancellation
+	if callCount < 1 {
+		t.Errorf("expected at least 1 call, got %d", callCount)
+	}
+}
+
+func TestRetryOnNotFound_ExponentialBackoff(t *testing.T) {
+	callCount := 0
+	callTimes := []time.Time{}
+	fn := func() error {
+		callCount++
+		callTimes = append(callTimes, time.Now())
+		if callCount < 4 {
+			return &APIError{StatusCode: http.StatusNotFound, Message: "not found"}
+		}
+		return nil
+	}
+
+	ctx := context.Background()
+	start := time.Now()
+	err := RetryOnNotFound(ctx, fn, 5)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Errorf("RetryOnNotFound() returned error: %v", err)
+	}
+	if callCount != 4 {
+		t.Errorf("expected 4 calls, got %d", callCount)
+	}
+
+	// Verify backoff timing (1s + 2s + 4s = 7s minimum, allow some tolerance)
+	expectedMin := 7 * time.Second
+	if elapsed < expectedMin {
+		t.Errorf("expected elapsed time >= %v, got %v", expectedMin, elapsed)
+	}
+}
+
+func TestRetryOnNotFound_502Error(t *testing.T) {
+	callCount := 0
+	fn := func() error {
+		callCount++
+		return &APIError{StatusCode: http.StatusBadGateway, Message: "bad gateway"}
+	}
+
+	ctx := context.Background()
+	err := RetryOnNotFound(ctx, fn, 5)
+
+	if err == nil {
+		t.Error("RetryOnNotFound() expected error, got nil")
+	}
+	if IsNotFoundError(err) {
+		t.Error("RetryOnNotFound() should not treat 502 as 404")
+	}
+	if callCount != 1 {
+		t.Errorf("expected 1 call (fail fast on 502), got %d", callCount)
+	}
+}
+
+func TestRetryOnNotFound_TimeoutError(t *testing.T) {
+	callCount := 0
+	fn := func() error {
+		callCount++
+		return fmt.Errorf("request timeout")
+	}
+
+	ctx := context.Background()
+	err := RetryOnNotFound(ctx, fn, 5)
+
+	if err == nil {
+		t.Error("RetryOnNotFound() expected error, got nil")
+	}
+	if IsNotFoundError(err) {
+		t.Error("RetryOnNotFound() should not treat timeout as 404")
+	}
+	if callCount != 1 {
+		t.Errorf("expected 1 call (fail fast on timeout), got %d", callCount)
+	}
+}
+
+func TestAPIErrorMessage(t *testing.T) {
+	err := &APIError{StatusCode: 404, Message: "resource not found"}
+	expected := "API request failed with status 404: resource not found"
+	if err.Error() != expected {
+		t.Errorf("APIError.Error() = %q, want %q", err.Error(), expected)
+	}
+}

--- a/internal/provider/resource_access_group.go
+++ b/internal/provider/resource_access_group.go
@@ -118,7 +118,9 @@ func (r *AccessGroupResource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
-	if err := r.readAccessGroup(ctx, &data); err != nil {
+	if err := RetryOnNotFound(ctx, func() error {
+		return r.readAccessGroup(ctx, &data)
+	}, 3); err != nil {
 		if IsNotFoundError(err) {
 			resp.State.RemoveResource(ctx)
 			return

--- a/internal/provider/resource_agent.go
+++ b/internal/provider/resource_agent.go
@@ -363,7 +363,9 @@ func (r *AgentResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		return
 	}
 
-	if err := r.readAgent(ctx, &data); err != nil {
+	if err := RetryOnNotFound(ctx, func() error {
+		return r.readAgent(ctx, &data)
+	}, 3); err != nil {
 		if IsNotFoundError(err) {
 			resp.State.RemoveResource(ctx)
 			return

--- a/internal/provider/resource_budget.go
+++ b/internal/provider/resource_budget.go
@@ -147,7 +147,9 @@ func (r *BudgetResource) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
-	if err := r.readBudget(ctx, &data); err != nil {
+	if err := RetryOnNotFound(ctx, func() error {
+		return r.readBudget(ctx, &data)
+	}, 3); err != nil {
 		if IsNotFoundError(err) {
 			resp.State.RemoveResource(ctx)
 			return

--- a/internal/provider/resource_credential.go
+++ b/internal/provider/resource_credential.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -112,7 +111,9 @@ func (r *CredentialResource) Create(ctx context.Context, req resource.CreateRequ
 
 	// Read back for full state with retry (note: credential_values won't be returned for security).
 	// The retry handles eventual-consistency delays after creating a credential.
-	if err := r.readCredentialWithRetry(ctx, &data, 5); err != nil {
+	if err := RetryOnNotFound(ctx, func() error {
+		return r.readCredential(ctx, &data)
+	}, 5); err != nil {
 		resp.Diagnostics.AddWarning("Read Error", fmt.Sprintf("Credential created but failed to read back: %s", err))
 	}
 
@@ -127,7 +128,9 @@ func (r *CredentialResource) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 
-	if err := r.readCredential(ctx, &data); err != nil {
+	if err := RetryOnNotFound(ctx, func() error {
+		return r.readCredential(ctx, &data)
+	}, 3); err != nil {
 		if IsNotFoundError(err) {
 			resp.State.RemoveResource(ctx)
 			return
@@ -272,33 +275,4 @@ func (r *CredentialResource) readCredential(ctx context.Context, data *Credentia
 	// The API might not return sensitive values, and we want to preserve what's in state
 
 	return nil
-}
-
-// readCredentialWithRetry retries the read operation with exponential backoff.
-// This handles eventual-consistency delays after creating a credential.
-func (r *CredentialResource) readCredentialWithRetry(ctx context.Context, data *CredentialResourceModel, maxRetries int) error {
-	var err error
-	delay := 1 * time.Second
-	maxDelay := 10 * time.Second
-
-	for i := 0; i < maxRetries; i++ {
-		err = r.readCredential(ctx, data)
-		if err == nil {
-			return nil
-		}
-
-		if !IsNotFoundError(err) {
-			return err
-		}
-
-		if i < maxRetries-1 {
-			time.Sleep(delay)
-			delay *= 2
-			if delay > maxDelay {
-				delay = maxDelay
-			}
-		}
-	}
-
-	return err
 }

--- a/internal/provider/resource_fallback.go
+++ b/internal/provider/resource_fallback.go
@@ -115,7 +115,9 @@ func (r *FallbackResource) Read(ctx context.Context, req resource.ReadRequest, r
 		return
 	}
 
-	if err := r.readFallback(ctx, &data); err != nil {
+	if err := RetryOnNotFound(ctx, func() error {
+		return r.readFallback(ctx, &data)
+	}, 3); err != nil {
 		if IsNotFoundError(err) {
 			resp.State.RemoveResource(ctx)
 			return

--- a/internal/provider/resource_guardrail.go
+++ b/internal/provider/resource_guardrail.go
@@ -155,7 +155,9 @@ func (r *GuardrailResource) Read(ctx context.Context, req resource.ReadRequest, 
 		return
 	}
 
-	if err := r.readGuardrail(ctx, &data); err != nil {
+	if err := RetryOnNotFound(ctx, func() error {
+		return r.readGuardrail(ctx, &data)
+	}, 3); err != nil {
 		if IsNotFoundError(err) {
 			resp.State.RemoveResource(ctx)
 			return

--- a/internal/provider/resource_key.go
+++ b/internal/provider/resource_key.go
@@ -325,7 +325,9 @@ func (r *KeyResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 		return
 	}
 
-	if err := r.readKey(ctx, &data); err != nil {
+	if err := RetryOnNotFound(ctx, func() error {
+		return r.readKey(ctx, &data)
+	}, 3); err != nil {
 		if IsNotFoundError(err) {
 			resp.State.RemoveResource(ctx)
 			return

--- a/internal/provider/resource_key_block.go
+++ b/internal/provider/resource_key_block.go
@@ -119,7 +119,9 @@ func (r *KeyBlockResource) Read(ctx context.Context, req resource.ReadRequest, r
 	endpoint := fmt.Sprintf("/key/info?key=%s", data.Key.ValueString())
 
 	var result map[string]interface{}
-	if err := r.client.DoRequestWithResponse(ctx, "GET", endpoint, nil, &result); err != nil {
+	if err := RetryOnNotFound(ctx, func() error {
+		return r.client.DoRequestWithResponse(ctx, "GET", endpoint, nil, &result)
+	}, 3); err != nil {
 		if IsNotFoundError(err) {
 			// Key no longer exists, remove the block resource
 			resp.State.RemoveResource(ctx)

--- a/internal/provider/resource_mcp_server.go
+++ b/internal/provider/resource_mcp_server.go
@@ -300,7 +300,9 @@ func (r *MCPServerResource) Read(ctx context.Context, req resource.ReadRequest, 
 		return
 	}
 
-	if err := r.readMCPServer(ctx, &data); err != nil {
+	if err := RetryOnNotFound(ctx, func() error {
+		return r.readMCPServer(ctx, &data)
+	}, 3); err != nil {
 		if IsNotFoundError(err) {
 			resp.State.RemoveResource(ctx)
 			return

--- a/internal/provider/resource_model.go
+++ b/internal/provider/resource_model.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -278,7 +277,9 @@ func (r *ModelResource) Create(ctx context.Context, req resource.CreateRequest, 
 	data.ID = types.StringValue(modelID)
 
 	// Read back to ensure consistency
-	if err := r.readModelWithRetry(ctx, &data, 5); err != nil {
+	if err := RetryOnNotFound(ctx, func() error {
+		return r.readModel(ctx, &data)
+	}, 5); err != nil {
 		resp.Diagnostics.AddWarning("Read Error", fmt.Sprintf("Model created but failed to read back: %s", err))
 	}
 
@@ -293,7 +294,9 @@ func (r *ModelResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		return
 	}
 
-	err := r.readModel(ctx, &data)
+	err := RetryOnNotFound(ctx, func() error {
+		return r.readModel(ctx, &data)
+	}, 3)
 	if err != nil {
 		if IsNotFoundError(err) {
 			resp.State.RemoveResource(ctx)
@@ -716,33 +719,6 @@ func (r *ModelResource) readModel(ctx context.Context, data *ModelResourceModel)
 	}
 
 	return nil
-}
-
-func (r *ModelResource) readModelWithRetry(ctx context.Context, data *ModelResourceModel, maxRetries int) error {
-	var err error
-	delay := 1 * time.Second
-	maxDelay := 10 * time.Second
-
-	for i := 0; i < maxRetries; i++ {
-		err = r.readModel(ctx, data)
-		if err == nil {
-			return nil
-		}
-
-		if !IsNotFoundError(err) {
-			return err
-		}
-
-		if i < maxRetries-1 {
-			time.Sleep(delay)
-			delay *= 2
-			if delay > maxDelay {
-				delay = maxDelay
-			}
-		}
-	}
-
-	return err
 }
 
 // patchModel uses the PATCH /model/{model_id}/update endpoint for partial updates

--- a/internal/provider/resource_organization.go
+++ b/internal/provider/resource_organization.go
@@ -191,7 +191,9 @@ func (r *OrganizationResource) Read(ctx context.Context, req resource.ReadReques
 		return
 	}
 
-	if err := r.readOrganization(ctx, &data); err != nil {
+	if err := RetryOnNotFound(ctx, func() error {
+		return r.readOrganization(ctx, &data)
+	}, 3); err != nil {
 		if IsNotFoundError(err) {
 			resp.State.RemoveResource(ctx)
 			return

--- a/internal/provider/resource_organization_member.go
+++ b/internal/provider/resource_organization_member.go
@@ -185,7 +185,9 @@ func (r *OrganizationMemberResource) Read(ctx context.Context, req resource.Read
 	endpoint := fmt.Sprintf("/organization/info?organization_id=%s", orgID)
 
 	var result map[string]interface{}
-	if err := r.client.DoRequestWithResponse(ctx, "GET", endpoint, nil, &result); err != nil {
+	if err := RetryOnNotFound(ctx, func() error {
+		return r.client.DoRequestWithResponse(ctx, "GET", endpoint, nil, &result)
+	}, 3); err != nil {
 		if IsNotFoundError(err) {
 			resp.State.RemoveResource(ctx)
 			return

--- a/internal/provider/resource_project.go
+++ b/internal/provider/resource_project.go
@@ -215,7 +215,9 @@ func (r *ProjectResource) Read(ctx context.Context, req resource.ReadRequest, re
 		return
 	}
 
-	if err := r.readProject(ctx, &data); err != nil {
+	if err := RetryOnNotFound(ctx, func() error {
+		return r.readProject(ctx, &data)
+	}, 3); err != nil {
 		if IsNotFoundError(err) {
 			resp.State.RemoveResource(ctx)
 			return

--- a/internal/provider/resource_prompt.go
+++ b/internal/provider/resource_prompt.go
@@ -147,7 +147,9 @@ func (r *PromptResource) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
-	if err := r.readPrompt(ctx, &data); err != nil {
+	if err := RetryOnNotFound(ctx, func() error {
+		return r.readPrompt(ctx, &data)
+	}, 3); err != nil {
 		if IsNotFoundError(err) {
 			resp.State.RemoveResource(ctx)
 			return

--- a/internal/provider/resource_search_tool.go
+++ b/internal/provider/resource_search_tool.go
@@ -154,7 +154,9 @@ func (r *SearchToolResource) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 
-	if err := r.readSearchTool(ctx, &data); err != nil {
+	if err := RetryOnNotFound(ctx, func() error {
+		return r.readSearchTool(ctx, &data)
+	}, 3); err != nil {
 		if IsNotFoundError(err) {
 			resp.State.RemoveResource(ctx)
 			return

--- a/internal/provider/resource_tag.go
+++ b/internal/provider/resource_tag.go
@@ -160,7 +160,9 @@ func (r *TagResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 		return
 	}
 
-	if err := r.readTag(ctx, &data); err != nil {
+	if err := RetryOnNotFound(ctx, func() error {
+		return r.readTag(ctx, &data)
+	}, 3); err != nil {
 		if IsNotFoundError(err) {
 			resp.State.RemoveResource(ctx)
 			return

--- a/internal/provider/resource_team.go
+++ b/internal/provider/resource_team.go
@@ -223,7 +223,9 @@ func (r *TeamResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		return
 	}
 
-	if err := r.readTeam(ctx, &data); err != nil {
+	if err := RetryOnNotFound(ctx, func() error {
+		return r.readTeam(ctx, &data)
+	}, 3); err != nil {
 		if IsNotFoundError(err) {
 			resp.State.RemoveResource(ctx)
 			return

--- a/internal/provider/resource_team_block.go
+++ b/internal/provider/resource_team_block.go
@@ -118,7 +118,9 @@ func (r *TeamBlockResource) Read(ctx context.Context, req resource.ReadRequest, 
 	endpoint := fmt.Sprintf("/team/info?team_id=%s", data.TeamID.ValueString())
 
 	var result map[string]interface{}
-	if err := r.client.DoRequestWithResponse(ctx, "GET", endpoint, nil, &result); err != nil {
+	if err := RetryOnNotFound(ctx, func() error {
+		return r.client.DoRequestWithResponse(ctx, "GET", endpoint, nil, &result)
+	}, 3); err != nil {
 		if IsNotFoundError(err) {
 			// Team no longer exists, remove the block resource
 			resp.State.RemoveResource(ctx)

--- a/internal/provider/resource_user.go
+++ b/internal/provider/resource_user.go
@@ -202,7 +202,9 @@ func (r *UserResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		return
 	}
 
-	if err := r.readUser(ctx, &data); err != nil {
+	if err := RetryOnNotFound(ctx, func() error {
+		return r.readUser(ctx, &data)
+	}, 3); err != nil {
 		if IsNotFoundError(err) {
 			resp.State.RemoveResource(ctx)
 			return

--- a/internal/provider/resource_vector_store.go
+++ b/internal/provider/resource_vector_store.go
@@ -153,7 +153,9 @@ func (r *VectorStoreResource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
-	if err := r.readVectorStore(ctx, &data); err != nil {
+	if err := RetryOnNotFound(ctx, func() error {
+		return r.readVectorStore(ctx, &data)
+	}, 3); err != nil {
 		if IsNotFoundError(err) {
 			resp.State.RemoveResource(ctx)
 			return


### PR DESCRIPTION
## Summary

Consolidate per-resource retry methods into a centralized `RetryOnNotFound` helper function. This eliminates code duplication and  applies consistent retry logic with exponential backoff across all resources.

Additionally, fixed error handling to check HTTP status codes instead of error message strings, preventing accidental resource removal  on transient errors that may include the string text (502s, timeouts, rate limits).

  ## Changes

  - Create structured `APIError` type that preserves HTTP status information
  - Update `IsNotFoundError()` to check `StatusCode == http.StatusNotFound` instead of pattern matching
  - Implement generic `RetryOnNotFound()` helper with exponential backoff (1s → 10s max)
  - Apply retry logic consistently to all 20 resource Read and Create operations
  - Remove per-resource retry methods (`readCredentialWithRetry`, `readModelWithRetry`)
  - Add context cancellation support to retry logic
  - Add unit tests for IsNotFoundError, RetryOnNotFound, and APIError to validate:
      - 404 detection vs transient errors (502, 503, timeouts)
      - Exponential backoff timing
      - Context cancellation support
      - Fail-fast behavior on non-404 errors