### PR TITLE
feat: Add router_settings Support to litellm_key Resource

### DIFF
--- a/docs/data-sources/key.md
+++ b/docs/data-sources/key.md
@@ -11,10 +11,11 @@ data "litellm_key" "existing" {
 
 output "key_info" {
   value = {
-    alias      = data.litellm_key.existing.key_alias
-    team_id    = data.litellm_key.existing.team_id
-    max_budget = data.litellm_key.existing.max_budget
-    blocked    = data.litellm_key.existing.blocked
+    alias             = data.litellm_key.existing.key_alias
+    team_id           = data.litellm_key.existing.team_id
+    max_budget        = data.litellm_key.existing.max_budget
+    router_settings   = data.litellm_key.existing.router_settings
+    blocked           = data.litellm_key.existing.blocked
   }
 }
 ```
@@ -39,6 +40,7 @@ output "key_info" {
 * `soft_budget` - Soft budget limit for warnings.
 * `metadata` - Map of metadata for the key.
 * `tags` - List of tags for the key.
+* `router_settings` - Map of router settings for the key.
 * `blocked` - Whether the key is blocked.
 
 ## Notes

--- a/docs/resources/key.md
+++ b/docs/resources/key.md
@@ -104,6 +104,24 @@ resource "litellm_key" "with_logging" {
 }
 ```
 
+### Key with Router Settings
+
+```hcl
+resource "litellm_key" "with_router_settings" {
+  key_alias = "router-configured-key"
+  models    = ["gpt-4o"]
+
+  router_settings = {
+    "fallback_routes" = "gpt-4o-mini"
+    "priority"        = "high"
+  }
+
+  metadata = {
+    environment = "production"
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -169,6 +187,8 @@ The following arguments are supported:
 * `enforced_params` - (Optional) List of enforced parameters for this key.
 
 * `tags` - (Optional) List of tags. **Note:** Requires LiteLLM Enterprise license.
+
+* `router_settings` - (Optional) Map of router settings for this key. Router settings control LiteLLM's routing behavior such as fallback routes and priority levels.
 
 * `blocked` - (Optional) Whether this key is blocked.
 

--- a/internal/provider/datasource_key.go
+++ b/internal/provider/datasource_key.go
@@ -36,6 +36,7 @@ type KeyDataSourceModel struct {
 	SoftBudget          types.Float64 `tfsdk:"soft_budget"`
 	Metadata            types.Map     `tfsdk:"metadata"`
 	Tags                types.List    `tfsdk:"tags"`
+	RouterSettings      types.Map     `tfsdk:"router_settings"`
 	Blocked             types.Bool    `tfsdk:"blocked"`
 }
 
@@ -108,6 +109,11 @@ func (d *KeyDataSource) Schema(ctx context.Context, req datasource.SchemaRequest
 			},
 			"tags": schema.ListAttribute{
 				Description: "Tags for the key.",
+				Computed:    true,
+				ElementType: types.StringType,
+			},
+			"router_settings": schema.MapAttribute{
+				Description: "Router settings for the key.",
 				Computed:    true,
 				ElementType: types.StringType,
 			},
@@ -237,6 +243,19 @@ func (d *KeyDataSource) Read(ctx context.Context, req datasource.ReadRequest, re
 		data.Tags, _ = types.ListValue(types.StringType, tagsList)
 	} else {
 		data.Tags, _ = types.ListValue(types.StringType, []attr.Value{})
+	}
+
+	// Handle router_settings map
+	if routerSettings, ok := info["router_settings"].(map[string]interface{}); ok && len(routerSettings) > 0 {
+		settingsMap := make(map[string]attr.Value)
+		for k, v := range routerSettings {
+			if str, ok := v.(string); ok {
+				settingsMap[k] = types.StringValue(str)
+			}
+		}
+		data.RouterSettings, _ = types.MapValue(types.StringType, settingsMap)
+	} else {
+		data.RouterSettings, _ = types.MapValue(types.StringType, map[string]attr.Value{})
 	}
 
 	// Handle metadata map

--- a/internal/provider/resource_key.go
+++ b/internal/provider/resource_key.go
@@ -70,6 +70,7 @@ type KeyResourceModel struct {
 	Prompts                  types.List    `tfsdk:"prompts"`
 	EnforcedParams           types.List    `tfsdk:"enforced_params"`
 	Tags                     types.List    `tfsdk:"tags"`
+	RouterSettings           types.Map     `tfsdk:"router_settings"`
 	Blocked                  types.Bool    `tfsdk:"blocked"`
 }
 
@@ -253,6 +254,12 @@ func (r *KeyResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 			},
 			"tags": schema.ListAttribute{
 				Description: "Tags for the key.",
+				Optional:    true,
+				Computed:    true,
+				ElementType: types.StringType,
+			},
+			"router_settings": schema.MapAttribute{
+				Description: "Router settings for the key.",
 				Optional:    true,
 				Computed:    true,
 				ElementType: types.StringType,
@@ -599,6 +606,14 @@ func (r *KeyResource) buildKeyRequest(ctx context.Context, data *KeyResourceMode
 	}
 
 	// Map fields - check IsNull, IsUnknown, and len > 0
+	if !data.RouterSettings.IsNull() && !data.RouterSettings.IsUnknown() {
+		var routerSettings map[string]string
+		data.RouterSettings.ElementsAs(ctx, &routerSettings, false)
+		if len(routerSettings) > 0 {
+			keyReq["router_settings"] = routerSettings
+		}
+	}
+
 	if !data.Metadata.IsNull() && !data.Metadata.IsUnknown() {
 		var metadata map[string]string
 		data.Metadata.ElementsAs(ctx, &metadata, false)
@@ -892,6 +907,19 @@ func (r *KeyResource) readKey(ctx context.Context, data *KeyResourceModel) error
 		data.Tags, _ = types.ListValue(types.StringType, tagsList)
 	} else if !data.Tags.IsNull() {
 		data.Tags, _ = types.ListValue(types.StringType, []attr.Value{})
+	}
+
+	// Handle router_settings map - preserve null when API returns empty and config didn't specify router_settings
+	if routerSettings, ok := info["router_settings"].(map[string]interface{}); ok && len(routerSettings) > 0 {
+		settingsMap := make(map[string]attr.Value)
+		for k, v := range routerSettings {
+			if str, ok := v.(string); ok {
+				settingsMap[k] = types.StringValue(str)
+			}
+		}
+		data.RouterSettings, _ = types.MapValue(types.StringType, settingsMap)
+	} else if !data.RouterSettings.IsNull() {
+		data.RouterSettings, _ = types.MapValue(types.StringType, map[string]attr.Value{})
 	}
 
 	// Handle metadata map - preserve null when API returns empty and config didn't specify metadata.


### PR DESCRIPTION
## Summary

- Added `router_settings` field to the `litellm_key` resource as a TypeMap field
- Allows per-key router behavior configuration (retry policies, fallbacks, timeouts, etc.)
- Updated documentation with example usage and argument reference
- Relocated initial implementation from legacy `litellm/` to `internal/provider/`

## Changes

- internal/provider/resource_key.go — Added schema, buildKeyRequest, and readKey handling for router_settings
- internal/provider/datasource_key.go — Added schema and Read function handling for router_settings to support reading router settings from existing keys
- docs/resources/key.md — Added example and argument documentation for router_settings
- docs/data-sources/key.md — Added router_settings to datasource output documentation