### PR TITLE
feat: add policy and policy attachment resources/data sources

### DIFF
--- a/docs/data-sources/policies.md
+++ b/docs/data-sources/policies.md
@@ -1,0 +1,47 @@
+# litellm_policies Data Source
+
+Retrieves a list of LiteLLM policies.
+
+## Example Usage
+
+```hcl
+data "litellm_policies" "all" {}
+
+output "policy_names" {
+  value = [for p in data.litellm_policies.all.policies : p.policy_name]
+}
+
+data "litellm_policies" "production" {
+  version_status = "production"
+}
+
+output "production_policy_count" {
+  value = data.litellm_policies.production.total_count
+}
+```
+
+## Argument Reference
+
+* `version_status` - (Optional) Filter by version status (`draft`, `published`, `production`).
+
+## Attribute Reference
+
+* `id` - Placeholder identifier.
+* `total_count` - Total number of returned policies.
+* `policies` - List of policy objects, each containing:
+  * `policy_id` - Policy ID.
+  * `policy_name` - Policy name.
+  * `version_number` - Version number.
+  * `version_status` - Version status.
+  * `parent_version_id` - Parent version ID.
+  * `is_latest` - Whether this is latest.
+  * `inherit` - Parent policy name.
+  * `description` - Policy description.
+  * `guardrails_add` - Guardrails to add.
+  * `guardrails_remove` - Guardrails to remove.
+  * `condition` - Condition as JSON string.
+  * `pipeline` - Pipeline as JSON string.
+  * `created_at` - Creation timestamp.
+  * `updated_at` - Last update timestamp.
+  * `created_by` - Creator.
+  * `updated_by` - Last updater.

--- a/docs/data-sources/policy.md
+++ b/docs/data-sources/policy.md
@@ -1,0 +1,45 @@
+# litellm_policy Data Source
+
+Retrieves information about a LiteLLM policy by policy ID.
+
+## Example Usage
+
+```hcl
+data "litellm_policy" "existing" {
+  policy_id = "123e4567-e89b-12d3-a456-426614174000"
+}
+
+output "policy_name" {
+  value = data.litellm_policy.existing.policy_name
+}
+
+output "policy_condition_model" {
+  value = data.litellm_policy.existing.condition.model
+}
+```
+
+## Argument Reference
+
+* `policy_id` - (Required) The policy ID to retrieve.
+
+## Attribute Reference
+
+* `id` - The policy ID.
+* `policy_name` - Policy name.
+* `inherit` - Name of parent policy.
+* `description` - Policy description.
+* `guardrails_add` - Guardrails to add.
+* `guardrails_remove` - Guardrails to remove from inherited set.
+* `condition` - Policy condition block.
+  * `model` - Model name pattern (exact match or regex).
+* `pipeline` - JSON string defining optional guardrail pipeline.
+* `version_number` - Version number.
+* `version_status` - Version status (`draft`, `published`, `production`).
+* `parent_version_id` - Policy ID this version was cloned from.
+* `is_latest` - Whether this is the latest version.
+* `published_at` - Timestamp when this version was published.
+* `production_at` - Timestamp when this version was promoted to production.
+* `created_at` - Timestamp when policy was created.
+* `updated_at` - Timestamp when policy was last updated.
+* `created_by` - Who created the policy.
+* `updated_by` - Who last updated the policy.

--- a/docs/data-sources/policy_attachment.md
+++ b/docs/data-sources/policy_attachment.md
@@ -1,0 +1,33 @@
+# litellm_policy_attachment Data Source
+
+Retrieves information about a policy attachment by attachment ID.
+
+## Example Usage
+
+```hcl
+data "litellm_policy_attachment" "existing" {
+  attachment_id = "123e4567-e89b-12d3-a456-426614174000"
+}
+
+output "attachment_policy_name" {
+  value = data.litellm_policy_attachment.existing.policy_name
+}
+```
+
+## Argument Reference
+
+* `attachment_id` - (Required) Attachment ID to retrieve.
+
+## Attribute Reference
+
+* `id` - The attachment ID.
+* `policy_name` - Name of attached policy.
+* `scope` - Attachment scope.
+* `teams` - Team patterns.
+* `keys` - Key patterns.
+* `models` - Model patterns.
+* `tags` - Tag patterns.
+* `created_at` - When the attachment was created.
+* `updated_at` - When the attachment was last updated.
+* `created_by` - Who created the attachment.
+* `updated_by` - Who last updated the attachment.

--- a/docs/data-sources/policy_attachments.md
+++ b/docs/data-sources/policy_attachments.md
@@ -1,0 +1,34 @@
+# litellm_policy_attachments Data Source
+
+Retrieves a list of policy attachments.
+
+## Example Usage
+
+```hcl
+data "litellm_policy_attachments" "all" {}
+
+output "attachment_ids" {
+  value = [for a in data.litellm_policy_attachments.all.attachments : a.attachment_id]
+}
+```
+
+## Argument Reference
+
+This data source has no required arguments.
+
+## Attribute Reference
+
+* `id` - Placeholder identifier.
+* `total_count` - Total number of returned attachments.
+* `attachments` - List of attachment objects, each containing:
+  * `attachment_id` - Attachment ID.
+  * `policy_name` - Name of attached policy.
+  * `scope` - Attachment scope.
+  * `teams` - Team patterns.
+  * `keys` - Key patterns.
+  * `models` - Model patterns.
+  * `tags` - Tag patterns.
+  * `created_at` - When created.
+  * `updated_at` - When updated.
+  * `created_by` - Creator.
+  * `updated_by` - Last updater.

--- a/docs/index.md
+++ b/docs/index.md
@@ -115,6 +115,8 @@ The LiteLLM provider supports the following resources:
 
 * [`litellm_prompt`](./resources/prompt.md) - Manage prompt templates
 * [`litellm_guardrail`](./resources/guardrail.md) - Manage content guardrails
+* [`litellm_policy`](./resources/policy.md) - Manage policies
+* [`litellm_policy_attachment`](./resources/policy_attachment.md) - Manage policy attachments
 * [`litellm_fallback`](./resources/fallback.md) - Manage model fallback configurations
 
 ### Integrations
@@ -138,6 +140,8 @@ The LiteLLM provider supports the following resources:
 * [`litellm_access_group`](./data-sources/access_group.md) - Retrieve access group information
 * [`litellm_prompt`](./data-sources/prompt.md) - Retrieve prompt information
 * [`litellm_guardrail`](./data-sources/guardrail.md) - Retrieve guardrail information
+* [`litellm_policy`](./data-sources/policy.md) - Retrieve policy information
+* [`litellm_policy_attachment`](./data-sources/policy_attachment.md) - Retrieve policy attachment information
 * [`litellm_fallback`](./data-sources/fallback.md) - Retrieve fallback configuration for a model
 * [`litellm_mcp_server`](./data-sources/mcp_server.md) - Retrieve MCP server information
 * [`litellm_search_tool`](./data-sources/search_tool.md) - Retrieve search tool information
@@ -155,6 +159,8 @@ The LiteLLM provider supports the following resources:
 * [`litellm_access_groups`](./data-sources/access_groups.md) - List all access groups
 * [`litellm_prompts`](./data-sources/prompts.md) - List all prompts
 * [`litellm_guardrails`](./data-sources/guardrails.md) - List all guardrails
+* [`litellm_policies`](./data-sources/policies.md) - List all policies
+* [`litellm_policy_attachments`](./data-sources/policy_attachments.md) - List all policy attachments
 * [`litellm_mcp_servers`](./data-sources/mcp_servers.md) - List all MCP servers
 * [`litellm_search_tools`](./data-sources/search_tools.md) - List all search tools
 

--- a/docs/resources/policy.md
+++ b/docs/resources/policy.md
@@ -1,0 +1,73 @@
+# litellm_policy Resource
+
+Manages a LiteLLM policy.
+
+## Example Usage
+
+### Minimal Policy
+
+```hcl
+resource "litellm_policy" "minimal" {
+  policy_name = "global-baseline"
+}
+```
+
+### Policy with Guardrails, Condition, and Pipeline
+
+```hcl
+resource "litellm_policy" "healthcare" {
+  policy_name = "healthcare-compliance"
+  inherit     = "global-baseline"
+  description = "Policy for healthcare workloads"
+
+  guardrails_add    = ["hipaa_audit", "pii_masking"]
+  guardrails_remove = ["prompt_injection"]
+
+  condition = {
+    model = "gpt-4.*"
+  }
+
+  pipeline = jsonencode({
+    mode = "pre_call"
+    steps = [
+      {
+        guardrail = "pii_masking"
+        on_fail   = "block"
+      }
+    ]
+  })
+}
+```
+
+## Argument Reference
+
+* `policy_name` - (Required) Unique policy name.
+* `inherit` - (Optional) Name of parent policy to inherit from.
+* `description` - (Optional) Human-readable policy description.
+* `guardrails_add` - (Optional) List of guardrails to add.
+* `guardrails_remove` - (Optional) List of guardrails to remove from inherited set.
+* `condition` - (Optional) Policy condition block.
+  * `model` - (Optional) Model name pattern (exact match or regex) for when the policy applies.
+* `pipeline` - (Optional) JSON string defining optional guardrail pipeline.
+
+## Attribute Reference
+
+* `id` - The policy ID.
+* `version_number` - Version number of this policy.
+* `version_status` - Version status (`draft`, `published`, `production`).
+* `parent_version_id` - Policy ID this version was cloned from.
+* `is_latest` - Whether this is the latest version.
+* `published_at` - Timestamp when this version was published.
+* `production_at` - Timestamp when this version was promoted to production.
+* `created_at` - Timestamp when the policy was created.
+* `updated_at` - Timestamp when the policy was last updated.
+* `created_by` - Who created the policy.
+* `updated_by` - Who last updated the policy.
+
+## Import
+
+Policies can be imported using their policy ID:
+
+```shell
+terraform import litellm_policy.example <policy-id>
+```

--- a/docs/resources/policy_attachment.md
+++ b/docs/resources/policy_attachment.md
@@ -1,0 +1,55 @@
+# litellm_policy_attachment Resource
+
+Manages a LiteLLM policy attachment.
+
+## Example Usage
+
+### Global Scope Attachment
+
+```hcl
+resource "litellm_policy_attachment" "global" {
+  policy_name = litellm_policy.minimal.policy_name
+  scope       = "*"
+}
+```
+
+### Targeted Attachment
+
+```hcl
+resource "litellm_policy_attachment" "targeted" {
+  policy_name = litellm_policy.minimal.policy_name
+  teams       = ["team-a", "team-b"]
+  models      = ["gpt-4o", "gpt-4o-mini"]
+  tags        = ["health-*", "prod"]
+}
+```
+
+## Argument Reference
+
+* `policy_name` - (Required) Name of the policy to attach.
+* `scope` - (Optional) Global scope. Only `"*"` is supported.
+* `teams` - (Optional) Team aliases or patterns this attachment applies to.
+* `keys` - (Optional) Key aliases or patterns this attachment applies to.
+* `models` - (Optional) Model names or patterns this attachment applies to.
+* `tags` - (Optional) Tag patterns this attachment applies to.
+
+Attachment targeting must follow one of these forms:
+
+* `scope = "*"` and none of `teams`, `keys`, `models`, `tags` are set
+* `scope` unset and at least one of `teams`, `keys`, `models`, `tags` set
+
+## Attribute Reference
+
+* `id` - The attachment ID.
+* `created_at` - When the attachment was created.
+* `updated_at` - When the attachment was last updated.
+* `created_by` - Who created the attachment.
+* `updated_by` - Who last updated the attachment.
+
+## Import
+
+Policy attachments can be imported using their attachment ID:
+
+```shell
+terraform import litellm_policy_attachment.example <attachment-id>
+```

--- a/internal/provider/datasource_policies_list.go
+++ b/internal/provider/datasource_policies_list.go
@@ -1,0 +1,243 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ datasource.DataSource = &PoliciesListDataSource{}
+
+func NewPoliciesListDataSource() datasource.DataSource {
+	return &PoliciesListDataSource{}
+}
+
+type PoliciesListDataSource struct {
+	client *Client
+}
+
+type PolicyListItemModel struct {
+	PolicyID         types.String `tfsdk:"policy_id"`
+	PolicyName       types.String `tfsdk:"policy_name"`
+	VersionNumber    types.Int64  `tfsdk:"version_number"`
+	VersionStatus    types.String `tfsdk:"version_status"`
+	ParentVersionID  types.String `tfsdk:"parent_version_id"`
+	IsLatest         types.Bool   `tfsdk:"is_latest"`
+	Inherit          types.String `tfsdk:"inherit"`
+	Description      types.String `tfsdk:"description"`
+	GuardrailsAdd    types.List   `tfsdk:"guardrails_add"`
+	GuardrailsRemove types.List   `tfsdk:"guardrails_remove"`
+	Condition        types.String `tfsdk:"condition"`
+	Pipeline         types.String `tfsdk:"pipeline"`
+	CreatedAt        types.String `tfsdk:"created_at"`
+	UpdatedAt        types.String `tfsdk:"updated_at"`
+	CreatedBy        types.String `tfsdk:"created_by"`
+	UpdatedBy        types.String `tfsdk:"updated_by"`
+}
+
+type PoliciesListDataSourceModel struct {
+	ID            types.String          `tfsdk:"id"`
+	VersionStatus types.String          `tfsdk:"version_status"`
+	Policies      []PolicyListItemModel `tfsdk:"policies"`
+	TotalCount    types.Int64           `tfsdk:"total_count"`
+}
+
+func (d *PoliciesListDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_policies"
+}
+
+func (d *PoliciesListDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Retrieves a list of LiteLLM policies.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: "Placeholder identifier.",
+				Computed:    true,
+			},
+			"version_status": schema.StringAttribute{
+				Description: "Optional filter for version status (draft, published, production).",
+				Optional:    true,
+			},
+			"total_count": schema.Int64Attribute{
+				Description: "Total number of returned policies.",
+				Computed:    true,
+			},
+			"policies": schema.ListNestedAttribute{
+				Description: "List of policies.",
+				Computed:    true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"policy_id":         schema.StringAttribute{Description: "The policy ID.", Computed: true},
+						"policy_name":       schema.StringAttribute{Description: "Policy name.", Computed: true},
+						"version_number":    schema.Int64Attribute{Description: "Version number.", Computed: true},
+						"version_status":    schema.StringAttribute{Description: "Version status.", Computed: true},
+						"parent_version_id": schema.StringAttribute{Description: "Parent version ID.", Computed: true},
+						"is_latest":         schema.BoolAttribute{Description: "Whether this is latest.", Computed: true},
+						"inherit":           schema.StringAttribute{Description: "Parent policy name.", Computed: true},
+						"description":       schema.StringAttribute{Description: "Policy description.", Computed: true},
+						"guardrails_add":    schema.ListAttribute{Description: "Guardrails to add.", Computed: true, ElementType: types.StringType},
+						"guardrails_remove": schema.ListAttribute{Description: "Guardrails to remove.", Computed: true, ElementType: types.StringType},
+						"condition":         schema.StringAttribute{Description: "Condition as JSON string.", Computed: true},
+						"pipeline":          schema.StringAttribute{Description: "Pipeline as JSON string.", Computed: true},
+						"created_at":        schema.StringAttribute{Description: "Creation timestamp.", Computed: true},
+						"updated_at":        schema.StringAttribute{Description: "Last update timestamp.", Computed: true},
+						"created_by":        schema.StringAttribute{Description: "Creator.", Computed: true},
+						"updated_by":        schema.StringAttribute{Description: "Last updater.", Computed: true},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *PoliciesListDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *Client, got: %T.", req.ProviderData),
+		)
+		return
+	}
+
+	d.client = client
+}
+
+func (d *PoliciesListDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data PoliciesListDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	endpoint := "/policies/list"
+	if !data.VersionStatus.IsNull() && !data.VersionStatus.IsUnknown() && data.VersionStatus.ValueString() != "" {
+		endpoint = endpoint + "?version_status=" + url.QueryEscape(data.VersionStatus.ValueString())
+	}
+
+	var result map[string]interface{}
+	if err := d.client.DoRequestWithResponse(ctx, "GET", endpoint, nil, &result); err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to list policies: %s", err))
+		return
+	}
+
+	data.ID = types.StringValue("policies")
+
+	if v, ok := result["total_count"].(float64); ok {
+		data.TotalCount = types.Int64Value(int64(v))
+	} else {
+		data.TotalCount = types.Int64Value(0)
+	}
+
+	data.Policies = make([]PolicyListItemModel, 0)
+	policiesData, _ := result["policies"].([]interface{})
+
+	for _, policyRaw := range policiesData {
+		policyMap, ok := policyRaw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		item := PolicyListItemModel{
+			Inherit:         types.StringNull(),
+			Description:     types.StringNull(),
+			ParentVersionID: types.StringNull(),
+			Condition:       types.StringNull(),
+			Pipeline:        types.StringNull(),
+			CreatedAt:       types.StringNull(),
+			UpdatedAt:       types.StringNull(),
+			CreatedBy:       types.StringNull(),
+			UpdatedBy:       types.StringNull(),
+		}
+
+		if v, ok := policyMap["policy_id"].(string); ok {
+			item.PolicyID = types.StringValue(v)
+		}
+		if v, ok := policyMap["policy_name"].(string); ok {
+			item.PolicyName = types.StringValue(v)
+		}
+		if v, ok := policyMap["version_number"].(float64); ok {
+			item.VersionNumber = types.Int64Value(int64(v))
+		}
+		if v, ok := policyMap["version_status"].(string); ok {
+			item.VersionStatus = types.StringValue(v)
+		}
+		if v, ok := policyMap["parent_version_id"].(string); ok && v != "" {
+			item.ParentVersionID = types.StringValue(v)
+		}
+		if v, ok := policyMap["is_latest"].(bool); ok {
+			item.IsLatest = types.BoolValue(v)
+		}
+		if v, ok := policyMap["inherit"].(string); ok && v != "" {
+			item.Inherit = types.StringValue(v)
+		}
+		if v, ok := policyMap["description"].(string); ok && v != "" {
+			item.Description = types.StringValue(v)
+		}
+		if v, ok := policyMap["created_at"].(string); ok && v != "" {
+			item.CreatedAt = types.StringValue(v)
+		}
+		if v, ok := policyMap["updated_at"].(string); ok && v != "" {
+			item.UpdatedAt = types.StringValue(v)
+		}
+		if v, ok := policyMap["created_by"].(string); ok && v != "" {
+			item.CreatedBy = types.StringValue(v)
+		}
+		if v, ok := policyMap["updated_by"].(string); ok && v != "" {
+			item.UpdatedBy = types.StringValue(v)
+		}
+
+		if values, ok := policyMap["guardrails_add"].([]interface{}); ok {
+			list := make([]attr.Value, 0, len(values))
+			for _, value := range values {
+				if strValue, ok := value.(string); ok {
+					list = append(list, types.StringValue(strValue))
+				}
+			}
+			item.GuardrailsAdd, _ = types.ListValue(types.StringType, list)
+		} else {
+			item.GuardrailsAdd, _ = types.ListValue(types.StringType, []attr.Value{})
+		}
+
+		if values, ok := policyMap["guardrails_remove"].([]interface{}); ok {
+			list := make([]attr.Value, 0, len(values))
+			for _, value := range values {
+				if strValue, ok := value.(string); ok {
+					list = append(list, types.StringValue(strValue))
+				}
+			}
+			item.GuardrailsRemove, _ = types.ListValue(types.StringType, list)
+		} else {
+			item.GuardrailsRemove, _ = types.ListValue(types.StringType, []attr.Value{})
+		}
+
+		if condition, ok := policyMap["condition"]; ok && condition != nil {
+			conditionBytes, err := json.Marshal(condition)
+			if err == nil {
+				item.Condition = types.StringValue(string(conditionBytes))
+			}
+		}
+
+		if pipeline, ok := policyMap["pipeline"]; ok && pipeline != nil {
+			pipelineBytes, err := json.Marshal(pipeline)
+			if err == nil {
+				item.Pipeline = types.StringValue(string(pipelineBytes))
+			}
+		}
+
+		data.Policies = append(data.Policies, item)
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/internal/provider/datasource_policy.go
+++ b/internal/provider/datasource_policy.go
@@ -1,0 +1,299 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ datasource.DataSource = &PolicyDataSource{}
+
+func NewPolicyDataSource() datasource.DataSource {
+	return &PolicyDataSource{}
+}
+
+type PolicyDataSource struct {
+	client *Client
+}
+
+type PolicyDataSourceModel struct {
+	ID               types.String `tfsdk:"id"`
+	PolicyID         types.String `tfsdk:"policy_id"`
+	PolicyName       types.String `tfsdk:"policy_name"`
+	Inherit          types.String `tfsdk:"inherit"`
+	Description      types.String `tfsdk:"description"`
+	GuardrailsAdd    types.List   `tfsdk:"guardrails_add"`
+	GuardrailsRemove types.List   `tfsdk:"guardrails_remove"`
+	Condition        types.Object `tfsdk:"condition"`
+	Pipeline         types.String `tfsdk:"pipeline"`
+
+	VersionNumber   types.Int64  `tfsdk:"version_number"`
+	VersionStatus   types.String `tfsdk:"version_status"`
+	ParentVersionID types.String `tfsdk:"parent_version_id"`
+	IsLatest        types.Bool   `tfsdk:"is_latest"`
+	PublishedAt     types.String `tfsdk:"published_at"`
+	ProductionAt    types.String `tfsdk:"production_at"`
+	CreatedAt       types.String `tfsdk:"created_at"`
+	UpdatedAt       types.String `tfsdk:"updated_at"`
+	CreatedBy       types.String `tfsdk:"created_by"`
+	UpdatedBy       types.String `tfsdk:"updated_by"`
+}
+
+func (d *PolicyDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_policy"
+}
+
+func (d *PolicyDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Retrieves information about a LiteLLM policy.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: "The policy ID.",
+				Computed:    true,
+			},
+			"policy_id": schema.StringAttribute{
+				Description: "The policy ID to look up.",
+				Required:    true,
+			},
+			"policy_name": schema.StringAttribute{
+				Description: "Policy name.",
+				Computed:    true,
+			},
+			"inherit": schema.StringAttribute{
+				Description: "Name of parent policy.",
+				Computed:    true,
+			},
+			"description": schema.StringAttribute{
+				Description: "Human-readable policy description.",
+				Computed:    true,
+			},
+			"guardrails_add": schema.ListAttribute{
+				Description: "Guardrails to add.",
+				Computed:    true,
+				ElementType: types.StringType,
+			},
+			"guardrails_remove": schema.ListAttribute{
+				Description: "Guardrails to remove from inherited set.",
+				Computed:    true,
+				ElementType: types.StringType,
+			},
+			"condition": schema.SingleNestedAttribute{
+				Description: "Condition for when this policy applies.",
+				Computed:    true,
+				Attributes: map[string]schema.Attribute{
+					"model": schema.StringAttribute{
+						Description: "Model name pattern (exact match or regex).",
+						Computed:    true,
+					},
+				},
+			},
+			"pipeline": schema.StringAttribute{
+				Description: "JSON string defining optional guardrail pipeline.",
+				Computed:    true,
+			},
+
+			"version_number": schema.Int64Attribute{
+				Description: "Version number.",
+				Computed:    true,
+			},
+			"version_status": schema.StringAttribute{
+				Description: "Version status (draft, published, production).",
+				Computed:    true,
+			},
+			"parent_version_id": schema.StringAttribute{
+				Description: "Policy ID this version was cloned from.",
+				Computed:    true,
+			},
+			"is_latest": schema.BoolAttribute{
+				Description: "Whether this is the latest version.",
+				Computed:    true,
+			},
+			"published_at": schema.StringAttribute{
+				Description: "Timestamp when this version was published.",
+				Computed:    true,
+			},
+			"production_at": schema.StringAttribute{
+				Description: "Timestamp when this version was promoted to production.",
+				Computed:    true,
+			},
+			"created_at": schema.StringAttribute{
+				Description: "Timestamp when the policy was created.",
+				Computed:    true,
+			},
+			"updated_at": schema.StringAttribute{
+				Description: "Timestamp when the policy was last updated.",
+				Computed:    true,
+			},
+			"created_by": schema.StringAttribute{
+				Description: "Who created the policy.",
+				Computed:    true,
+			},
+			"updated_by": schema.StringAttribute{
+				Description: "Who last updated the policy.",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func (d *PolicyDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *Client, got: %T.", req.ProviderData),
+		)
+		return
+	}
+
+	d.client = client
+}
+
+func (d *PolicyDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data PolicyDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	endpoint := fmt.Sprintf("/policies/%s", data.PolicyID.ValueString())
+
+	var result map[string]interface{}
+	if err := d.client.DoRequestWithResponse(ctx, "GET", endpoint, nil, &result); err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read policy: %s", err))
+		return
+	}
+
+	if v, ok := result["policy_id"].(string); ok && v != "" {
+		data.PolicyID = types.StringValue(v)
+		data.ID = types.StringValue(v)
+	} else {
+		data.ID = data.PolicyID
+	}
+	if v, ok := result["policy_name"].(string); ok {
+		data.PolicyName = types.StringValue(v)
+	}
+	if v, ok := result["inherit"].(string); ok && v != "" {
+		data.Inherit = types.StringValue(v)
+	} else {
+		data.Inherit = types.StringNull()
+	}
+	if v, ok := result["description"].(string); ok && v != "" {
+		data.Description = types.StringValue(v)
+	} else {
+		data.Description = types.StringNull()
+	}
+
+	if v, ok := result["version_number"].(float64); ok {
+		data.VersionNumber = types.Int64Value(int64(v))
+	} else {
+		data.VersionNumber = types.Int64Null()
+	}
+	if v, ok := result["version_status"].(string); ok && v != "" {
+		data.VersionStatus = types.StringValue(v)
+	} else {
+		data.VersionStatus = types.StringNull()
+	}
+	if v, ok := result["parent_version_id"].(string); ok && v != "" {
+		data.ParentVersionID = types.StringValue(v)
+	} else {
+		data.ParentVersionID = types.StringNull()
+	}
+	if v, ok := result["is_latest"].(bool); ok {
+		data.IsLatest = types.BoolValue(v)
+	} else {
+		data.IsLatest = types.BoolNull()
+	}
+	if v, ok := result["published_at"].(string); ok && v != "" {
+		data.PublishedAt = types.StringValue(v)
+	} else {
+		data.PublishedAt = types.StringNull()
+	}
+	if v, ok := result["production_at"].(string); ok && v != "" {
+		data.ProductionAt = types.StringValue(v)
+	} else {
+		data.ProductionAt = types.StringNull()
+	}
+	if v, ok := result["created_at"].(string); ok && v != "" {
+		data.CreatedAt = types.StringValue(v)
+	} else {
+		data.CreatedAt = types.StringNull()
+	}
+	if v, ok := result["updated_at"].(string); ok && v != "" {
+		data.UpdatedAt = types.StringValue(v)
+	} else {
+		data.UpdatedAt = types.StringNull()
+	}
+	if v, ok := result["created_by"].(string); ok && v != "" {
+		data.CreatedBy = types.StringValue(v)
+	} else {
+		data.CreatedBy = types.StringNull()
+	}
+	if v, ok := result["updated_by"].(string); ok && v != "" {
+		data.UpdatedBy = types.StringValue(v)
+	} else {
+		data.UpdatedBy = types.StringNull()
+	}
+
+	if values, ok := result["guardrails_add"].([]interface{}); ok {
+		list := make([]attr.Value, 0, len(values))
+		for _, value := range values {
+			if strValue, ok := value.(string); ok {
+				list = append(list, types.StringValue(strValue))
+			}
+		}
+		data.GuardrailsAdd, _ = types.ListValue(types.StringType, list)
+	} else {
+		data.GuardrailsAdd, _ = types.ListValue(types.StringType, []attr.Value{})
+	}
+
+	if values, ok := result["guardrails_remove"].([]interface{}); ok {
+		list := make([]attr.Value, 0, len(values))
+		for _, value := range values {
+			if strValue, ok := value.(string); ok {
+				list = append(list, types.StringValue(strValue))
+			}
+		}
+		data.GuardrailsRemove, _ = types.ListValue(types.StringType, list)
+	} else {
+		data.GuardrailsRemove, _ = types.ListValue(types.StringType, []attr.Value{})
+	}
+
+	if condition, ok := result["condition"].(map[string]interface{}); ok && len(condition) > 0 {
+		conditionModel := ""
+		if v, ok := condition["model"].(string); ok {
+			conditionModel = v
+		}
+		obj, err := policyConditionObject(conditionModel)
+		if err != nil {
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to map condition: %s", err))
+			return
+		}
+		data.Condition = obj
+	} else {
+		data.Condition = policyConditionNullObject()
+	}
+
+	if pipeline, ok := result["pipeline"]; ok && pipeline != nil {
+		pipelineBytes, err := json.Marshal(pipeline)
+		if err != nil {
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to encode pipeline: %s", err))
+			return
+		}
+		data.Pipeline = types.StringValue(string(pipelineBytes))
+	} else {
+		data.Pipeline = types.StringNull()
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/internal/provider/datasource_policy_attachment.go
+++ b/internal/provider/datasource_policy_attachment.go
@@ -1,0 +1,180 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ datasource.DataSource = &PolicyAttachmentDataSource{}
+
+func NewPolicyAttachmentDataSource() datasource.DataSource {
+	return &PolicyAttachmentDataSource{}
+}
+
+type PolicyAttachmentDataSource struct {
+	client *Client
+}
+
+type PolicyAttachmentDataSourceModel struct {
+	ID           types.String `tfsdk:"id"`
+	AttachmentID types.String `tfsdk:"attachment_id"`
+	PolicyName   types.String `tfsdk:"policy_name"`
+	Scope        types.String `tfsdk:"scope"`
+	Teams        types.List   `tfsdk:"teams"`
+	Keys         types.List   `tfsdk:"keys"`
+	Models       types.List   `tfsdk:"models"`
+	Tags         types.List   `tfsdk:"tags"`
+	CreatedAt    types.String `tfsdk:"created_at"`
+	UpdatedAt    types.String `tfsdk:"updated_at"`
+	CreatedBy    types.String `tfsdk:"created_by"`
+	UpdatedBy    types.String `tfsdk:"updated_by"`
+}
+
+func (d *PolicyAttachmentDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_policy_attachment"
+}
+
+func (d *PolicyAttachmentDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Retrieves information about a policy attachment.",
+		Attributes: map[string]schema.Attribute{
+			"id":            schema.StringAttribute{Description: "The attachment ID.", Computed: true},
+			"attachment_id": schema.StringAttribute{Description: "Attachment ID to look up.", Required: true},
+			"policy_name":   schema.StringAttribute{Description: "Name of the attached policy.", Computed: true},
+			"scope":         schema.StringAttribute{Description: "Attachment scope.", Computed: true},
+			"teams":         schema.ListAttribute{Description: "Team patterns.", Computed: true, ElementType: types.StringType},
+			"keys":          schema.ListAttribute{Description: "Key patterns.", Computed: true, ElementType: types.StringType},
+			"models":        schema.ListAttribute{Description: "Model patterns.", Computed: true, ElementType: types.StringType},
+			"tags":          schema.ListAttribute{Description: "Tag patterns.", Computed: true, ElementType: types.StringType},
+			"created_at":    schema.StringAttribute{Description: "When the attachment was created.", Computed: true},
+			"updated_at":    schema.StringAttribute{Description: "When the attachment was last updated.", Computed: true},
+			"created_by":    schema.StringAttribute{Description: "Who created the attachment.", Computed: true},
+			"updated_by":    schema.StringAttribute{Description: "Who last updated the attachment.", Computed: true},
+		},
+	}
+}
+
+func (d *PolicyAttachmentDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *Client, got: %T.", req.ProviderData),
+		)
+		return
+	}
+
+	d.client = client
+}
+
+func (d *PolicyAttachmentDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data PolicyAttachmentDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	endpoint := fmt.Sprintf("/policies/attachments/%s", data.AttachmentID.ValueString())
+
+	var result map[string]interface{}
+	if err := d.client.DoRequestWithResponse(ctx, "GET", endpoint, nil, &result); err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read policy attachment: %s", err))
+		return
+	}
+
+	if v, ok := result["attachment_id"].(string); ok && v != "" {
+		data.AttachmentID = types.StringValue(v)
+		data.ID = types.StringValue(v)
+	} else {
+		data.ID = data.AttachmentID
+	}
+	if v, ok := result["policy_name"].(string); ok {
+		data.PolicyName = types.StringValue(v)
+	}
+	if v, ok := result["scope"].(string); ok && v != "" {
+		data.Scope = types.StringValue(v)
+	} else {
+		data.Scope = types.StringNull()
+	}
+
+	if values, ok := result["teams"].([]interface{}); ok {
+		list := make([]attr.Value, 0, len(values))
+		for _, value := range values {
+			if strValue, ok := value.(string); ok {
+				list = append(list, types.StringValue(strValue))
+			}
+		}
+		data.Teams, _ = types.ListValue(types.StringType, list)
+	} else {
+		data.Teams, _ = types.ListValue(types.StringType, []attr.Value{})
+	}
+
+	if values, ok := result["keys"].([]interface{}); ok {
+		list := make([]attr.Value, 0, len(values))
+		for _, value := range values {
+			if strValue, ok := value.(string); ok {
+				list = append(list, types.StringValue(strValue))
+			}
+		}
+		data.Keys, _ = types.ListValue(types.StringType, list)
+	} else {
+		data.Keys, _ = types.ListValue(types.StringType, []attr.Value{})
+	}
+
+	if values, ok := result["models"].([]interface{}); ok {
+		list := make([]attr.Value, 0, len(values))
+		for _, value := range values {
+			if strValue, ok := value.(string); ok {
+				list = append(list, types.StringValue(strValue))
+			}
+		}
+		data.Models, _ = types.ListValue(types.StringType, list)
+	} else {
+		data.Models, _ = types.ListValue(types.StringType, []attr.Value{})
+	}
+
+	if values, ok := result["tags"].([]interface{}); ok {
+		list := make([]attr.Value, 0, len(values))
+		for _, value := range values {
+			if strValue, ok := value.(string); ok {
+				list = append(list, types.StringValue(strValue))
+			}
+		}
+		data.Tags, _ = types.ListValue(types.StringType, list)
+	} else {
+		data.Tags, _ = types.ListValue(types.StringType, []attr.Value{})
+	}
+
+	if v, ok := result["created_at"].(string); ok && v != "" {
+		data.CreatedAt = types.StringValue(v)
+	} else {
+		data.CreatedAt = types.StringNull()
+	}
+	if v, ok := result["updated_at"].(string); ok && v != "" {
+		data.UpdatedAt = types.StringValue(v)
+	} else {
+		data.UpdatedAt = types.StringNull()
+	}
+	if v, ok := result["created_by"].(string); ok && v != "" {
+		data.CreatedBy = types.StringValue(v)
+	} else {
+		data.CreatedBy = types.StringNull()
+	}
+	if v, ok := result["updated_by"].(string); ok && v != "" {
+		data.UpdatedBy = types.StringValue(v)
+	} else {
+		data.UpdatedBy = types.StringNull()
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/internal/provider/datasource_policy_attachments_list.go
+++ b/internal/provider/datasource_policy_attachments_list.go
@@ -1,0 +1,191 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ datasource.DataSource = &PolicyAttachmentsListDataSource{}
+
+func NewPolicyAttachmentsListDataSource() datasource.DataSource {
+	return &PolicyAttachmentsListDataSource{}
+}
+
+type PolicyAttachmentsListDataSource struct {
+	client *Client
+}
+
+type PolicyAttachmentListItemModel struct {
+	AttachmentID types.String `tfsdk:"attachment_id"`
+	PolicyName   types.String `tfsdk:"policy_name"`
+	Scope        types.String `tfsdk:"scope"`
+	Teams        types.List   `tfsdk:"teams"`
+	Keys         types.List   `tfsdk:"keys"`
+	Models       types.List   `tfsdk:"models"`
+	Tags         types.List   `tfsdk:"tags"`
+	CreatedAt    types.String `tfsdk:"created_at"`
+	UpdatedAt    types.String `tfsdk:"updated_at"`
+	CreatedBy    types.String `tfsdk:"created_by"`
+	UpdatedBy    types.String `tfsdk:"updated_by"`
+}
+
+type PolicyAttachmentsListDataSourceModel struct {
+	ID          types.String                    `tfsdk:"id"`
+	Attachments []PolicyAttachmentListItemModel `tfsdk:"attachments"`
+	TotalCount  types.Int64                     `tfsdk:"total_count"`
+}
+
+func (d *PolicyAttachmentsListDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_policy_attachments"
+}
+
+func (d *PolicyAttachmentsListDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Retrieves a list of policy attachments.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: "Placeholder identifier.",
+				Computed:    true,
+			},
+			"total_count": schema.Int64Attribute{
+				Description: "Total number of returned attachments.",
+				Computed:    true,
+			},
+			"attachments": schema.ListNestedAttribute{
+				Description: "List of policy attachments.",
+				Computed:    true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"attachment_id": schema.StringAttribute{Description: "Attachment ID.", Computed: true},
+						"policy_name":   schema.StringAttribute{Description: "Name of attached policy.", Computed: true},
+						"scope":         schema.StringAttribute{Description: "Attachment scope.", Computed: true},
+						"teams":         schema.ListAttribute{Description: "Team patterns.", Computed: true, ElementType: types.StringType},
+						"keys":          schema.ListAttribute{Description: "Key patterns.", Computed: true, ElementType: types.StringType},
+						"models":        schema.ListAttribute{Description: "Model patterns.", Computed: true, ElementType: types.StringType},
+						"tags":          schema.ListAttribute{Description: "Tag patterns.", Computed: true, ElementType: types.StringType},
+						"created_at":    schema.StringAttribute{Description: "When created.", Computed: true},
+						"updated_at":    schema.StringAttribute{Description: "When updated.", Computed: true},
+						"created_by":    schema.StringAttribute{Description: "Who created it.", Computed: true},
+						"updated_by":    schema.StringAttribute{Description: "Who updated it.", Computed: true},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *PolicyAttachmentsListDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *Client, got: %T.", req.ProviderData),
+		)
+		return
+	}
+
+	d.client = client
+}
+
+func (d *PolicyAttachmentsListDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data PolicyAttachmentsListDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var result map[string]interface{}
+	if err := d.client.DoRequestWithResponse(ctx, "GET", "/policies/attachments/list", nil, &result); err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to list policy attachments: %s", err))
+		return
+	}
+
+	data.ID = types.StringValue("policy_attachments")
+
+	if v, ok := result["total_count"].(float64); ok {
+		data.TotalCount = types.Int64Value(int64(v))
+	} else {
+		data.TotalCount = types.Int64Value(0)
+	}
+
+	attachments := make([]PolicyAttachmentListItemModel, 0)
+	if rows, ok := result["attachments"].([]interface{}); ok {
+		for _, row := range rows {
+			itemMap, ok := row.(map[string]interface{})
+			if !ok {
+				continue
+			}
+
+			item := PolicyAttachmentListItemModel{}
+
+			if v, ok := itemMap["attachment_id"].(string); ok {
+				item.AttachmentID = types.StringValue(v)
+			}
+			if v, ok := itemMap["policy_name"].(string); ok {
+				item.PolicyName = types.StringValue(v)
+			}
+			if v, ok := itemMap["scope"].(string); ok && v != "" {
+				item.Scope = types.StringValue(v)
+			} else {
+				item.Scope = types.StringNull()
+			}
+
+			item.Teams = toStringListValue(itemMap["teams"])
+			item.Keys = toStringListValue(itemMap["keys"])
+			item.Models = toStringListValue(itemMap["models"])
+			item.Tags = toStringListValue(itemMap["tags"])
+
+			if v, ok := itemMap["created_at"].(string); ok && v != "" {
+				item.CreatedAt = types.StringValue(v)
+			} else {
+				item.CreatedAt = types.StringNull()
+			}
+			if v, ok := itemMap["updated_at"].(string); ok && v != "" {
+				item.UpdatedAt = types.StringValue(v)
+			} else {
+				item.UpdatedAt = types.StringNull()
+			}
+			if v, ok := itemMap["created_by"].(string); ok && v != "" {
+				item.CreatedBy = types.StringValue(v)
+			} else {
+				item.CreatedBy = types.StringNull()
+			}
+			if v, ok := itemMap["updated_by"].(string); ok && v != "" {
+				item.UpdatedBy = types.StringValue(v)
+			} else {
+				item.UpdatedBy = types.StringNull()
+			}
+
+			attachments = append(attachments, item)
+		}
+	}
+
+	data.Attachments = attachments
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func toStringListValue(raw interface{}) types.List {
+	values := make([]attr.Value, 0)
+
+	if arr, ok := raw.([]interface{}); ok {
+		for _, item := range arr {
+			if str, ok := item.(string); ok {
+				values = append(values, types.StringValue(str))
+			}
+		}
+	}
+
+	list, _ := types.ListValue(types.StringType, values)
+	return list
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -164,6 +164,8 @@ func (p *LiteLLMProvider) Resources(ctx context.Context) []func() resource.Resou
 		NewFallbackResource,
 		NewAgentResource,
 		NewProjectResource,
+		NewPolicyResource,
+		NewPolicyAttachmentResource,
 	}
 }
 
@@ -187,6 +189,8 @@ func (p *LiteLLMProvider) DataSources(ctx context.Context) []func() datasource.D
 		NewFallbackDataSource,
 		NewAgentDataSource,
 		NewProjectDataSource,
+		NewPolicyDataSource,
+		NewPolicyAttachmentDataSource,
 		// List data sources
 		NewModelsListDataSource,
 		NewKeysListDataSource,
@@ -202,6 +206,8 @@ func (p *LiteLLMProvider) DataSources(ctx context.Context) []func() datasource.D
 		NewSearchToolsListDataSource,
 		NewAgentsListDataSource,
 		NewProjectsListDataSource,
+		NewPoliciesListDataSource,
+		NewPolicyAttachmentsListDataSource,
 	}
 }
 

--- a/internal/provider/resource_policy.go
+++ b/internal/provider/resource_policy.go
@@ -1,0 +1,492 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ resource.Resource = &PolicyResource{}
+var _ resource.ResourceWithImportState = &PolicyResource{}
+
+func NewPolicyResource() resource.Resource {
+	return &PolicyResource{}
+}
+
+type PolicyResource struct {
+	client *Client
+}
+
+type PolicyResourceModel struct {
+	ID               types.String `tfsdk:"id"`
+	PolicyName       types.String `tfsdk:"policy_name"`
+	Inherit          types.String `tfsdk:"inherit"`
+	Description      types.String `tfsdk:"description"`
+	GuardrailsAdd    types.List   `tfsdk:"guardrails_add"`
+	GuardrailsRemove types.List   `tfsdk:"guardrails_remove"`
+	Condition        types.Object `tfsdk:"condition"`
+	Pipeline         types.String `tfsdk:"pipeline"`
+
+	VersionNumber   types.Int64  `tfsdk:"version_number"`
+	VersionStatus   types.String `tfsdk:"version_status"`
+	ParentVersionID types.String `tfsdk:"parent_version_id"`
+	IsLatest        types.Bool   `tfsdk:"is_latest"`
+	PublishedAt     types.String `tfsdk:"published_at"`
+	ProductionAt    types.String `tfsdk:"production_at"`
+	CreatedAt       types.String `tfsdk:"created_at"`
+	UpdatedAt       types.String `tfsdk:"updated_at"`
+	CreatedBy       types.String `tfsdk:"created_by"`
+	UpdatedBy       types.String `tfsdk:"updated_by"`
+}
+
+func policyConditionAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"model": types.StringType,
+	}
+}
+
+func policyConditionNullObject() types.Object {
+	return types.ObjectNull(policyConditionAttrTypes())
+}
+
+func policyConditionObject(model string) (types.Object, error) {
+	attrs := map[string]attr.Value{
+		"model": types.StringNull(),
+	}
+	if model != "" {
+		attrs["model"] = types.StringValue(model)
+	}
+
+	obj, diags := types.ObjectValue(policyConditionAttrTypes(), attrs)
+	if diags.HasError() {
+		return types.Object{}, fmt.Errorf("failed to build condition object")
+	}
+	return obj, nil
+}
+
+func (r *PolicyResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_policy"
+}
+
+func (r *PolicyResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Manages a LiteLLM policy.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: "The policy ID.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"policy_name": schema.StringAttribute{
+				Description: "Unique policy name.",
+				Required:    true,
+			},
+			"inherit": schema.StringAttribute{
+				Description: "Name of parent policy to inherit from.",
+				Optional:    true,
+			},
+			"description": schema.StringAttribute{
+				Description: "Human-readable policy description.",
+				Optional:    true,
+			},
+			"guardrails_add": schema.ListAttribute{
+				Description: "Guardrails to add.",
+				Optional:    true,
+				ElementType: types.StringType,
+			},
+			"guardrails_remove": schema.ListAttribute{
+				Description: "Guardrails to remove from inherited set.",
+				Optional:    true,
+				ElementType: types.StringType,
+			},
+			"condition": schema.SingleNestedAttribute{
+				Description: "Condition for when this policy applies.",
+				Optional:    true,
+				Attributes: map[string]schema.Attribute{
+					"model": schema.StringAttribute{
+						Description: "Model name pattern (exact match or regex).",
+						Optional:    true,
+					},
+				},
+			},
+			"pipeline": schema.StringAttribute{
+				Description: "JSON string defining optional guardrail pipeline.",
+				Optional:    true,
+			},
+
+			"version_number": schema.Int64Attribute{
+				Description: "Version number of this policy.",
+				Computed:    true,
+			},
+			"version_status": schema.StringAttribute{
+				Description: "Version status (draft, published, production).",
+				Computed:    true,
+			},
+			"parent_version_id": schema.StringAttribute{
+				Description: "Policy ID this version was cloned from.",
+				Computed:    true,
+			},
+			"is_latest": schema.BoolAttribute{
+				Description: "Whether this is the latest version.",
+				Computed:    true,
+			},
+			"published_at": schema.StringAttribute{
+				Description: "Timestamp when this version was published.",
+				Computed:    true,
+			},
+			"production_at": schema.StringAttribute{
+				Description: "Timestamp when this version was promoted to production.",
+				Computed:    true,
+			},
+			"created_at": schema.StringAttribute{
+				Description: "Timestamp when the policy was created.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"updated_at": schema.StringAttribute{
+				Description: "Timestamp when the policy was last updated.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"created_by": schema.StringAttribute{
+				Description: "Who created the policy.",
+				Computed:    true,
+			},
+			"updated_by": schema.StringAttribute{
+				Description: "Who last updated the policy.",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func (r *PolicyResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *Client, got: %T.", req.ProviderData),
+		)
+		return
+	}
+
+	r.client = client
+}
+
+func (r *PolicyResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data PolicyResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	policyReq, err := r.buildPolicyRequest(ctx, &data)
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid policy configuration", err.Error())
+		return
+	}
+
+	var result map[string]interface{}
+	if err := r.client.DoRequestWithResponse(ctx, "POST", "/policies", policyReq, &result); err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create policy: %s", err))
+		return
+	}
+
+	policyID, err := requiredStringField(result, "policy_id")
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create policy: %s", err))
+		return
+	}
+	data.ID = types.StringValue(policyID)
+
+	if err := r.readPolicy(ctx, &data); err != nil {
+		resp.Diagnostics.AddWarning("Read Error", fmt.Sprintf("Policy created but failed to read back: %s", err))
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *PolicyResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data PolicyResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := r.readPolicy(ctx, &data); err != nil {
+		if IsNotFoundError(err) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read policy: %s", err))
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *PolicyResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data PolicyResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var state PolicyResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data.ID = state.ID
+
+	policyReq, err := r.buildPolicyRequest(ctx, &data)
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid policy configuration", err.Error())
+		return
+	}
+
+	endpoint := fmt.Sprintf("/policies/%s", data.ID.ValueString())
+	if err := r.client.DoRequestWithResponse(ctx, "PUT", endpoint, policyReq, nil); err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update policy: %s", err))
+		return
+	}
+
+	if err := r.readPolicy(ctx, &data); err != nil {
+		resp.Diagnostics.AddWarning("Read Error", fmt.Sprintf("Policy updated but failed to read back: %s", err))
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *PolicyResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data PolicyResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	endpoint := fmt.Sprintf("/policies/%s", data.ID.ValueString())
+	if err := r.client.DoRequestWithResponse(ctx, "DELETE", endpoint, nil, nil); err != nil {
+		if !IsNotFoundError(err) {
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete policy: %s", err))
+			return
+		}
+	}
+}
+
+func (r *PolicyResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+func (r *PolicyResource) buildPolicyRequest(ctx context.Context, data *PolicyResourceModel) (map[string]interface{}, error) {
+	req := map[string]interface{}{
+		"policy_name": data.PolicyName.ValueString(),
+	}
+
+	if !data.Inherit.IsNull() && !data.Inherit.IsUnknown() && data.Inherit.ValueString() != "" {
+		req["inherit"] = data.Inherit.ValueString()
+	}
+	if !data.Description.IsNull() && !data.Description.IsUnknown() {
+		req["description"] = data.Description.ValueString()
+	}
+
+	if !data.GuardrailsAdd.IsNull() && !data.GuardrailsAdd.IsUnknown() {
+		var guardrailsAdd []string
+		data.GuardrailsAdd.ElementsAs(ctx, &guardrailsAdd, false)
+		req["guardrails_add"] = guardrailsAdd
+	}
+	if !data.GuardrailsRemove.IsNull() && !data.GuardrailsRemove.IsUnknown() {
+		var guardrailsRemove []string
+		data.GuardrailsRemove.ElementsAs(ctx, &guardrailsRemove, false)
+		req["guardrails_remove"] = guardrailsRemove
+	}
+
+	if !data.Condition.IsNull() && !data.Condition.IsUnknown() {
+		condition := map[string]interface{}{}
+		if modelAttr, ok := data.Condition.Attributes()["model"]; ok {
+			if modelValue, ok := modelAttr.(types.String); ok && !modelValue.IsNull() && !modelValue.IsUnknown() && modelValue.ValueString() != "" {
+				condition["model"] = modelValue.ValueString()
+			}
+		}
+		if len(condition) > 0 {
+			req["condition"] = condition
+		}
+	}
+
+	if !data.Pipeline.IsNull() && !data.Pipeline.IsUnknown() && data.Pipeline.ValueString() != "" {
+		var pipeline map[string]interface{}
+		if err := json.Unmarshal([]byte(data.Pipeline.ValueString()), &pipeline); err != nil {
+			return nil, fmt.Errorf("pipeline must be valid JSON object: %w", err)
+		}
+		req["pipeline"] = pipeline
+	}
+
+	return req, nil
+}
+
+func (r *PolicyResource) readPolicy(ctx context.Context, data *PolicyResourceModel) error {
+	policyID := data.ID.ValueString()
+	if policyID == "" {
+		return fmt.Errorf("policy ID is empty, cannot read policy")
+	}
+
+	endpoint := fmt.Sprintf("/policies/%s", policyID)
+
+	var result map[string]interface{}
+	if err := r.client.DoRequestWithResponse(ctx, "GET", endpoint, nil, &result); err != nil {
+		return err
+	}
+
+	if v, ok := result["policy_id"].(string); ok && v != "" {
+		data.ID = types.StringValue(v)
+	}
+	if v, ok := result["policy_name"].(string); ok {
+		data.PolicyName = types.StringValue(v)
+	}
+	if v, ok := result["inherit"].(string); ok && v != "" {
+		data.Inherit = types.StringValue(v)
+	} else if data.Inherit.IsUnknown() || !data.Inherit.IsNull() {
+		data.Inherit = types.StringNull()
+	}
+	if v, ok := result["description"].(string); ok {
+		data.Description = types.StringValue(v)
+	} else if data.Description.IsUnknown() || !data.Description.IsNull() {
+		data.Description = types.StringNull()
+	}
+
+	if v, ok := result["version_number"].(float64); ok {
+		data.VersionNumber = types.Int64Value(int64(v))
+	} else if data.VersionNumber.IsUnknown() {
+		data.VersionNumber = types.Int64Null()
+	}
+	if v, ok := result["version_status"].(string); ok && v != "" {
+		data.VersionStatus = types.StringValue(v)
+	} else if data.VersionStatus.IsUnknown() {
+		data.VersionStatus = types.StringNull()
+	}
+	if v, ok := result["parent_version_id"].(string); ok && v != "" {
+		data.ParentVersionID = types.StringValue(v)
+	} else if data.ParentVersionID.IsUnknown() {
+		data.ParentVersionID = types.StringNull()
+	}
+	if v, ok := result["is_latest"].(bool); ok {
+		data.IsLatest = types.BoolValue(v)
+	} else if data.IsLatest.IsUnknown() {
+		data.IsLatest = types.BoolNull()
+	}
+	if v, ok := result["published_at"].(string); ok && v != "" {
+		data.PublishedAt = types.StringValue(v)
+	} else if data.PublishedAt.IsUnknown() {
+		data.PublishedAt = types.StringNull()
+	}
+	if v, ok := result["production_at"].(string); ok && v != "" {
+		data.ProductionAt = types.StringValue(v)
+	} else if data.ProductionAt.IsUnknown() {
+		data.ProductionAt = types.StringNull()
+	}
+	if v, ok := result["created_at"].(string); ok && v != "" {
+		data.CreatedAt = types.StringValue(v)
+	} else if data.CreatedAt.IsUnknown() {
+		data.CreatedAt = types.StringNull()
+	}
+	if v, ok := result["updated_at"].(string); ok && v != "" {
+		data.UpdatedAt = types.StringValue(v)
+	} else if data.UpdatedAt.IsUnknown() {
+		data.UpdatedAt = types.StringNull()
+	}
+	if v, ok := result["created_by"].(string); ok && v != "" {
+		data.CreatedBy = types.StringValue(v)
+	} else if data.CreatedBy.IsUnknown() {
+		data.CreatedBy = types.StringNull()
+	}
+	if v, ok := result["updated_by"].(string); ok && v != "" {
+		data.UpdatedBy = types.StringValue(v)
+	} else if data.UpdatedBy.IsUnknown() {
+		data.UpdatedBy = types.StringNull()
+	}
+
+	if values, ok := result["guardrails_add"].([]interface{}); ok {
+		if len(values) > 0 {
+			list := make([]attr.Value, 0, len(values))
+			for _, value := range values {
+				if strValue, ok := value.(string); ok {
+					list = append(list, types.StringValue(strValue))
+				}
+			}
+			data.GuardrailsAdd, _ = types.ListValue(types.StringType, list)
+		} else if !data.GuardrailsAdd.IsNull() {
+			data.GuardrailsAdd, _ = types.ListValue(types.StringType, []attr.Value{})
+		} else if data.GuardrailsAdd.IsUnknown() {
+			data.GuardrailsAdd = types.ListNull(types.StringType)
+		}
+	} else if data.GuardrailsAdd.IsUnknown() {
+		data.GuardrailsAdd = types.ListNull(types.StringType)
+	}
+
+	if values, ok := result["guardrails_remove"].([]interface{}); ok {
+		if len(values) > 0 {
+			list := make([]attr.Value, 0, len(values))
+			for _, value := range values {
+				if strValue, ok := value.(string); ok {
+					list = append(list, types.StringValue(strValue))
+				}
+			}
+			data.GuardrailsRemove, _ = types.ListValue(types.StringType, list)
+		} else if !data.GuardrailsRemove.IsNull() {
+			data.GuardrailsRemove, _ = types.ListValue(types.StringType, []attr.Value{})
+		} else if data.GuardrailsRemove.IsUnknown() {
+			data.GuardrailsRemove = types.ListNull(types.StringType)
+		}
+	} else if data.GuardrailsRemove.IsUnknown() {
+		data.GuardrailsRemove = types.ListNull(types.StringType)
+	}
+
+	if condition, ok := result["condition"].(map[string]interface{}); ok && len(condition) > 0 {
+		conditionModel := ""
+		if v, ok := condition["model"].(string); ok {
+			conditionModel = v
+		}
+		obj, err := policyConditionObject(conditionModel)
+		if err != nil {
+			return err
+		}
+		data.Condition = obj
+	} else if data.Condition.IsUnknown() || !data.Condition.IsNull() {
+		data.Condition = policyConditionNullObject()
+	}
+
+	if pipeline, ok := result["pipeline"]; ok && pipeline != nil {
+		pipelineBytes, err := json.Marshal(pipeline)
+		if err != nil {
+			return fmt.Errorf("failed to marshal pipeline from response: %w", err)
+		}
+		data.Pipeline = types.StringValue(string(pipelineBytes))
+	} else if data.Pipeline.IsUnknown() || !data.Pipeline.IsNull() {
+		data.Pipeline = types.StringNull()
+	}
+
+	return nil
+}

--- a/internal/provider/resource_policy_attachment.go
+++ b/internal/provider/resource_policy_attachment.go
@@ -1,0 +1,421 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ resource.Resource = &PolicyAttachmentResource{}
+var _ resource.ResourceWithImportState = &PolicyAttachmentResource{}
+
+func NewPolicyAttachmentResource() resource.Resource {
+	return &PolicyAttachmentResource{}
+}
+
+type PolicyAttachmentResource struct {
+	client *Client
+}
+
+type PolicyAttachmentResourceModel struct {
+	ID         types.String `tfsdk:"id"`
+	PolicyName types.String `tfsdk:"policy_name"`
+	Scope      types.String `tfsdk:"scope"`
+	Teams      types.List   `tfsdk:"teams"`
+	Keys       types.List   `tfsdk:"keys"`
+	Models     types.List   `tfsdk:"models"`
+	Tags       types.List   `tfsdk:"tags"`
+	CreatedAt  types.String `tfsdk:"created_at"`
+	UpdatedAt  types.String `tfsdk:"updated_at"`
+	CreatedBy  types.String `tfsdk:"created_by"`
+	UpdatedBy  types.String `tfsdk:"updated_by"`
+}
+
+func (r *PolicyAttachmentResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_policy_attachment"
+}
+
+func (r *PolicyAttachmentResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Manages a LiteLLM policy attachment.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: "The attachment ID.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"policy_name": schema.StringAttribute{
+				Description: "Name of the policy to attach.",
+				Required:    true,
+			},
+			"scope": schema.StringAttribute{
+				Description: "Use '*' for global scope.",
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.OneOf("*"),
+				},
+			},
+			"teams": schema.ListAttribute{
+				Description: "Team aliases or patterns this attachment applies to.",
+				Optional:    true,
+				ElementType: types.StringType,
+			},
+			"keys": schema.ListAttribute{
+				Description: "Key aliases or patterns this attachment applies to.",
+				Optional:    true,
+				ElementType: types.StringType,
+			},
+			"models": schema.ListAttribute{
+				Description: "Model names or patterns this attachment applies to.",
+				Optional:    true,
+				ElementType: types.StringType,
+			},
+			"tags": schema.ListAttribute{
+				Description: "Tag patterns this attachment applies to.",
+				Optional:    true,
+				ElementType: types.StringType,
+			},
+			"created_at": schema.StringAttribute{
+				Description: "When the attachment was created.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"updated_at": schema.StringAttribute{
+				Description: "When the attachment was last updated.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"created_by": schema.StringAttribute{
+				Description: "Who created the attachment.",
+				Computed:    true,
+			},
+			"updated_by": schema.StringAttribute{
+				Description: "Who last updated the attachment.",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func (r *PolicyAttachmentResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *Client, got: %T.", req.ProviderData),
+		)
+		return
+	}
+
+	r.client = client
+}
+
+func (r *PolicyAttachmentResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data PolicyAttachmentResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := validatePolicyAttachmentTargeting(ctx, data.Scope, data.Teams, data.Keys, data.Models, data.Tags); err != nil {
+		resp.Diagnostics.AddError("Invalid attachment targeting", err.Error())
+		return
+	}
+
+	attachmentReq := buildPolicyAttachmentRequest(ctx, data.PolicyName, data.Scope, data.Teams, data.Keys, data.Models, data.Tags)
+
+	var result map[string]interface{}
+	if err := r.client.DoRequestWithResponse(ctx, "POST", "/policies/attachments", attachmentReq, &result); err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create policy attachment: %s", err))
+		return
+	}
+
+	attachmentID, err := requiredStringField(result, "attachment_id")
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create policy attachment: %s", err))
+		return
+	}
+	data.ID = types.StringValue(attachmentID)
+
+	if err := r.readPolicyAttachment(ctx, &data); err != nil {
+		resp.Diagnostics.AddWarning("Read Error", fmt.Sprintf("Attachment created but failed to read back: %s", err))
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *PolicyAttachmentResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data PolicyAttachmentResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := r.readPolicyAttachment(ctx, &data); err != nil {
+		if IsNotFoundError(err) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read policy attachment: %s", err))
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *PolicyAttachmentResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data PolicyAttachmentResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var state PolicyAttachmentResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := validatePolicyAttachmentTargeting(ctx, data.Scope, data.Teams, data.Keys, data.Models, data.Tags); err != nil {
+		resp.Diagnostics.AddError("Invalid attachment targeting", err.Error())
+		return
+	}
+
+	data.ID = state.ID
+
+	deleteEndpoint := fmt.Sprintf("/policies/attachments/%s", data.ID.ValueString())
+	if err := r.client.DoRequestWithResponse(ctx, "DELETE", deleteEndpoint, nil, nil); err != nil {
+		if !IsNotFoundError(err) {
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update policy attachment: %s", err))
+			return
+		}
+	}
+
+	attachmentReq := buildPolicyAttachmentRequest(ctx, data.PolicyName, data.Scope, data.Teams, data.Keys, data.Models, data.Tags)
+
+	var result map[string]interface{}
+	if err := r.client.DoRequestWithResponse(ctx, "POST", "/policies/attachments", attachmentReq, &result); err != nil {
+		resp.State.RemoveResource(ctx)
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update policy attachment: %s", err))
+		return
+	}
+
+	attachmentID, err := requiredStringField(result, "attachment_id")
+	if err != nil {
+		resp.State.RemoveResource(ctx)
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update policy attachment: %s", err))
+		return
+	}
+	data.ID = types.StringValue(attachmentID)
+
+	if err := r.readPolicyAttachment(ctx, &data); err != nil {
+		resp.Diagnostics.AddWarning("Read Error", fmt.Sprintf("Attachment updated but failed to read back: %s", err))
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *PolicyAttachmentResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data PolicyAttachmentResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	endpoint := fmt.Sprintf("/policies/attachments/%s", data.ID.ValueString())
+	if err := r.client.DoRequestWithResponse(ctx, "DELETE", endpoint, nil, nil); err != nil {
+		if !IsNotFoundError(err) {
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete policy attachment: %s", err))
+			return
+		}
+	}
+}
+
+func (r *PolicyAttachmentResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+func buildPolicyAttachmentRequest(ctx context.Context, policyName, scope types.String, teams, keys, models, tags types.List) map[string]interface{} {
+	req := map[string]interface{}{
+		"policy_name": policyName.ValueString(),
+	}
+
+	if !scope.IsNull() && !scope.IsUnknown() && scope.ValueString() != "" {
+		req["scope"] = scope.ValueString()
+	}
+
+	if teamsList := listStringValues(ctx, teams); len(teamsList) > 0 {
+		req["teams"] = teamsList
+	}
+	if keysList := listStringValues(ctx, keys); len(keysList) > 0 {
+		req["keys"] = keysList
+	}
+	if modelsList := listStringValues(ctx, models); len(modelsList) > 0 {
+		req["models"] = modelsList
+	}
+	if tagsList := listStringValues(ctx, tags); len(tagsList) > 0 {
+		req["tags"] = tagsList
+	}
+
+	return req
+}
+
+func listStringValues(ctx context.Context, list types.List) []string {
+	if list.IsNull() || list.IsUnknown() {
+		return nil
+	}
+
+	vals := make([]string, 0)
+	list.ElementsAs(ctx, &vals, false)
+	return vals
+}
+
+func validatePolicyAttachmentTargeting(ctx context.Context, scope types.String, teams, keys, models, tags types.List) error {
+	hasScope := !scope.IsNull() && !scope.IsUnknown() && scope.ValueString() != ""
+	hasTargets := len(listStringValues(ctx, teams)) > 0 ||
+		len(listStringValues(ctx, keys)) > 0 ||
+		len(listStringValues(ctx, models)) > 0 ||
+		len(listStringValues(ctx, tags)) > 0
+
+	if hasScope && scope.ValueString() != "*" {
+		return fmt.Errorf("scope must be '*' when provided")
+	}
+
+	if hasScope && hasTargets {
+		return fmt.Errorf("set either scope='*' OR one or more of teams/keys/models/tags, not both")
+	}
+
+	if !hasScope && !hasTargets {
+		return fmt.Errorf("set either scope='*' OR at least one of teams/keys/models/tags")
+	}
+
+	return nil
+}
+
+func (r *PolicyAttachmentResource) readPolicyAttachment(ctx context.Context, data *PolicyAttachmentResourceModel) error {
+	attachmentID := data.ID.ValueString()
+	if attachmentID == "" {
+		return fmt.Errorf("attachment ID is empty, cannot read policy attachment")
+	}
+
+	endpoint := fmt.Sprintf("/policies/attachments/%s", attachmentID)
+
+	var result map[string]interface{}
+	if err := r.client.DoRequestWithResponse(ctx, "GET", endpoint, nil, &result); err != nil {
+		return err
+	}
+
+	if v, ok := result["attachment_id"].(string); ok && v != "" {
+		data.ID = types.StringValue(v)
+	}
+	if v, ok := result["policy_name"].(string); ok {
+		data.PolicyName = types.StringValue(v)
+	}
+	if v, ok := result["scope"].(string); ok && v != "" {
+		data.Scope = types.StringValue(v)
+	} else if data.Scope.IsUnknown() || !data.Scope.IsNull() {
+		data.Scope = types.StringNull()
+	}
+
+	if values, ok := result["teams"].([]interface{}); ok {
+		if len(values) > 0 || !data.Teams.IsNull() {
+			list := make([]attr.Value, 0, len(values))
+			for _, value := range values {
+				if strValue, ok := value.(string); ok {
+					list = append(list, types.StringValue(strValue))
+				}
+			}
+			data.Teams, _ = types.ListValue(types.StringType, list)
+		} else if data.Teams.IsUnknown() {
+			data.Teams = types.ListNull(types.StringType)
+		}
+	}
+
+	if values, ok := result["keys"].([]interface{}); ok {
+		if len(values) > 0 || !data.Keys.IsNull() {
+			list := make([]attr.Value, 0, len(values))
+			for _, value := range values {
+				if strValue, ok := value.(string); ok {
+					list = append(list, types.StringValue(strValue))
+				}
+			}
+			data.Keys, _ = types.ListValue(types.StringType, list)
+		} else if data.Keys.IsUnknown() {
+			data.Keys = types.ListNull(types.StringType)
+		}
+	}
+
+	if values, ok := result["models"].([]interface{}); ok {
+		if len(values) > 0 || !data.Models.IsNull() {
+			list := make([]attr.Value, 0, len(values))
+			for _, value := range values {
+				if strValue, ok := value.(string); ok {
+					list = append(list, types.StringValue(strValue))
+				}
+			}
+			data.Models, _ = types.ListValue(types.StringType, list)
+		} else if data.Models.IsUnknown() {
+			data.Models = types.ListNull(types.StringType)
+		}
+	}
+
+	if values, ok := result["tags"].([]interface{}); ok {
+		if len(values) > 0 || !data.Tags.IsNull() {
+			list := make([]attr.Value, 0, len(values))
+			for _, value := range values {
+				if strValue, ok := value.(string); ok {
+					list = append(list, types.StringValue(strValue))
+				}
+			}
+			data.Tags, _ = types.ListValue(types.StringType, list)
+		} else if data.Tags.IsUnknown() {
+			data.Tags = types.ListNull(types.StringType)
+		}
+	}
+
+	if v, ok := result["created_at"].(string); ok && v != "" {
+		data.CreatedAt = types.StringValue(v)
+	} else if data.CreatedAt.IsUnknown() {
+		data.CreatedAt = types.StringNull()
+	}
+	if v, ok := result["updated_at"].(string); ok && v != "" {
+		data.UpdatedAt = types.StringValue(v)
+	} else if data.UpdatedAt.IsUnknown() {
+		data.UpdatedAt = types.StringNull()
+	}
+	if v, ok := result["created_by"].(string); ok && v != "" {
+		data.CreatedBy = types.StringValue(v)
+	} else if data.CreatedBy.IsUnknown() {
+		data.CreatedBy = types.StringNull()
+	}
+	if v, ok := result["updated_by"].(string); ok && v != "" {
+		data.UpdatedBy = types.StringValue(v)
+	} else if data.UpdatedBy.IsUnknown() {
+		data.UpdatedBy = types.StringNull()
+	}
+
+	return nil
+}

--- a/internal/provider/resource_policy_attachment_test.go
+++ b/internal/provider/resource_policy_attachment_test.go
@@ -1,0 +1,157 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestValidatePolicyAttachmentTargeting_GlobalScopeOnly(t *testing.T) {
+	t.Parallel()
+
+	err := validatePolicyAttachmentTargeting(
+		context.Background(),
+		types.StringValue("*"),
+		types.ListNull(types.StringType),
+		types.ListNull(types.StringType),
+		types.ListNull(types.StringType),
+		types.ListNull(types.StringType),
+	)
+
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestValidatePolicyAttachmentTargeting_TargetsOnly(t *testing.T) {
+	t.Parallel()
+
+	err := validatePolicyAttachmentTargeting(
+		context.Background(),
+		types.StringNull(),
+		stringListValue("team-a"),
+		types.ListNull(types.StringType),
+		types.ListNull(types.StringType),
+		types.ListNull(types.StringType),
+	)
+
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestValidatePolicyAttachmentTargeting_InvalidScopeValue(t *testing.T) {
+	t.Parallel()
+
+	err := validatePolicyAttachmentTargeting(
+		context.Background(),
+		types.StringValue("team"),
+		types.ListNull(types.StringType),
+		types.ListNull(types.StringType),
+		types.ListNull(types.StringType),
+		types.ListNull(types.StringType),
+	)
+
+	if err == nil {
+		t.Fatal("expected error for invalid scope value")
+	}
+}
+
+func TestValidatePolicyAttachmentTargeting_ScopeWithTargets(t *testing.T) {
+	t.Parallel()
+
+	err := validatePolicyAttachmentTargeting(
+		context.Background(),
+		types.StringValue("*"),
+		stringListValue("team-a"),
+		types.ListNull(types.StringType),
+		types.ListNull(types.StringType),
+		types.ListNull(types.StringType),
+	)
+
+	if err == nil {
+		t.Fatal("expected error when scope is combined with targeting lists")
+	}
+}
+
+func TestValidatePolicyAttachmentTargeting_NoScopeAndNoTargets(t *testing.T) {
+	t.Parallel()
+
+	err := validatePolicyAttachmentTargeting(
+		context.Background(),
+		types.StringNull(),
+		types.ListNull(types.StringType),
+		types.ListNull(types.StringType),
+		types.ListNull(types.StringType),
+		types.ListNull(types.StringType),
+	)
+
+	if err == nil {
+		t.Fatal("expected error when no scope and no targets are set")
+	}
+}
+
+func TestBuildPolicyAttachmentRequest(t *testing.T) {
+	t.Parallel()
+
+	req := buildPolicyAttachmentRequest(
+		context.Background(),
+		types.StringValue("global-baseline"),
+		types.StringNull(),
+		stringListValue("team-a", "team-b"),
+		types.ListNull(types.StringType),
+		stringListValue("gpt-4o"),
+		stringListValue("health-*"),
+	)
+
+	if req["policy_name"] != "global-baseline" {
+		t.Errorf("expected policy_name to be set, got %v", req["policy_name"])
+	}
+
+	teams, ok := req["teams"].([]string)
+	if !ok || len(teams) != 2 {
+		t.Fatalf("expected two teams, got %v", req["teams"])
+	}
+
+	if _, exists := req["scope"]; exists {
+		t.Error("scope should not be set when null")
+	}
+}
+
+func TestReadPolicyAttachment_ClearsExistingScopeWhenOmitted(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"attachment_id": "att-123",
+			"policy_name":   "baseline",
+		})
+	}))
+	defer server.Close()
+
+	r := &PolicyAttachmentResource{
+		client: &Client{
+			APIBase:    server.URL,
+			APIKey:     "test-key",
+			HTTPClient: server.Client(),
+		},
+	}
+
+	data := PolicyAttachmentResourceModel{
+		ID:    types.StringValue("att-123"),
+		Scope: types.StringValue("*"),
+	}
+
+	if err := r.readPolicyAttachment(context.Background(), &data); err != nil {
+		t.Fatalf("readPolicyAttachment returned error: %v", err)
+	}
+
+	if !data.Scope.IsNull() {
+		t.Fatalf("expected scope to be cleared to null, got %q", data.Scope.ValueString())
+	}
+}

--- a/internal/provider/resource_policy_test.go
+++ b/internal/provider/resource_policy_test.go
@@ -1,0 +1,296 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestBuildPolicyRequest_Minimal(t *testing.T) {
+	t.Parallel()
+
+	r := &PolicyResource{}
+	data := &PolicyResourceModel{
+		PolicyName: types.StringValue("global-baseline"),
+	}
+
+	req, err := r.buildPolicyRequest(context.Background(), data)
+	if err != nil {
+		t.Fatalf("buildPolicyRequest returned error: %v", err)
+	}
+
+	if req["policy_name"] != "global-baseline" {
+		t.Errorf("expected policy_name 'global-baseline', got %v", req["policy_name"])
+	}
+	if _, exists := req["guardrails_add"]; exists {
+		t.Error("guardrails_add should not be present when not configured")
+	}
+	if _, exists := req["condition"]; exists {
+		t.Error("condition should not be present when not configured")
+	}
+	if _, exists := req["pipeline"]; exists {
+		t.Error("pipeline should not be present when not configured")
+	}
+}
+
+func TestBuildPolicyRequest_Full(t *testing.T) {
+	t.Parallel()
+
+	r := &PolicyResource{}
+	conditionObj, diags := types.ObjectValue(
+		policyConditionAttrTypes(),
+		map[string]attr.Value{"model": types.StringValue("gpt-4.*")},
+	)
+	if diags.HasError() {
+		t.Fatalf("failed to build condition object: %v", diags)
+	}
+
+	data := &PolicyResourceModel{
+		PolicyName:       types.StringValue("healthcare-compliance"),
+		Inherit:          types.StringValue("global-baseline"),
+		Description:      types.StringValue("Policy for healthcare traffic"),
+		GuardrailsAdd:    stringListValue("hipaa_audit", "pii_masking"),
+		GuardrailsRemove: stringListValue("prompt_injection"),
+		Condition:        conditionObj,
+		Pipeline:         types.StringValue(`{"mode":"pre_call","steps":[{"guardrail":"hipaa_audit","on_fail":"block"}]}`),
+	}
+
+	req, err := r.buildPolicyRequest(context.Background(), data)
+	if err != nil {
+		t.Fatalf("buildPolicyRequest returned error: %v", err)
+	}
+
+	if req["policy_name"] != "healthcare-compliance" {
+		t.Errorf("expected policy_name 'healthcare-compliance', got %v", req["policy_name"])
+	}
+	if req["inherit"] != "global-baseline" {
+		t.Errorf("expected inherit 'global-baseline', got %v", req["inherit"])
+	}
+
+	guardrailsAdd, ok := req["guardrails_add"].([]string)
+	if !ok || len(guardrailsAdd) != 2 {
+		t.Fatalf("expected 2 guardrails_add entries, got %v", req["guardrails_add"])
+	}
+
+	condition, ok := req["condition"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected condition map, got %T", req["condition"])
+	}
+	if condition["model"] != "gpt-4.*" {
+		t.Errorf("expected condition.model 'gpt-4.*', got %v", condition["model"])
+	}
+
+	pipeline, ok := req["pipeline"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected pipeline map, got %T", req["pipeline"])
+	}
+	if pipeline["mode"] != "pre_call" {
+		t.Errorf("expected pipeline.mode 'pre_call', got %v", pipeline["mode"])
+	}
+}
+
+func TestBuildPolicyRequest_InvalidPipelineJSON(t *testing.T) {
+	t.Parallel()
+
+	r := &PolicyResource{}
+	data := &PolicyResourceModel{
+		PolicyName: types.StringValue("broken-policy"),
+		Pipeline:   types.StringValue(`{"mode":"pre_call"`),
+	}
+
+	_, err := r.buildPolicyRequest(context.Background(), data)
+	if err == nil {
+		t.Fatal("expected error for invalid pipeline JSON")
+	}
+}
+
+func TestReadPolicy_PopulatesState(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"policy_id":         "pol-123",
+			"policy_name":       "global-baseline",
+			"version_number":    2,
+			"version_status":    "production",
+			"parent_version_id": "pol-122",
+			"is_latest":         true,
+			"published_at":      "2026-04-01T00:00:00Z",
+			"production_at":     "2026-04-02T00:00:00Z",
+			"inherit":           "base-policy",
+			"description":       "Baseline policy",
+			"guardrails_add":    []interface{}{"pii_masking", "toxicity_filter"},
+			"guardrails_remove": []interface{}{"prompt_injection"},
+			"condition": map[string]interface{}{
+				"model": "gpt-4.*",
+			},
+			"pipeline": map[string]interface{}{
+				"mode": "pre_call",
+				"steps": []interface{}{
+					map[string]interface{}{"guardrail": "pii_masking", "on_fail": "block"},
+				},
+			},
+			"created_at": "2026-03-30T10:00:00Z",
+			"updated_at": "2026-04-02T11:00:00Z",
+			"created_by": "admin",
+			"updated_by": "admin",
+		})
+	}))
+	defer server.Close()
+
+	r := &PolicyResource{
+		client: &Client{
+			APIBase:    server.URL,
+			APIKey:     "test-key",
+			HTTPClient: server.Client(),
+		},
+	}
+
+	data := PolicyResourceModel{
+		ID:               types.StringValue("pol-123"),
+		GuardrailsAdd:    types.ListUnknown(types.StringType),
+		GuardrailsRemove: types.ListUnknown(types.StringType),
+		Condition:        types.ObjectUnknown(policyConditionAttrTypes()),
+		Pipeline:         types.StringUnknown(),
+	}
+
+	if err := r.readPolicy(context.Background(), &data); err != nil {
+		t.Fatalf("readPolicy returned error: %v", err)
+	}
+
+	if data.ID.ValueString() != "pol-123" {
+		t.Errorf("expected id 'pol-123', got %q", data.ID.ValueString())
+	}
+	if data.PolicyName.ValueString() != "global-baseline" {
+		t.Errorf("expected policy_name 'global-baseline', got %q", data.PolicyName.ValueString())
+	}
+	if data.VersionNumber.ValueInt64() != 2 {
+		t.Errorf("expected version_number 2, got %d", data.VersionNumber.ValueInt64())
+	}
+	if data.Condition.IsNull() || data.Condition.IsUnknown() {
+		t.Fatal("condition should be known and non-null")
+	}
+	if data.Pipeline.IsNull() || data.Pipeline.IsUnknown() {
+		t.Fatal("pipeline should be known and non-null")
+	}
+	if data.CreatedBy.ValueString() != "admin" {
+		t.Errorf("expected created_by 'admin', got %q", data.CreatedBy.ValueString())
+	}
+}
+
+func TestReadPolicy_ResolvesUnknownToNull(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"policy_id":   "pol-minimal",
+			"policy_name": "minimal-policy",
+		})
+	}))
+	defer server.Close()
+
+	r := &PolicyResource{
+		client: &Client{
+			APIBase:    server.URL,
+			APIKey:     "test-key",
+			HTTPClient: server.Client(),
+		},
+	}
+
+	data := PolicyResourceModel{
+		ID:               types.StringValue("pol-minimal"),
+		VersionNumber:    types.Int64Unknown(),
+		VersionStatus:    types.StringUnknown(),
+		ParentVersionID:  types.StringUnknown(),
+		IsLatest:         types.BoolUnknown(),
+		PublishedAt:      types.StringUnknown(),
+		ProductionAt:     types.StringUnknown(),
+		CreatedAt:        types.StringUnknown(),
+		UpdatedAt:        types.StringUnknown(),
+		CreatedBy:        types.StringUnknown(),
+		UpdatedBy:        types.StringUnknown(),
+		GuardrailsAdd:    types.ListUnknown(types.StringType),
+		GuardrailsRemove: types.ListUnknown(types.StringType),
+		Condition:        types.ObjectUnknown(policyConditionAttrTypes()),
+		Pipeline:         types.StringUnknown(),
+	}
+
+	if err := r.readPolicy(context.Background(), &data); err != nil {
+		t.Fatalf("readPolicy returned error: %v", err)
+	}
+
+	if data.VersionNumber.IsUnknown() {
+		t.Error("version_number should not be Unknown after read")
+	}
+	if data.VersionStatus.IsUnknown() {
+		t.Error("version_status should not be Unknown after read")
+	}
+	if data.Condition.IsUnknown() {
+		t.Error("condition should not be Unknown after read")
+	}
+	if data.Pipeline.IsUnknown() {
+		t.Error("pipeline should not be Unknown after read")
+	}
+	if !data.Condition.IsNull() {
+		t.Error("condition should be null when API omits it")
+	}
+	if !data.Pipeline.IsNull() {
+		t.Error("pipeline should be null when API omits it")
+	}
+}
+
+func TestReadPolicy_OverwritesExistingPipeline(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"policy_id":   "pol-pipeline",
+			"policy_name": "pipeline-policy",
+			"pipeline": map[string]interface{}{
+				"mode": "post_call",
+				"steps": []interface{}{
+					map[string]interface{}{"guardrail": "toxicity_filter", "on_fail": "mask"},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	r := &PolicyResource{
+		client: &Client{
+			APIBase:    server.URL,
+			APIKey:     "test-key",
+			HTTPClient: server.Client(),
+		},
+	}
+
+	data := PolicyResourceModel{
+		ID:       types.StringValue("pol-pipeline"),
+		Pipeline: types.StringValue(`{"mode":"pre_call","steps":[]}`),
+	}
+
+	if err := r.readPolicy(context.Background(), &data); err != nil {
+		t.Fatalf("readPolicy returned error: %v", err)
+	}
+
+	if data.Pipeline.IsNull() || data.Pipeline.IsUnknown() {
+		t.Fatal("pipeline should be known and non-null")
+	}
+
+	var pipeline map[string]interface{}
+	if err := json.Unmarshal([]byte(data.Pipeline.ValueString()), &pipeline); err != nil {
+		t.Fatalf("pipeline is not valid JSON: %v", err)
+	}
+
+	if pipeline["mode"] != "post_call" {
+		t.Fatalf("expected pipeline mode 'post_call', got %v", pipeline["mode"])
+	}
+}

--- a/internal/provider/response_helpers.go
+++ b/internal/provider/response_helpers.go
@@ -1,0 +1,17 @@
+package provider
+
+import "fmt"
+
+func requiredStringField(result map[string]interface{}, fieldName string) (string, error) {
+	value, ok := result[fieldName]
+	if !ok {
+		return "", fmt.Errorf("response missing %s", fieldName)
+	}
+
+	stringValue, ok := value.(string)
+	if !ok || stringValue == "" {
+		return "", fmt.Errorf("response missing %s", fieldName)
+	}
+
+	return stringValue, nil
+}

--- a/internal/provider/response_helpers_test.go
+++ b/internal/provider/response_helpers_test.go
@@ -1,0 +1,59 @@
+package provider
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRequiredStringField(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		result := map[string]interface{}{"policy_id": "pol-123"}
+		value, err := requiredStringField(result, "policy_id")
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if value != "pol-123" {
+			t.Fatalf("expected value 'pol-123', got %q", value)
+		}
+	})
+
+	t.Run("missing key", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := requiredStringField(map[string]interface{}{}, "policy_id")
+		if err == nil {
+			t.Fatal("expected error for missing key")
+		}
+		if !strings.Contains(err.Error(), "response missing policy_id") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("empty string", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := requiredStringField(map[string]interface{}{"policy_id": ""}, "policy_id")
+		if err == nil {
+			t.Fatal("expected error for empty string")
+		}
+		if !strings.Contains(err.Error(), "response missing policy_id") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("wrong type", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := requiredStringField(map[string]interface{}{"policy_id": 123}, "policy_id")
+		if err == nil {
+			t.Fatal("expected error for non-string type")
+		}
+		if !strings.Contains(err.Error(), "response missing policy_id") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}

--- a/internal_testing/datasources/policies_list.tf
+++ b/internal_testing/datasources/policies_list.tf
@@ -1,0 +1,8 @@
+# data.litellm_policies - Lists all policies
+
+data "litellm_policies" "all" {
+}
+
+output "ds_policies_total_count" {
+  value = data.litellm_policies.all.total_count
+}

--- a/internal_testing/datasources/policy.tf
+++ b/internal_testing/datasources/policy.tf
@@ -1,0 +1,13 @@
+# data.litellm_policy - Looks up a policy by policy_id
+
+data "litellm_policy" "lookup" {
+  policy_id = litellm_policy.minimal.id
+}
+
+output "ds_policy_name" {
+  value = data.litellm_policy.lookup.policy_name
+}
+
+output "ds_policy_version_status" {
+  value = data.litellm_policy.lookup.version_status
+}

--- a/internal_testing/datasources/policy_attachment.tf
+++ b/internal_testing/datasources/policy_attachment.tf
@@ -1,0 +1,9 @@
+# data.litellm_policy_attachment - Looks up an attachment by attachment_id
+
+data "litellm_policy_attachment" "lookup" {
+  attachment_id = litellm_policy_attachment.global.id
+}
+
+output "ds_policy_attachment_policy_name" {
+  value = data.litellm_policy_attachment.lookup.policy_name
+}

--- a/internal_testing/datasources/policy_attachments_list.tf
+++ b/internal_testing/datasources/policy_attachments_list.tf
@@ -1,0 +1,8 @@
+# data.litellm_policy_attachments - Lists all policy attachments
+
+data "litellm_policy_attachments" "all" {
+}
+
+output "ds_policy_attachments_total_count" {
+  value = data.litellm_policy_attachments.all.total_count
+}

--- a/internal_testing/resources/policy_attachment_global.tf
+++ b/internal_testing/resources/policy_attachment_global.tf
@@ -1,0 +1,14 @@
+# litellm_policy_attachment - Global scope
+
+resource "litellm_policy" "attachment_global_policy" {
+  policy_name = "tf-test-policy-attachment-global"
+}
+
+resource "litellm_policy_attachment" "global" {
+  policy_name = litellm_policy.attachment_global_policy.policy_name
+  scope       = "*"
+}
+
+output "policy_attachment_global_id" {
+  value = litellm_policy_attachment.global.id
+}

--- a/internal_testing/resources/policy_attachment_targeted.tf
+++ b/internal_testing/resources/policy_attachment_targeted.tf
@@ -1,0 +1,16 @@
+# litellm_policy_attachment - Targeted scope
+
+resource "litellm_policy" "attachment_targeted_policy" {
+  policy_name = "tf-test-policy-attachment-targeted"
+}
+
+resource "litellm_policy_attachment" "targeted" {
+  policy_name = litellm_policy.attachment_targeted_policy.policy_name
+  teams       = ["default"]
+  models      = ["gpt-4o"]
+  tags        = ["health-*"]
+}
+
+output "policy_attachment_targeted_id" {
+  value = litellm_policy_attachment.targeted.id
+}

--- a/internal_testing/resources/policy_full.tf
+++ b/internal_testing/resources/policy_full.tf
@@ -1,0 +1,45 @@
+# litellm_policy - Full
+# Parent + child policy with inheritance, guardrails, condition, and pipeline
+
+resource "litellm_policy" "full_parent" {
+  policy_name = "tf-test-policy-full-parent"
+  description = "Parent policy for full inheritance smoke test"
+
+  guardrails_add = ["pii_masking"]
+}
+
+resource "litellm_policy" "full" {
+  policy_name = "tf-test-policy-full"
+  description = "Child policy with inheritance managed by terraform smoke test"
+  inherit     = litellm_policy.full_parent.policy_name
+
+  guardrails_add    = ["pii_masking", "prompt_injection"]
+  guardrails_remove = ["legacy_guardrail"]
+
+  condition = {
+    model = "gpt-4.*"
+  }
+
+  pipeline = jsonencode({
+    mode = "pre_call"
+    steps = [
+      {
+        guardrail = "pii_masking"
+        on_pass   = "next"
+        on_fail   = "block"
+      }
+    ]
+  })
+}
+
+output "policy_full_parent_id" {
+  value = litellm_policy.full_parent.id
+}
+
+output "policy_full_id" {
+  value = litellm_policy.full.id
+}
+
+output "policy_full_version_status" {
+  value = litellm_policy.full.version_status
+}

--- a/internal_testing/resources/policy_minimal.tf
+++ b/internal_testing/resources/policy_minimal.tf
@@ -1,0 +1,10 @@
+# litellm_policy - Minimal
+# Only required attributes
+
+resource "litellm_policy" "minimal" {
+  policy_name = "tf-test-policy-minimal"
+}
+
+output "policy_minimal_id" {
+  value = litellm_policy.minimal.id
+}


### PR DESCRIPTION
## Summary
- add `litellm_policy` and `litellm_policy_attachment` resources with CRUD, import support, request/response mapping, and validation for attachment targeting
- add single and list data sources for policies and policy attachments, and register all new resources/data sources in the provider
- add docs and internal testing Terraform examples for the new resource/data-source surface, plus helper/unit tests for response parsing and state normalization
