### PR TITLE
fix: send Authorization header alongside x-api-key for all API requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.1] - 2026-04-13
+
+### Fixed
+- **`litellm_user`**: Fix "Missing or invalid Authorization header" error by sending `Authorization: Bearer` header alongside `x-api-key` for all API requests. ([#90](https://github.com/ncecere/terraform-provider-litellm/issues/90))
+
 ## [1.4.0] - 2026-04-13
 
 ### Added

--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -35,6 +35,7 @@ func (c *Client) DoRequest(ctx context.Context, method, path string, body interf
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("x-api-key", c.APIKey)
+	req.Header.Set("Authorization", "Bearer "+c.APIKey)
 
 	if c.LiteLLMChangedBy != "" {
 		req.Header.Set("litellm-changed-by", c.LiteLLMChangedBy)


### PR DESCRIPTION
## Summary
- Send `Authorization: Bearer` header alongside `x-api-key` for all API requests, fixing "Missing or invalid Authorization header" error on `/user/new` and other user endpoints

Closes #90

## Test plan
- [x] Unit tests pass
- [x] Smoke test: `user_minimal.tf` — plan/apply/destroy pass
- [x] Regression test: `model_minimal.tf`, `key_minimal.tf`, `team_minimal.tf` — all pass