### PR TITLE
feat: Add router_settings Support to litellm_key Resource

### DIFF
--- a/docs/data-sources/key.md
+++ b/docs/data-sources/key.md
@@ -11,10 +11,11 @@ data "litellm_key" "existing" {
 
 output "key_info" {
   value = {
-    alias      = data.litellm_key.existing.key_alias
-    team_id    = data.litellm_key.existing.team_id
-    max_budget = data.litellm_key.existing.max_budget
-    blocked    = data.litellm_key.existing.blocked
+    alias             = data.litellm_key.existing.key_alias
+    team_id           = data.litellm_key.existing.team_id
+    max_budget        = data.litellm_key.existing.max_budget
+    router_settings   = data.litellm_key.existing.router_settings
+    blocked           = data.litellm_key.existing.blocked
   }
 }
 ```
@@ -39,6 +40,7 @@ output "key_info" {
 * `soft_budget` - Soft budget limit for warnings.
 * `metadata` - Map of metadata for the key.
 * `tags` - List of tags for the key.
+* `router_settings` - Map of router settings for the key.
 * `blocked` - Whether the key is blocked.
 
 ## Notes

--- a/docs/data-sources/key.md
+++ b/docs/data-sources/key.md
@@ -11,11 +11,12 @@ data "litellm_key" "existing" {
 
 output "key_info" {
   value = {
-    alias             = data.litellm_key.existing.key_alias
-    team_id           = data.litellm_key.existing.team_id
-    max_budget        = data.litellm_key.existing.max_budget
-    router_settings   = data.litellm_key.existing.router_settings
-    blocked           = data.litellm_key.existing.blocked
+    alias           = data.litellm_key.existing.key_alias
+    team_id         = data.litellm_key.existing.team_id
+    max_budget      = data.litellm_key.existing.max_budget
+    num_retries     = data.litellm_key.existing.router_settings.num_retries
+    timeout         = data.litellm_key.existing.router_settings.timeout
+    blocked         = data.litellm_key.existing.blocked
   }
 }
 ```
@@ -40,7 +41,7 @@ output "key_info" {
 * `soft_budget` - Soft budget limit for warnings.
 * `metadata` - Map of metadata for the key.
 * `tags` - List of tags for the key.
-* `router_settings` - Map of router settings for the key.
+* `router_settings` - Router configuration for the key. Contains all 21 fields matching the resource block: `routing_strategy`, `num_retries`, `timeout`, `stream_timeout`, `max_fallbacks`, `allowed_fails`, `cooldown_time`, `retry_after`, `default_max_parallel_requests`, `enable_pre_call_checks`, `set_verbose`, `enable_tag_filtering`, `tag_filtering_match_any`, `disable_cooldowns`, `routing_strategy_args`, `model_group_alias`, `default_litellm_params`, `fallbacks`, `context_window_fallbacks`, `content_policy_fallbacks`, and `retry_policy`.
 * `blocked` - Whether the key is blocked.
 
 ## Notes

--- a/docs/resources/key.md
+++ b/docs/resources/key.md
@@ -109,15 +109,29 @@ resource "litellm_key" "with_logging" {
 ```hcl
 resource "litellm_key" "with_router_settings" {
   key_alias = "router-configured-key"
-  models    = ["gpt-4o"]
+  models    = ["gpt-4o", "gpt-4o-mini"]
 
-  router_settings = {
-    "fallback_routes" = "gpt-4o-mini"
-    "priority"        = "high"
-  }
+  router_settings {
+    num_retries   = 3
+    timeout       = 30.0
+    allowed_fails = 2
+    cooldown_time = 60.0
 
-  metadata = {
-    environment = "production"
+    fallbacks {
+      model           = "gpt-4o"
+      fallback_models = ["gpt-4o-mini", "gpt-3.5-turbo"]
+    }
+
+    context_window_fallbacks {
+      model           = "gpt-4o"
+      fallback_models = ["gpt-4o-mini"]
+    }
+
+    retry_policy {
+      rate_limit_error_retries     = 3
+      timeout_error_retries        = 2
+      internal_server_error_retries = 1
+    }
   }
 }
 ```
@@ -188,7 +202,36 @@ The following arguments are supported:
 
 * `tags` - (Optional) List of tags. **Note:** Requires LiteLLM Enterprise license.
 
-* `router_settings` - (Optional) Map of router settings for this key. Router settings control LiteLLM's routing behavior such as fallback routes and priority levels.
+* `router_settings` - (Optional) Per-key router configuration block. Overrides team and global router settings for requests made with this key. Supports the following nested arguments:
+  * `routing_strategy` - (Optional) Strategy for routing requests (e.g. `"simple-shuffle"`, `"least-busy"`, `"latency-based-routing"`, `"cost-based-routing"`, `"usage-based-routing"`).
+  * `num_retries` - (Optional) Number of retries on failure.
+  * `timeout` - (Optional) Request timeout in seconds.
+  * `stream_timeout` - (Optional) Timeout in seconds for streaming requests.
+  * `max_fallbacks` - (Optional) Maximum number of fallbacks to attempt.
+  * `allowed_fails` - (Optional) Number of failures allowed before a model is put into cooldown.
+  * `cooldown_time` - (Optional) Seconds a model stays in cooldown after exceeding `allowed_fails`.
+  * `retry_after` - (Optional) Minimum seconds to wait before retrying a rate-limited request.
+  * `default_max_parallel_requests` - (Optional) Default maximum parallel requests per deployment.
+  * `enable_pre_call_checks` - (Optional) Enable pre-call checks such as context window validation.
+  * `set_verbose` - (Optional) Enable verbose logging for requests made with this key.
+  * `enable_tag_filtering` - (Optional) Enable tag-based routing.
+  * `tag_filtering_match_any` - (Optional) When tag filtering is enabled, match deployments with any request tag (`true`) vs all tags (`false`).
+  * `disable_cooldowns` - (Optional) Disable the cooldown mechanism.
+  * `routing_strategy_args` - (Optional) Map of additional arguments for the routing strategy.
+  * `model_group_alias` - (Optional) Map of model group name aliases.
+  * `default_litellm_params` - (Optional) Map of default parameters merged into every request.
+  * `fallbacks` - (Optional) List of fallback chains for general failures. Each block requires:
+    * `model` - (Required) The primary model name.
+    * `fallback_models` - (Required) Ordered list of fallback model names.
+  * `context_window_fallbacks` - (Optional) List of fallback chains triggered on context window errors. Same structure as `fallbacks`.
+  * `content_policy_fallbacks` - (Optional) List of fallback chains triggered on content policy violations. Same structure as `fallbacks`.
+  * `retry_policy` - (Optional) Per-error-type retry counts overriding `num_retries`. Supports:
+    * `bad_request_error_retries` - (Optional) Retries for HTTP 400 errors.
+    * `authentication_error_retries` - (Optional) Retries for HTTP 401 errors.
+    * `timeout_error_retries` - (Optional) Retries for timeout errors.
+    * `rate_limit_error_retries` - (Optional) Retries for HTTP 429 errors.
+    * `content_policy_violation_error_retries` - (Optional) Retries for content policy violations.
+    * `internal_server_error_retries` - (Optional) Retries for HTTP 500 errors.
 
 * `blocked` - (Optional) Whether this key is blocked.
 

--- a/docs/resources/key.md
+++ b/docs/resources/key.md
@@ -104,6 +104,24 @@ resource "litellm_key" "with_logging" {
 }
 ```
 
+### Key with Router Settings
+
+```hcl
+resource "litellm_key" "with_router_settings" {
+  key_alias = "router-configured-key"
+  models    = ["gpt-4o"]
+
+  router_settings = {
+    "fallback_routes" = "gpt-4o-mini"
+    "priority"        = "high"
+  }
+
+  metadata = {
+    environment = "production"
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -169,6 +187,8 @@ The following arguments are supported:
 * `enforced_params` - (Optional) List of enforced parameters for this key.
 
 * `tags` - (Optional) List of tags. **Note:** Requires LiteLLM Enterprise license.
+
+* `router_settings` - (Optional) Map of router settings for this key. Router settings control LiteLLM's routing behavior such as fallback routes and priority levels.
 
 * `blocked` - (Optional) Whether this key is blocked.
 

--- a/internal/provider/datasource_key.go
+++ b/internal/provider/datasource_key.go
@@ -249,9 +249,7 @@ func (d *KeyDataSource) Read(ctx context.Context, req datasource.ReadRequest, re
 	if routerSettings, ok := info["router_settings"].(map[string]interface{}); ok && len(routerSettings) > 0 {
 		settingsMap := make(map[string]attr.Value)
 		for k, v := range routerSettings {
-			if str, ok := v.(string); ok {
-				settingsMap[k] = types.StringValue(str)
-			}
+			settingsMap[k] = types.StringValue(metadataValueToString(v))
 		}
 		data.RouterSettings, _ = types.MapValue(types.StringType, settingsMap)
 	} else {

--- a/internal/provider/datasource_key.go
+++ b/internal/provider/datasource_key.go
@@ -36,6 +36,7 @@ type KeyDataSourceModel struct {
 	SoftBudget          types.Float64 `tfsdk:"soft_budget"`
 	Metadata            types.Map     `tfsdk:"metadata"`
 	Tags                types.List    `tfsdk:"tags"`
+	RouterSettings      types.Map     `tfsdk:"router_settings"`
 	Blocked             types.Bool    `tfsdk:"blocked"`
 }
 
@@ -108,6 +109,11 @@ func (d *KeyDataSource) Schema(ctx context.Context, req datasource.SchemaRequest
 			},
 			"tags": schema.ListAttribute{
 				Description: "Tags for the key.",
+				Computed:    true,
+				ElementType: types.StringType,
+			},
+			"router_settings": schema.MapAttribute{
+				Description: "Router settings for the key.",
 				Computed:    true,
 				ElementType: types.StringType,
 			},
@@ -237,6 +243,19 @@ func (d *KeyDataSource) Read(ctx context.Context, req datasource.ReadRequest, re
 		data.Tags, _ = types.ListValue(types.StringType, tagsList)
 	} else {
 		data.Tags, _ = types.ListValue(types.StringType, []attr.Value{})
+	}
+
+	// Handle router_settings map
+	if routerSettings, ok := info["router_settings"].(map[string]interface{}); ok && len(routerSettings) > 0 {
+		settingsMap := make(map[string]attr.Value)
+		for k, v := range routerSettings {
+			if str, ok := v.(string); ok {
+				settingsMap[k] = types.StringValue(str)
+			}
+		}
+		data.RouterSettings, _ = types.MapValue(types.StringType, settingsMap)
+	} else {
+		data.RouterSettings, _ = types.MapValue(types.StringType, map[string]attr.Value{})
 	}
 
 	// Handle metadata map

--- a/internal/provider/datasource_key.go
+++ b/internal/provider/datasource_key.go
@@ -249,7 +249,7 @@ func (d *KeyDataSource) Read(ctx context.Context, req datasource.ReadRequest, re
 	if routerSettings, ok := info["router_settings"].(map[string]interface{}); ok && len(routerSettings) > 0 {
 		settingsMap := make(map[string]attr.Value)
 		for k, v := range routerSettings {
-			settingsMap[k] = types.StringValue(metadataValueToString(v))
+			settingsMap[k] = types.StringValue(valueToJSONString(v))
 		}
 		data.RouterSettings, _ = types.MapValue(types.StringType, settingsMap)
 	} else {

--- a/internal/provider/datasource_key.go
+++ b/internal/provider/datasource_key.go
@@ -36,7 +36,7 @@ type KeyDataSourceModel struct {
 	SoftBudget          types.Float64 `tfsdk:"soft_budget"`
 	Metadata            types.Map     `tfsdk:"metadata"`
 	Tags                types.List    `tfsdk:"tags"`
-	RouterSettings      types.Map     `tfsdk:"router_settings"`
+	RouterSettings      types.Object  `tfsdk:"router_settings"`
 	Blocked             types.Bool    `tfsdk:"blocked"`
 }
 
@@ -112,10 +112,66 @@ func (d *KeyDataSource) Schema(ctx context.Context, req datasource.SchemaRequest
 				Computed:    true,
 				ElementType: types.StringType,
 			},
-			"router_settings": schema.MapAttribute{
+			"router_settings": schema.SingleNestedAttribute{
 				Description: "Router settings for the key.",
 				Computed:    true,
-				ElementType: types.StringType,
+				Attributes: map[string]schema.Attribute{
+					"routing_strategy":      schema.StringAttribute{Computed: true},
+					"routing_strategy_args": schema.MapAttribute{Computed: true, ElementType: types.StringType},
+					"num_retries":           schema.Int64Attribute{Computed: true},
+					"timeout":               schema.Float64Attribute{Computed: true},
+					"stream_timeout":        schema.Float64Attribute{Computed: true},
+					"max_fallbacks":         schema.Int64Attribute{Computed: true},
+					"fallbacks": schema.ListNestedAttribute{
+						Computed: true,
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"model":           schema.StringAttribute{Computed: true},
+								"fallback_models": schema.ListAttribute{Computed: true, ElementType: types.StringType},
+							},
+						},
+					},
+					"context_window_fallbacks": schema.ListNestedAttribute{
+						Computed: true,
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"model":           schema.StringAttribute{Computed: true},
+								"fallback_models": schema.ListAttribute{Computed: true, ElementType: types.StringType},
+							},
+						},
+					},
+					"content_policy_fallbacks": schema.ListNestedAttribute{
+						Computed: true,
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"model":           schema.StringAttribute{Computed: true},
+								"fallback_models": schema.ListAttribute{Computed: true, ElementType: types.StringType},
+							},
+						},
+					},
+					"allowed_fails": schema.Int64Attribute{Computed: true},
+					"cooldown_time": schema.Float64Attribute{Computed: true},
+					"retry_after":   schema.Int64Attribute{Computed: true},
+					"retry_policy": schema.SingleNestedAttribute{
+						Computed: true,
+						Attributes: map[string]schema.Attribute{
+							"bad_request_error_retries":              schema.Int64Attribute{Computed: true},
+							"authentication_error_retries":           schema.Int64Attribute{Computed: true},
+							"timeout_error_retries":                  schema.Int64Attribute{Computed: true},
+							"rate_limit_error_retries":               schema.Int64Attribute{Computed: true},
+							"content_policy_violation_error_retries": schema.Int64Attribute{Computed: true},
+							"internal_server_error_retries":          schema.Int64Attribute{Computed: true},
+						},
+					},
+					"model_group_alias":             schema.MapAttribute{Computed: true, ElementType: types.StringType},
+					"enable_pre_call_checks":        schema.BoolAttribute{Computed: true},
+					"default_litellm_params":        schema.MapAttribute{Computed: true, ElementType: types.StringType},
+					"set_verbose":                   schema.BoolAttribute{Computed: true},
+					"default_max_parallel_requests": schema.Int64Attribute{Computed: true},
+					"enable_tag_filtering":          schema.BoolAttribute{Computed: true},
+					"tag_filtering_match_any":       schema.BoolAttribute{Computed: true},
+					"disable_cooldowns":             schema.BoolAttribute{Computed: true},
+				},
 			},
 			"blocked": schema.BoolAttribute{
 				Description: "Whether the key is blocked.",
@@ -245,15 +301,11 @@ func (d *KeyDataSource) Read(ctx context.Context, req datasource.ReadRequest, re
 		data.Tags, _ = types.ListValue(types.StringType, []attr.Value{})
 	}
 
-	// Handle router_settings map
+	// Handle router_settings
 	if routerSettings, ok := info["router_settings"].(map[string]interface{}); ok && len(routerSettings) > 0 {
-		settingsMap := make(map[string]attr.Value)
-		for k, v := range routerSettings {
-			settingsMap[k] = types.StringValue(valueToJSONString(v))
-		}
-		data.RouterSettings, _ = types.MapValue(types.StringType, settingsMap)
+		data.RouterSettings = parseKeyRouterSettingsFromAPI(routerSettings)
 	} else {
-		data.RouterSettings, _ = types.MapValue(types.StringType, map[string]attr.Value{})
+		data.RouterSettings = types.ObjectNull(keyRouterSettingsAttrTypes)
 	}
 
 	// Handle metadata map

--- a/internal/provider/datasource_project.go
+++ b/internal/provider/datasource_project.go
@@ -22,21 +22,21 @@ type ProjectDataSource struct {
 }
 
 type ProjectDataSourceModel struct {
-	ID             types.String  `tfsdk:"id"`
-	ProjectAlias   types.String  `tfsdk:"project_alias"`
-	Description    types.String  `tfsdk:"description"`
-	TeamID         types.String  `tfsdk:"team_id"`
-	Models         types.List    `tfsdk:"models"`
-	Metadata       types.Map     `tfsdk:"metadata"`
-	Tags           types.List    `tfsdk:"tags"`
-	Blocked        types.Bool    `tfsdk:"blocked"`
-	Spend          types.Float64 `tfsdk:"spend"`
-	ModelRPMLimit  types.Map     `tfsdk:"model_rpm_limit"`
-	ModelTPMLimit  types.Map     `tfsdk:"model_tpm_limit"`
-	CreatedAt      types.String  `tfsdk:"created_at"`
-	UpdatedAt      types.String  `tfsdk:"updated_at"`
-	CreatedBy      types.String  `tfsdk:"created_by"`
-	UpdatedBy      types.String  `tfsdk:"updated_by"`
+	ID            types.String  `tfsdk:"id"`
+	ProjectAlias  types.String  `tfsdk:"project_alias"`
+	Description   types.String  `tfsdk:"description"`
+	TeamID        types.String  `tfsdk:"team_id"`
+	Models        types.List    `tfsdk:"models"`
+	Metadata      types.Map     `tfsdk:"metadata"`
+	Tags          types.List    `tfsdk:"tags"`
+	Blocked       types.Bool    `tfsdk:"blocked"`
+	Spend         types.Float64 `tfsdk:"spend"`
+	ModelRPMLimit types.Map     `tfsdk:"model_rpm_limit"`
+	ModelTPMLimit types.Map     `tfsdk:"model_tpm_limit"`
+	CreatedAt     types.String  `tfsdk:"created_at"`
+	UpdatedAt     types.String  `tfsdk:"updated_at"`
+	CreatedBy     types.String  `tfsdk:"created_by"`
+	UpdatedBy     types.String  `tfsdk:"updated_by"`
 }
 
 func (d *ProjectDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -205,7 +205,7 @@ func (d *ProjectDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	if metadata, ok := result["metadata"].(map[string]interface{}); ok && len(metadata) > 0 {
 		metaMap := make(map[string]attr.Value)
 		for k, v := range metadata {
-			metaMap[k] = types.StringValue(metadataValueToString(v))
+			metaMap[k] = types.StringValue(valueToJSONString(v))
 		}
 		data.Metadata, _ = types.MapValue(types.StringType, metaMap)
 	} else {

--- a/internal/provider/json_helpers.go
+++ b/internal/provider/json_helpers.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 )
 
-// convertMetadataToNative takes a Terraform metadata map (map[string]string)
-// and converts values that contain JSON objects or arrays into native Go types
-// so the API receives structured data rather than escaped JSON strings.
+// convertJSONStringsToNative takes a map of string values and converts any values
+// that contain JSON objects or arrays into native Go types so the API receives
+// structured data rather than escaped JSON strings.
 //
 // For example, a Terraform config like:
 //
@@ -17,9 +17,9 @@ import (
 //	}
 //
 // will send the "logging" value as a native JSON array, not a string.
-func convertMetadataToNative(metadata map[string]string) map[string]interface{} {
-	result := make(map[string]interface{}, len(metadata))
-	for k, v := range metadata {
+func convertJSONStringsToNative(values map[string]string) map[string]interface{} {
+	result := make(map[string]interface{}, len(values))
+	for k, v := range values {
 		trimmed := strings.TrimSpace(v)
 		if strings.HasPrefix(trimmed, "[") || strings.HasPrefix(trimmed, "{") {
 			var parsed interface{}
@@ -33,10 +33,10 @@ func convertMetadataToNative(metadata map[string]string) map[string]interface{} 
 	return result
 }
 
-// metadataValueToString converts a metadata value from the API response back
-// to a string for storage in Terraform state. String values are returned as-is;
+// valueToJSONString converts a value from an API response back to a string
+// for storage in Terraform state. String values are returned as-is;
 // non-string values (arrays, objects, numbers, booleans) are JSON-encoded.
-func metadataValueToString(v interface{}) string {
+func valueToJSONString(v interface{}) string {
 	switch val := v.(type) {
 	case string:
 		return val

--- a/internal/provider/json_helpers_test.go
+++ b/internal/provider/json_helpers_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestConvertMetadataToNative_StringValues(t *testing.T) {
+func TestConvertJSONStringsToNative_StringValues(t *testing.T) {
 	t.Parallel()
 
 	input := map[string]string{
@@ -14,7 +14,7 @@ func TestConvertMetadataToNative_StringValues(t *testing.T) {
 		"version": "1.0",
 	}
 
-	result := convertMetadataToNative(input)
+	result := convertJSONStringsToNative(input)
 
 	if result["env"] != "production" {
 		t.Errorf("expected 'production', got %v", result["env"])
@@ -24,14 +24,14 @@ func TestConvertMetadataToNative_StringValues(t *testing.T) {
 	}
 }
 
-func TestConvertMetadataToNative_JSONArray(t *testing.T) {
+func TestConvertJSONStringsToNative_JSONArray(t *testing.T) {
 	t.Parallel()
 
 	input := map[string]string{
 		"logging": `[{"callback_name":"langsmith","callback_type":"success","callback_vars":{"langsmith_project":"my-project"}}]`,
 	}
 
-	result := convertMetadataToNative(input)
+	result := convertJSONStringsToNative(input)
 
 	// Should be a native array, not a string
 	arr, ok := result["logging"].([]interface{})
@@ -50,14 +50,14 @@ func TestConvertMetadataToNative_JSONArray(t *testing.T) {
 	}
 }
 
-func TestConvertMetadataToNative_JSONObject(t *testing.T) {
+func TestConvertJSONStringsToNative_JSONObject(t *testing.T) {
 	t.Parallel()
 
 	input := map[string]string{
 		"config": `{"key":"value","nested":{"a":1}}`,
 	}
 
-	result := convertMetadataToNative(input)
+	result := convertJSONStringsToNative(input)
 
 	obj, ok := result["config"].(map[string]interface{})
 	if !ok {
@@ -68,7 +68,7 @@ func TestConvertMetadataToNative_JSONObject(t *testing.T) {
 	}
 }
 
-func TestConvertMetadataToNative_MixedValues(t *testing.T) {
+func TestConvertJSONStringsToNative_MixedValues(t *testing.T) {
 	t.Parallel()
 
 	input := map[string]string{
@@ -78,7 +78,7 @@ func TestConvertMetadataToNative_MixedValues(t *testing.T) {
 		"invalid": `{not valid json`,
 	}
 
-	result := convertMetadataToNative(input)
+	result := convertJSONStringsToNative(input)
 
 	// Simple string preserved
 	if result["simple"] != "hello" {
@@ -98,23 +98,23 @@ func TestConvertMetadataToNative_MixedValues(t *testing.T) {
 	}
 }
 
-func TestMetadataValueToString_String(t *testing.T) {
+func TestValueToJSONString_String(t *testing.T) {
 	t.Parallel()
 
-	if got := metadataValueToString("hello"); got != "hello" {
+	if got := valueToJSONString("hello"); got != "hello" {
 		t.Errorf("expected 'hello', got %q", got)
 	}
 }
 
-func TestMetadataValueToString_Nil(t *testing.T) {
+func TestValueToJSONString_Nil(t *testing.T) {
 	t.Parallel()
 
-	if got := metadataValueToString(nil); got != "" {
+	if got := valueToJSONString(nil); got != "" {
 		t.Errorf("expected empty string, got %q", got)
 	}
 }
 
-func TestMetadataValueToString_Array(t *testing.T) {
+func TestValueToJSONString_Array(t *testing.T) {
 	t.Parallel()
 
 	input := []interface{}{
@@ -124,7 +124,7 @@ func TestMetadataValueToString_Array(t *testing.T) {
 		},
 	}
 
-	got := metadataValueToString(input)
+	got := valueToJSONString(input)
 
 	// Should be valid JSON
 	var parsed interface{}
@@ -142,7 +142,7 @@ func TestMetadataValueToString_Array(t *testing.T) {
 	}
 }
 
-func TestMetadataValueToString_Object(t *testing.T) {
+func TestValueToJSONString_Object(t *testing.T) {
 	t.Parallel()
 
 	input := map[string]interface{}{
@@ -150,7 +150,7 @@ func TestMetadataValueToString_Object(t *testing.T) {
 		"num": float64(42),
 	}
 
-	got := metadataValueToString(input)
+	got := valueToJSONString(input)
 
 	var parsed map[string]interface{}
 	if err := json.Unmarshal([]byte(got), &parsed); err != nil {
@@ -161,24 +161,24 @@ func TestMetadataValueToString_Object(t *testing.T) {
 	}
 }
 
-func TestMetadataValueToString_Number(t *testing.T) {
+func TestValueToJSONString_Number(t *testing.T) {
 	t.Parallel()
 
-	if got := metadataValueToString(float64(42)); got != "42" {
+	if got := valueToJSONString(float64(42)); got != "42" {
 		t.Errorf("expected '42', got %q", got)
 	}
 }
 
-func TestMetadataValueToString_Bool(t *testing.T) {
+func TestValueToJSONString_Bool(t *testing.T) {
 	t.Parallel()
 
-	if got := metadataValueToString(true); got != "true" {
+	if got := valueToJSONString(true); got != "true" {
 		t.Errorf("expected 'true', got %q", got)
 	}
 }
 
 // TestMetadataRoundTrip verifies the full cycle:
-// Terraform map(string) → convertMetadataToNative → API → metadataValueToString → map(string)
+// Terraform map(string) → convertJSONStringsToNative → API → valueToJSONString → map(string)
 func TestMetadataRoundTrip(t *testing.T) {
 	t.Parallel()
 
@@ -189,12 +189,12 @@ func TestMetadataRoundTrip(t *testing.T) {
 	}
 
 	// Simulate write: convert for API
-	native := convertMetadataToNative(original)
+	native := convertJSONStringsToNative(original)
 
 	// Simulate read: convert back to strings
 	roundTripped := make(map[string]string, len(native))
 	for k, v := range native {
-		roundTripped[k] = metadataValueToString(v)
+		roundTripped[k] = valueToJSONString(v)
 	}
 
 	// Simple string should be identical

--- a/internal/provider/resource_key.go
+++ b/internal/provider/resource_key.go
@@ -261,7 +261,6 @@ func (r *KeyResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 			"router_settings": schema.MapAttribute{
 				Description: "Router settings for the key.",
 				Optional:    true,
-				Computed:    true,
 				ElementType: types.StringType,
 			},
 			"blocked": schema.BoolAttribute{

--- a/internal/provider/resource_key.go
+++ b/internal/provider/resource_key.go
@@ -610,7 +610,10 @@ func (r *KeyResource) buildKeyRequest(ctx context.Context, data *KeyResourceMode
 		var routerSettings map[string]string
 		data.RouterSettings.ElementsAs(ctx, &routerSettings, false)
 		if len(routerSettings) > 0 {
-			keyReq["router_settings"] = routerSettings
+			// Convert string values that contain JSON objects/arrays to native
+			// types so the API receives them as structured data rather than
+			// escaped strings (e.g. fallbacks configuration).
+			keyReq["router_settings"] = convertMetadataToNative(routerSettings)
 		}
 	}
 
@@ -913,9 +916,7 @@ func (r *KeyResource) readKey(ctx context.Context, data *KeyResourceModel) error
 	if routerSettings, ok := info["router_settings"].(map[string]interface{}); ok && len(routerSettings) > 0 {
 		settingsMap := make(map[string]attr.Value)
 		for k, v := range routerSettings {
-			if str, ok := v.(string); ok {
-				settingsMap[k] = types.StringValue(str)
-			}
+			settingsMap[k] = types.StringValue(metadataValueToString(v))
 		}
 		data.RouterSettings, _ = types.MapValue(types.StringType, settingsMap)
 	} else if !data.RouterSettings.IsNull() {

--- a/internal/provider/resource_key.go
+++ b/internal/provider/resource_key.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -362,6 +363,37 @@ func (r *KeyResource) Update(ctx context.Context, req resource.UpdateRequest, re
 
 	updateReq := r.buildKeyRequest(ctx, &data)
 	updateReq["key"] = data.Key.ValueString()
+
+	// router_settings: Pydantic validates the whole object, so we must send safe values.
+	// Null plan → send {} (API rejects null). Removed keys → inject [] or {} zero-values
+	// to avoid 422. Scalars can be omitted.
+	switch {
+	case data.RouterSettings.IsNull():
+		updateReq["router_settings"] = map[string]interface{}{}
+	case !data.RouterSettings.IsUnknown():
+		// inject zero values for removed list/object keys so Pydantic
+		// receives a valid type rather than null.
+		if routerMap, ok := updateReq["router_settings"].(map[string]interface{}); ok {
+			if !state.RouterSettings.IsNull() && !state.RouterSettings.IsUnknown() {
+				var stateRouter map[string]string
+				state.RouterSettings.ElementsAs(ctx, &stateRouter, false)
+				for k, v := range stateRouter {
+					if _, inPlan := routerMap[k]; !inPlan {
+						trimmed := strings.TrimSpace(v)
+						if strings.HasPrefix(trimmed, "[") {
+							routerMap[k] = []interface{}{}
+						} else if strings.HasPrefix(trimmed, "{") {
+							routerMap[k] = map[string]interface{}{}
+						}
+						// Scalars omitted: the API replaces router_settings wholesale.
+					}
+				}
+			}
+		} else {
+			// Non-null but empty plan map (router_settings = {}) — clear entirely.
+			updateReq["router_settings"] = map[string]interface{}{}
+		}
+	}
 
 	if err := r.client.DoRequestWithResponse(ctx, "POST", "/key/update", updateReq, nil); err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update key: %s", err))
@@ -911,14 +943,37 @@ func (r *KeyResource) readKey(ctx context.Context, data *KeyResourceModel) error
 		data.Tags, _ = types.ListValue(types.StringType, []attr.Value{})
 	}
 
-	// Handle router_settings map - preserve null when API returns empty and config didn't specify router_settings
-	if routerSettings, ok := info["router_settings"].(map[string]interface{}); ok && len(routerSettings) > 0 {
+	// Handle router_settings map - preserve null when API returns empty and config didn't specify router_settings.
+	// The API may inject internal keys (e.g. fallbacks, timeout) into router_settings.
+	// Only include keys that were in the user's original config to avoid drift.
+	if data.RouterSettings.IsNull() {
+		// Preserve null - do not repopulate from API
+	} else if routerSettings, ok := info["router_settings"].(map[string]interface{}); ok && len(routerSettings) > 0 {
+		// Build the set of keys the user has in their current config.
+		configuredKeys := make(map[string]bool)
+		if !data.RouterSettings.IsUnknown() {
+			var currentRouter map[string]string
+			data.RouterSettings.ElementsAs(ctx, &currentRouter, false)
+			for k := range currentRouter {
+				configuredKeys[k] = true
+			}
+		}
+
 		settingsMap := make(map[string]attr.Value)
 		for k, v := range routerSettings {
+			// Skip keys not in the user's config (e.g. zero-value sentinels
+			// injected by Update to satisfy API validation).
+			if len(configuredKeys) > 0 && !configuredKeys[k] {
+				continue
+			}
 			settingsMap[k] = types.StringValue(valueToJSONString(v))
 		}
-		data.RouterSettings, _ = types.MapValue(types.StringType, settingsMap)
-	} else if !data.RouterSettings.IsNull() {
+		if len(settingsMap) > 0 {
+			data.RouterSettings, _ = types.MapValue(types.StringType, settingsMap)
+		} else {
+			data.RouterSettings, _ = types.MapValue(types.StringType, map[string]attr.Value{})
+		}
+	} else {
 		data.RouterSettings, _ = types.MapValue(types.StringType, map[string]attr.Value{})
 	}
 

--- a/internal/provider/resource_key.go
+++ b/internal/provider/resource_key.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -15,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -71,8 +71,76 @@ type KeyResourceModel struct {
 	Prompts                  types.List    `tfsdk:"prompts"`
 	EnforcedParams           types.List    `tfsdk:"enforced_params"`
 	Tags                     types.List    `tfsdk:"tags"`
-	RouterSettings           types.Map     `tfsdk:"router_settings"`
+	RouterSettings           types.Object  `tfsdk:"router_settings"`
 	Blocked                  types.Bool    `tfsdk:"blocked"`
+}
+
+// KeyRouterSettingsModel represents all 21 fields from LiteLLM's ROUTER_SETTINGS_FIELDS.
+type KeyRouterSettingsModel struct {
+	RoutingStrategy            types.String  `tfsdk:"routing_strategy"`
+	RoutingStrategyArgs        types.Map     `tfsdk:"routing_strategy_args"`
+	NumRetries                 types.Int64   `tfsdk:"num_retries"`
+	Timeout                    types.Float64 `tfsdk:"timeout"`
+	StreamTimeout              types.Float64 `tfsdk:"stream_timeout"`
+	MaxFallbacks               types.Int64   `tfsdk:"max_fallbacks"`
+	Fallbacks                  types.List    `tfsdk:"fallbacks"`
+	ContextWindowFallbacks     types.List    `tfsdk:"context_window_fallbacks"`
+	ContentPolicyFallbacks     types.List    `tfsdk:"content_policy_fallbacks"`
+	AllowedFails               types.Int64   `tfsdk:"allowed_fails"`
+	CooldownTime               types.Float64 `tfsdk:"cooldown_time"`
+	RetryAfter                 types.Int64   `tfsdk:"retry_after"`
+	RetryPolicy                types.Object  `tfsdk:"retry_policy"`
+	ModelGroupAlias            types.Map     `tfsdk:"model_group_alias"`
+	EnablePreCallChecks        types.Bool    `tfsdk:"enable_pre_call_checks"`
+	DefaultLitellmParams       types.Map     `tfsdk:"default_litellm_params"`
+	SetVerbose                 types.Bool    `tfsdk:"set_verbose"`
+	DefaultMaxParallelRequests types.Int64   `tfsdk:"default_max_parallel_requests"`
+	EnableTagFiltering         types.Bool    `tfsdk:"enable_tag_filtering"`
+	TagFilteringMatchAny       types.Bool    `tfsdk:"tag_filtering_match_any"`
+	DisableCooldowns           types.Bool    `tfsdk:"disable_cooldowns"`
+}
+
+// KeyRetryPolicyModel maps to LiteLLM's RetryPolicy Pydantic model.
+type KeyRetryPolicyModel struct {
+	BadRequestErrorRetries             types.Int64 `tfsdk:"bad_request_error_retries"`
+	AuthenticationErrorRetries         types.Int64 `tfsdk:"authentication_error_retries"`
+	TimeoutErrorRetries                types.Int64 `tfsdk:"timeout_error_retries"`
+	RateLimitErrorRetries              types.Int64 `tfsdk:"rate_limit_error_retries"`
+	ContentPolicyViolationErrorRetries types.Int64 `tfsdk:"content_policy_violation_error_retries"`
+	InternalServerErrorRetries         types.Int64 `tfsdk:"internal_server_error_retries"`
+}
+
+var keyRetryPolicyAttrTypes = map[string]attr.Type{
+	"bad_request_error_retries":              types.Int64Type,
+	"authentication_error_retries":           types.Int64Type,
+	"timeout_error_retries":                  types.Int64Type,
+	"rate_limit_error_retries":               types.Int64Type,
+	"content_policy_violation_error_retries": types.Int64Type,
+	"internal_server_error_retries":          types.Int64Type,
+}
+
+var keyRouterSettingsAttrTypes = map[string]attr.Type{
+	"routing_strategy":              types.StringType,
+	"routing_strategy_args":         types.MapType{ElemType: types.StringType},
+	"num_retries":                   types.Int64Type,
+	"timeout":                       types.Float64Type,
+	"stream_timeout":                types.Float64Type,
+	"max_fallbacks":                 types.Int64Type,
+	"fallbacks":                     types.ListType{ElemType: types.ObjectType{AttrTypes: fallbackEntryAttrTypes}},
+	"context_window_fallbacks":      types.ListType{ElemType: types.ObjectType{AttrTypes: fallbackEntryAttrTypes}},
+	"content_policy_fallbacks":      types.ListType{ElemType: types.ObjectType{AttrTypes: fallbackEntryAttrTypes}},
+	"allowed_fails":                 types.Int64Type,
+	"cooldown_time":                 types.Float64Type,
+	"retry_after":                   types.Int64Type,
+	"retry_policy":                  types.ObjectType{AttrTypes: keyRetryPolicyAttrTypes},
+	"model_group_alias":             types.MapType{ElemType: types.StringType},
+	"enable_pre_call_checks":        types.BoolType,
+	"default_litellm_params":        types.MapType{ElemType: types.StringType},
+	"set_verbose":                   types.BoolType,
+	"default_max_parallel_requests": types.Int64Type,
+	"enable_tag_filtering":          types.BoolType,
+	"tag_filtering_match_any":       types.BoolType,
+	"disable_cooldowns":             types.BoolType,
 }
 
 func (r *KeyResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -259,10 +327,164 @@ func (r *KeyResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 				Computed:    true,
 				ElementType: types.StringType,
 			},
-			"router_settings": schema.MapAttribute{
-				Description: "Router settings for the key.",
-				Optional:    true,
-				ElementType: types.StringType,
+			"router_settings": schema.SingleNestedAttribute{
+				Description: "Router settings for the key. These override global and team-level routing " +
+					"settings for requests made with this key. Resolution order: Key > Team > Global.",
+				Optional: true,
+				Attributes: map[string]schema.Attribute{
+					"routing_strategy": schema.StringAttribute{
+						Description: "Strategy for routing requests across model deployments (e.g. 'simple-shuffle', 'least-busy', 'latency-based-routing', 'cost-based-routing', 'usage-based-routing').",
+						Optional:    true,
+					},
+					"routing_strategy_args": schema.MapAttribute{
+						Description: "Additional arguments for the routing strategy.",
+						Optional:    true,
+						ElementType: types.StringType,
+					},
+					"num_retries": schema.Int64Attribute{
+						Description: "Number of retries on failure.",
+						Optional:    true,
+					},
+					"timeout": schema.Float64Attribute{
+						Description: "Request timeout in seconds.",
+						Optional:    true,
+					},
+					"stream_timeout": schema.Float64Attribute{
+						Description: "Timeout in seconds for streaming requests.",
+						Optional:    true,
+					},
+					"max_fallbacks": schema.Int64Attribute{
+						Description: "Maximum number of fallbacks to attempt.",
+						Optional:    true,
+					},
+					"fallbacks": schema.ListNestedAttribute{
+						Description: "Fallback model chains triggered when a model call fails after retries.",
+						Optional:    true,
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"model": schema.StringAttribute{
+									Description: "The primary model name to configure fallbacks for.",
+									Required:    true,
+								},
+								"fallback_models": schema.ListAttribute{
+									Description: "Ordered list of fallback model names.",
+									Required:    true,
+									ElementType: types.StringType,
+								},
+							},
+						},
+					},
+					"context_window_fallbacks": schema.ListNestedAttribute{
+						Description: "Fallback model chains triggered when a context window exceeded error occurs.",
+						Optional:    true,
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"model": schema.StringAttribute{
+									Description: "The primary model name to configure fallbacks for.",
+									Required:    true,
+								},
+								"fallback_models": schema.ListAttribute{
+									Description: "Ordered list of fallback model names.",
+									Required:    true,
+									ElementType: types.StringType,
+								},
+							},
+						},
+					},
+					"content_policy_fallbacks": schema.ListNestedAttribute{
+						Description: "Fallback model chains triggered when a content policy violation error occurs.",
+						Optional:    true,
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"model": schema.StringAttribute{
+									Description: "The primary model name to configure fallbacks for.",
+									Required:    true,
+								},
+								"fallback_models": schema.ListAttribute{
+									Description: "Ordered list of fallback model names.",
+									Required:    true,
+									ElementType: types.StringType,
+								},
+							},
+						},
+					},
+					"allowed_fails": schema.Int64Attribute{
+						Description: "Number of failures allowed before a model is put into cooldown.",
+						Optional:    true,
+					},
+					"cooldown_time": schema.Float64Attribute{
+						Description: "Duration in seconds a model stays in cooldown after exceeding allowed_fails.",
+						Optional:    true,
+					},
+					"retry_after": schema.Int64Attribute{
+						Description: "Minimum seconds to wait before retrying a rate-limited request.",
+						Optional:    true,
+					},
+					"retry_policy": schema.SingleNestedAttribute{
+						Description: "Per-error-type retry counts that override num_retries.",
+						Optional:    true,
+						Attributes: map[string]schema.Attribute{
+							"bad_request_error_retries": schema.Int64Attribute{
+								Description: "Retries for BadRequestError (HTTP 400).",
+								Optional:    true,
+							},
+							"authentication_error_retries": schema.Int64Attribute{
+								Description: "Retries for AuthenticationError (HTTP 401).",
+								Optional:    true,
+							},
+							"timeout_error_retries": schema.Int64Attribute{
+								Description: "Retries for TimeoutError.",
+								Optional:    true,
+							},
+							"rate_limit_error_retries": schema.Int64Attribute{
+								Description: "Retries for RateLimitError (HTTP 429).",
+								Optional:    true,
+							},
+							"content_policy_violation_error_retries": schema.Int64Attribute{
+								Description: "Retries for ContentPolicyViolationError.",
+								Optional:    true,
+							},
+							"internal_server_error_retries": schema.Int64Attribute{
+								Description: "Retries for InternalServerError (HTTP 500).",
+								Optional:    true,
+							},
+						},
+					},
+					"model_group_alias": schema.MapAttribute{
+						Description: "Alias mappings from one model group name to another.",
+						Optional:    true,
+						ElementType: types.StringType,
+					},
+					"enable_pre_call_checks": schema.BoolAttribute{
+						Description: "Enable pre-call checks (e.g. context window validation) before routing.",
+						Optional:    true,
+					},
+					"default_litellm_params": schema.MapAttribute{
+						Description: "Default parameters to merge into every LiteLLM request for this key.",
+						Optional:    true,
+						ElementType: types.StringType,
+					},
+					"set_verbose": schema.BoolAttribute{
+						Description: "Enable verbose logging for requests made with this key.",
+						Optional:    true,
+					},
+					"default_max_parallel_requests": schema.Int64Attribute{
+						Description: "Default maximum parallel requests allowed per deployment.",
+						Optional:    true,
+					},
+					"enable_tag_filtering": schema.BoolAttribute{
+						Description: "Enable tag-based routing so only deployments matching request tags are considered.",
+						Optional:    true,
+					},
+					"tag_filtering_match_any": schema.BoolAttribute{
+						Description: "When tag filtering is enabled, match deployments that have any of the request tags (true) vs all tags (false).",
+						Optional:    true,
+					},
+					"disable_cooldowns": schema.BoolAttribute{
+						Description: "Disable the cooldown mechanism so failed deployments are always retried.",
+						Optional:    true,
+					},
+				},
 			},
 			"blocked": schema.BoolAttribute{
 				Description: "Whether the key is blocked.",
@@ -363,37 +585,6 @@ func (r *KeyResource) Update(ctx context.Context, req resource.UpdateRequest, re
 
 	updateReq := r.buildKeyRequest(ctx, &data)
 	updateReq["key"] = data.Key.ValueString()
-
-	// router_settings: Pydantic validates the whole object, so we must send safe values.
-	// Null plan → send {} (API rejects null). Removed keys → inject [] or {} zero-values
-	// to avoid 422. Scalars can be omitted.
-	switch {
-	case data.RouterSettings.IsNull():
-		updateReq["router_settings"] = map[string]interface{}{}
-	case !data.RouterSettings.IsUnknown():
-		// inject zero values for removed list/object keys so Pydantic
-		// receives a valid type rather than null.
-		if routerMap, ok := updateReq["router_settings"].(map[string]interface{}); ok {
-			if !state.RouterSettings.IsNull() && !state.RouterSettings.IsUnknown() {
-				var stateRouter map[string]string
-				state.RouterSettings.ElementsAs(ctx, &stateRouter, false)
-				for k, v := range stateRouter {
-					if _, inPlan := routerMap[k]; !inPlan {
-						trimmed := strings.TrimSpace(v)
-						if strings.HasPrefix(trimmed, "[") {
-							routerMap[k] = []interface{}{}
-						} else if strings.HasPrefix(trimmed, "{") {
-							routerMap[k] = map[string]interface{}{}
-						}
-						// Scalars omitted: the API replaces router_settings wholesale.
-					}
-				}
-			}
-		} else {
-			// Non-null but empty plan map (router_settings = {}) — clear entirely.
-			updateReq["router_settings"] = map[string]interface{}{}
-		}
-	}
 
 	if err := r.client.DoRequestWithResponse(ctx, "POST", "/key/update", updateReq, nil); err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update key: %s", err))
@@ -638,14 +829,9 @@ func (r *KeyResource) buildKeyRequest(ctx context.Context, data *KeyResourceMode
 
 	// Map fields - check IsNull, IsUnknown, and len > 0
 	if !data.RouterSettings.IsNull() && !data.RouterSettings.IsUnknown() {
-		var routerSettings map[string]string
-		data.RouterSettings.ElementsAs(ctx, &routerSettings, false)
-		if len(routerSettings) > 0 {
-			// Convert string values that contain JSON objects/arrays to native
-			// types so the API receives them as structured data rather than
-			// escaped strings (e.g. fallbacks configuration).
-			keyReq["router_settings"] = convertJSONStringsToNative(routerSettings)
-		}
+		keyReq["router_settings"] = buildKeyRouterSettingsPayload(ctx, data.RouterSettings)
+	} else {
+		keyReq["router_settings"] = map[string]interface{}{}
 	}
 
 	if !data.Metadata.IsNull() && !data.Metadata.IsUnknown() {
@@ -722,6 +908,214 @@ func (r *KeyResource) buildKeyRequest(ctx context.Context, data *KeyResourceMode
 	}
 
 	return keyReq
+}
+
+// buildKeyRouterSettingsPayload converts the Terraform router_settings object
+// into the LiteLLM API wire format.
+func buildKeyRouterSettingsPayload(ctx context.Context, obj types.Object) map[string]interface{} {
+	var rs KeyRouterSettingsModel
+	obj.As(ctx, &rs, basetypes.ObjectAsOptions{})
+
+	payload := map[string]interface{}{}
+
+	if !rs.RoutingStrategy.IsNull() && !rs.RoutingStrategy.IsUnknown() {
+		payload["routing_strategy"] = rs.RoutingStrategy.ValueString()
+	}
+	if !rs.NumRetries.IsNull() && !rs.NumRetries.IsUnknown() {
+		payload["num_retries"] = rs.NumRetries.ValueInt64()
+	}
+	if !rs.MaxFallbacks.IsNull() && !rs.MaxFallbacks.IsUnknown() {
+		payload["max_fallbacks"] = rs.MaxFallbacks.ValueInt64()
+	}
+	if !rs.AllowedFails.IsNull() && !rs.AllowedFails.IsUnknown() {
+		payload["allowed_fails"] = rs.AllowedFails.ValueInt64()
+	}
+	if !rs.RetryAfter.IsNull() && !rs.RetryAfter.IsUnknown() {
+		payload["retry_after"] = rs.RetryAfter.ValueInt64()
+	}
+	if !rs.DefaultMaxParallelRequests.IsNull() && !rs.DefaultMaxParallelRequests.IsUnknown() {
+		payload["default_max_parallel_requests"] = rs.DefaultMaxParallelRequests.ValueInt64()
+	}
+	if !rs.Timeout.IsNull() && !rs.Timeout.IsUnknown() {
+		payload["timeout"] = rs.Timeout.ValueFloat64()
+	}
+	if !rs.StreamTimeout.IsNull() && !rs.StreamTimeout.IsUnknown() {
+		payload["stream_timeout"] = rs.StreamTimeout.ValueFloat64()
+	}
+	if !rs.CooldownTime.IsNull() && !rs.CooldownTime.IsUnknown() {
+		payload["cooldown_time"] = rs.CooldownTime.ValueFloat64()
+	}
+	if !rs.EnablePreCallChecks.IsNull() && !rs.EnablePreCallChecks.IsUnknown() {
+		payload["enable_pre_call_checks"] = rs.EnablePreCallChecks.ValueBool()
+	}
+	if !rs.SetVerbose.IsNull() && !rs.SetVerbose.IsUnknown() {
+		payload["set_verbose"] = rs.SetVerbose.ValueBool()
+	}
+	if !rs.EnableTagFiltering.IsNull() && !rs.EnableTagFiltering.IsUnknown() {
+		payload["enable_tag_filtering"] = rs.EnableTagFiltering.ValueBool()
+	}
+	if !rs.TagFilteringMatchAny.IsNull() && !rs.TagFilteringMatchAny.IsUnknown() {
+		payload["tag_filtering_match_any"] = rs.TagFilteringMatchAny.ValueBool()
+	}
+	if !rs.DisableCooldowns.IsNull() && !rs.DisableCooldowns.IsUnknown() {
+		payload["disable_cooldowns"] = rs.DisableCooldowns.ValueBool()
+	}
+	if !rs.Fallbacks.IsNull() && !rs.Fallbacks.IsUnknown() {
+		payload["fallbacks"] = fallbackEntriesToAPIFormat(ctx, rs.Fallbacks)
+	}
+	if !rs.ContextWindowFallbacks.IsNull() && !rs.ContextWindowFallbacks.IsUnknown() {
+		payload["context_window_fallbacks"] = fallbackEntriesToAPIFormat(ctx, rs.ContextWindowFallbacks)
+	}
+	if !rs.ContentPolicyFallbacks.IsNull() && !rs.ContentPolicyFallbacks.IsUnknown() {
+		payload["content_policy_fallbacks"] = fallbackEntriesToAPIFormat(ctx, rs.ContentPolicyFallbacks)
+	}
+	if !rs.RoutingStrategyArgs.IsNull() && !rs.RoutingStrategyArgs.IsUnknown() {
+		var m map[string]string
+		rs.RoutingStrategyArgs.ElementsAs(ctx, &m, false)
+		payload["routing_strategy_args"] = m
+	}
+	if !rs.ModelGroupAlias.IsNull() && !rs.ModelGroupAlias.IsUnknown() {
+		var m map[string]string
+		rs.ModelGroupAlias.ElementsAs(ctx, &m, false)
+		payload["model_group_alias"] = m
+	}
+	if !rs.DefaultLitellmParams.IsNull() && !rs.DefaultLitellmParams.IsUnknown() {
+		var m map[string]string
+		rs.DefaultLitellmParams.ElementsAs(ctx, &m, false)
+		payload["default_litellm_params"] = m
+	}
+	if !rs.RetryPolicy.IsNull() && !rs.RetryPolicy.IsUnknown() {
+		var rp KeyRetryPolicyModel
+		rs.RetryPolicy.As(ctx, &rp, basetypes.ObjectAsOptions{})
+		rpMap := map[string]interface{}{}
+		if !rp.BadRequestErrorRetries.IsNull() {
+			rpMap["BadRequestErrorRetries"] = rp.BadRequestErrorRetries.ValueInt64()
+		}
+		if !rp.AuthenticationErrorRetries.IsNull() {
+			rpMap["AuthenticationErrorRetries"] = rp.AuthenticationErrorRetries.ValueInt64()
+		}
+		if !rp.TimeoutErrorRetries.IsNull() {
+			rpMap["TimeoutErrorRetries"] = rp.TimeoutErrorRetries.ValueInt64()
+		}
+		if !rp.RateLimitErrorRetries.IsNull() {
+			rpMap["RateLimitErrorRetries"] = rp.RateLimitErrorRetries.ValueInt64()
+		}
+		if !rp.ContentPolicyViolationErrorRetries.IsNull() {
+			rpMap["ContentPolicyViolationErrorRetries"] = rp.ContentPolicyViolationErrorRetries.ValueInt64()
+		}
+		if !rp.InternalServerErrorRetries.IsNull() {
+			rpMap["InternalServerErrorRetries"] = rp.InternalServerErrorRetries.ValueInt64()
+		}
+		payload["retry_policy"] = rpMap
+	}
+
+	return payload
+}
+
+// parseKeyRouterSettingsFromAPI converts the LiteLLM API router_settings response
+// back into a Terraform types.Object matching the KeyRouterSettingsModel schema.
+func parseKeyRouterSettingsFromAPI(rs map[string]interface{}) types.Object {
+	rsAttrs := map[string]attr.Value{
+		"routing_strategy":              stringFromAPIVal(rs["routing_strategy"]),
+		"num_retries":                   int64FromAPIVal(rs["num_retries"]),
+		"max_fallbacks":                 int64FromAPIVal(rs["max_fallbacks"]),
+		"allowed_fails":                 int64FromAPIVal(rs["allowed_fails"]),
+		"retry_after":                   int64FromAPIVal(rs["retry_after"]),
+		"default_max_parallel_requests": int64FromAPIVal(rs["default_max_parallel_requests"]),
+		"timeout":                       float64FromAPIVal(rs["timeout"]),
+		"stream_timeout":                float64FromAPIVal(rs["stream_timeout"]),
+		"cooldown_time":                 float64FromAPIVal(rs["cooldown_time"]),
+		"enable_pre_call_checks":        boolFromAPIVal(rs["enable_pre_call_checks"]),
+		"set_verbose":                   boolFromAPIVal(rs["set_verbose"]),
+		"enable_tag_filtering":          boolFromAPIVal(rs["enable_tag_filtering"]),
+		"tag_filtering_match_any":       boolFromAPIVal(rs["tag_filtering_match_any"]),
+		"disable_cooldowns":             boolFromAPIVal(rs["disable_cooldowns"]),
+		"routing_strategy_args":         stringMapFromAPIVal(rs["routing_strategy_args"]),
+		"model_group_alias":             stringMapFromAPIVal(rs["model_group_alias"]),
+		"default_litellm_params":        stringMapFromAPIVal(rs["default_litellm_params"]),
+		"retry_policy":                  parseKeyRetryPolicyFromAPIVal(rs["retry_policy"]),
+	}
+
+	if fb, ok := rs["fallbacks"].([]interface{}); ok {
+		rsAttrs["fallbacks"] = apiFormatToFallbackEntries(fb)
+	} else {
+		rsAttrs["fallbacks"] = types.ListNull(types.ObjectType{AttrTypes: fallbackEntryAttrTypes})
+	}
+	if cwf, ok := rs["context_window_fallbacks"].([]interface{}); ok {
+		rsAttrs["context_window_fallbacks"] = apiFormatToFallbackEntries(cwf)
+	} else {
+		rsAttrs["context_window_fallbacks"] = types.ListNull(types.ObjectType{AttrTypes: fallbackEntryAttrTypes})
+	}
+	if cpf, ok := rs["content_policy_fallbacks"].([]interface{}); ok {
+		rsAttrs["content_policy_fallbacks"] = apiFormatToFallbackEntries(cpf)
+	} else {
+		rsAttrs["content_policy_fallbacks"] = types.ListNull(types.ObjectType{AttrTypes: fallbackEntryAttrTypes})
+	}
+
+	obj, _ := types.ObjectValue(keyRouterSettingsAttrTypes, rsAttrs)
+	return obj
+}
+
+func stringFromAPIVal(v interface{}) types.String {
+	if s, ok := v.(string); ok {
+		return types.StringValue(s)
+	}
+	return types.StringNull()
+}
+
+func int64FromAPIVal(v interface{}) types.Int64 {
+	if f, ok := v.(float64); ok {
+		return types.Int64Value(int64(f))
+	}
+	return types.Int64Null()
+}
+
+func float64FromAPIVal(v interface{}) types.Float64 {
+	if f, ok := v.(float64); ok {
+		return types.Float64Value(f)
+	}
+	return types.Float64Null()
+}
+
+func boolFromAPIVal(v interface{}) types.Bool {
+	if b, ok := v.(bool); ok {
+		return types.BoolValue(b)
+	}
+	return types.BoolNull()
+}
+
+func stringMapFromAPIVal(v interface{}) types.Map {
+	m, ok := v.(map[string]interface{})
+	if !ok || len(m) == 0 {
+		return types.MapNull(types.StringType)
+	}
+	elems := make(map[string]attr.Value, len(m))
+	for k, val := range m {
+		if s, ok := val.(string); ok {
+			elems[k] = types.StringValue(s)
+		} else {
+			elems[k] = types.StringValue(valueToJSONString(val))
+		}
+	}
+	result, _ := types.MapValue(types.StringType, elems)
+	return result
+}
+
+func parseKeyRetryPolicyFromAPIVal(v interface{}) types.Object {
+	m, ok := v.(map[string]interface{})
+	if !ok {
+		return types.ObjectNull(keyRetryPolicyAttrTypes)
+	}
+	attrs := map[string]attr.Value{
+		"bad_request_error_retries":              int64FromAPIVal(m["BadRequestErrorRetries"]),
+		"authentication_error_retries":           int64FromAPIVal(m["AuthenticationErrorRetries"]),
+		"timeout_error_retries":                  int64FromAPIVal(m["TimeoutErrorRetries"]),
+		"rate_limit_error_retries":               int64FromAPIVal(m["RateLimitErrorRetries"]),
+		"content_policy_violation_error_retries": int64FromAPIVal(m["ContentPolicyViolationErrorRetries"]),
+		"internal_server_error_retries":          int64FromAPIVal(m["InternalServerErrorRetries"]),
+	}
+	obj, _ := types.ObjectValue(keyRetryPolicyAttrTypes, attrs)
+	return obj
 }
 
 func (r *KeyResource) readKey(ctx context.Context, data *KeyResourceModel) error {
@@ -943,38 +1337,13 @@ func (r *KeyResource) readKey(ctx context.Context, data *KeyResourceModel) error
 		data.Tags, _ = types.ListValue(types.StringType, []attr.Value{})
 	}
 
-	// Handle router_settings map - preserve null when API returns empty and config didn't specify router_settings.
-	// The API may inject internal keys (e.g. fallbacks, timeout) into router_settings.
-	// Only include keys that were in the user's original config to avoid drift.
+	// Handle router_settings - preserve null when user didn't configure it.
 	if data.RouterSettings.IsNull() {
 		// Preserve null - do not repopulate from API
 	} else if routerSettings, ok := info["router_settings"].(map[string]interface{}); ok && len(routerSettings) > 0 {
-		// Build the set of keys the user has in their current config.
-		configuredKeys := make(map[string]bool)
-		if !data.RouterSettings.IsUnknown() {
-			var currentRouter map[string]string
-			data.RouterSettings.ElementsAs(ctx, &currentRouter, false)
-			for k := range currentRouter {
-				configuredKeys[k] = true
-			}
-		}
-
-		settingsMap := make(map[string]attr.Value)
-		for k, v := range routerSettings {
-			// Skip keys not in the user's config (e.g. zero-value sentinels
-			// injected by Update to satisfy API validation).
-			if len(configuredKeys) > 0 && !configuredKeys[k] {
-				continue
-			}
-			settingsMap[k] = types.StringValue(valueToJSONString(v))
-		}
-		if len(settingsMap) > 0 {
-			data.RouterSettings, _ = types.MapValue(types.StringType, settingsMap)
-		} else {
-			data.RouterSettings, _ = types.MapValue(types.StringType, map[string]attr.Value{})
-		}
+		data.RouterSettings = parseKeyRouterSettingsFromAPI(routerSettings)
 	} else {
-		data.RouterSettings, _ = types.MapValue(types.StringType, map[string]attr.Value{})
+		data.RouterSettings = types.ObjectNull(keyRouterSettingsAttrTypes)
 	}
 
 	// Handle metadata map - preserve null when API returns empty and config didn't specify metadata.

--- a/internal/provider/resource_key.go
+++ b/internal/provider/resource_key.go
@@ -613,7 +613,7 @@ func (r *KeyResource) buildKeyRequest(ctx context.Context, data *KeyResourceMode
 			// Convert string values that contain JSON objects/arrays to native
 			// types so the API receives them as structured data rather than
 			// escaped strings (e.g. fallbacks configuration).
-			keyReq["router_settings"] = convertMetadataToNative(routerSettings)
+			keyReq["router_settings"] = convertJSONStringsToNative(routerSettings)
 		}
 	}
 
@@ -624,7 +624,7 @@ func (r *KeyResource) buildKeyRequest(ctx context.Context, data *KeyResourceMode
 			// Convert string values that contain JSON objects/arrays to native
 			// types so the API receives them as structured data rather than
 			// escaped strings (e.g. logging configuration).
-			keyReq["metadata"] = convertMetadataToNative(metadata)
+			keyReq["metadata"] = convertJSONStringsToNative(metadata)
 		}
 	}
 
@@ -916,7 +916,7 @@ func (r *KeyResource) readKey(ctx context.Context, data *KeyResourceModel) error
 	if routerSettings, ok := info["router_settings"].(map[string]interface{}); ok && len(routerSettings) > 0 {
 		settingsMap := make(map[string]attr.Value)
 		for k, v := range routerSettings {
-			settingsMap[k] = types.StringValue(metadataValueToString(v))
+			settingsMap[k] = types.StringValue(valueToJSONString(v))
 		}
 		data.RouterSettings, _ = types.MapValue(types.StringType, settingsMap)
 	} else if !data.RouterSettings.IsNull() {
@@ -943,7 +943,7 @@ func (r *KeyResource) readKey(ctx context.Context, data *KeyResourceModel) error
 			if len(configuredKeys) > 0 && !configuredKeys[k] {
 				continue
 			}
-			metaMap[k] = types.StringValue(metadataValueToString(v))
+			metaMap[k] = types.StringValue(valueToJSONString(v))
 		}
 		if len(metaMap) > 0 {
 			data.Metadata, _ = types.MapValue(types.StringType, metaMap)

--- a/internal/provider/resource_key.go
+++ b/internal/provider/resource_key.go
@@ -70,6 +70,7 @@ type KeyResourceModel struct {
 	Prompts                  types.List    `tfsdk:"prompts"`
 	EnforcedParams           types.List    `tfsdk:"enforced_params"`
 	Tags                     types.List    `tfsdk:"tags"`
+	RouterSettings           types.Map     `tfsdk:"router_settings"`
 	Blocked                  types.Bool    `tfsdk:"blocked"`
 }
 
@@ -253,6 +254,12 @@ func (r *KeyResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 			},
 			"tags": schema.ListAttribute{
 				Description: "Tags for the key.",
+				Optional:    true,
+				Computed:    true,
+				ElementType: types.StringType,
+			},
+			"router_settings": schema.MapAttribute{
+				Description: "Router settings for the key.",
 				Optional:    true,
 				Computed:    true,
 				ElementType: types.StringType,
@@ -599,6 +606,14 @@ func (r *KeyResource) buildKeyRequest(ctx context.Context, data *KeyResourceMode
 	}
 
 	// Map fields - check IsNull, IsUnknown, and len > 0
+	if !data.RouterSettings.IsNull() && !data.RouterSettings.IsUnknown() {
+		var routerSettings map[string]string
+		data.RouterSettings.ElementsAs(ctx, &routerSettings, false)
+		if len(routerSettings) > 0 {
+			keyReq["router_settings"] = routerSettings
+		}
+	}
+
 	if !data.Metadata.IsNull() && !data.Metadata.IsUnknown() {
 		var metadata map[string]string
 		data.Metadata.ElementsAs(ctx, &metadata, false)
@@ -892,6 +907,19 @@ func (r *KeyResource) readKey(ctx context.Context, data *KeyResourceModel) error
 		data.Tags, _ = types.ListValue(types.StringType, tagsList)
 	} else if !data.Tags.IsNull() {
 		data.Tags, _ = types.ListValue(types.StringType, []attr.Value{})
+	}
+
+	// Handle router_settings map - preserve null when API returns empty and config didn't specify router_settings
+	if routerSettings, ok := info["router_settings"].(map[string]interface{}); ok && len(routerSettings) > 0 {
+		settingsMap := make(map[string]attr.Value)
+		for k, v := range routerSettings {
+			if str, ok := v.(string); ok {
+				settingsMap[k] = types.StringValue(str)
+			}
+		}
+		data.RouterSettings, _ = types.MapValue(types.StringType, settingsMap)
+	} else if !data.RouterSettings.IsNull() {
+		data.RouterSettings, _ = types.MapValue(types.StringType, map[string]attr.Value{})
 	}
 
 	// Handle metadata map - preserve null when API returns empty and config didn't specify metadata.

--- a/internal/provider/resource_key_test.go
+++ b/internal/provider/resource_key_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 )
 
@@ -755,160 +756,6 @@ func TestReadKeyTagsFromMetadata(t *testing.T) {
 	}
 }
 
-// TestReadKeyRouterSettingsWithComplexValues verifies that router_settings values
-// containing nested structures (arrays, objects) are properly handled:
-// - Arrays/objects from API response are JSON-encoded back to strings in state
-// - When building requests, JSON strings are decoded back to native types
-func TestReadKeyRouterSettingsWithComplexValues(t *testing.T) {
-	t.Parallel()
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]interface{}{
-			"key": "sk-router-test",
-			"info": map[string]interface{}{
-				"token": "sk-router-test",
-				"router_settings": map[string]interface{}{
-					"num_retries":   float64(1),
-					"timeout":       float64(4),
-					"max_retries":   float64(1),
-					"retry_after":   float64(0),
-					"allowed_fails": float64(1),
-					"fallbacks": []interface{}{
-						map[string]interface{}{
-							"provider-a-model-1": []interface{}{
-								"provider-a-model-2",
-								"provider-a-model-3",
-							},
-						},
-						map[string]interface{}{
-							"provider-b-model-1": []interface{}{
-								"provider-b-model-2",
-								"provider-c-model-1",
-							},
-						},
-					},
-				},
-			},
-		})
-	}))
-	defer server.Close()
-
-	r := &KeyResource{
-		client: &Client{
-			APIBase:    server.URL,
-			APIKey:     "test-key",
-			HTTPClient: server.Client(),
-		},
-	}
-
-	// Simulate user config with these router_settings keys
-	data := KeyResourceModel{
-		ID:  types.StringValue(hashKeyForID("sk-router-test")),
-		Key: types.StringValue("sk-router-test"),
-		RouterSettings: stringMapValue(map[string]string{
-			"num_retries": "1",
-			"timeout":     "4",
-			"fallbacks":   `[{"provider-a-model-1":["provider-a-model-2"]}]`,
-		}),
-		// Initialize other fields to avoid nil panics
-		Models:                   types.ListNull(types.StringType),
-		AllowedRoutes:            types.ListNull(types.StringType),
-		AllowedPassthroughRoutes: types.ListNull(types.StringType),
-		AllowedCacheControls:     types.ListNull(types.StringType),
-		Guardrails:               types.ListNull(types.StringType),
-		Prompts:                  types.ListNull(types.StringType),
-		EnforcedParams:           types.ListNull(types.StringType),
-		Tags:                     types.ListNull(types.StringType),
-		Aliases:                  types.MapNull(types.StringType),
-		Config:                   types.MapNull(types.StringType),
-		Permissions:              types.MapNull(types.StringType),
-		Metadata:                 types.MapNull(types.StringType),
-		ModelMaxBudget:           types.MapNull(types.Float64Type),
-		ModelRPMLimit:            types.MapNull(types.Int64Type),
-		ModelTPMLimit:            types.MapNull(types.Int64Type),
-	}
-
-	if err := r.readKey(context.Background(), &data); err != nil {
-		t.Fatalf("readKey returned error: %v", err)
-	}
-
-	if data.RouterSettings.IsNull() || data.RouterSettings.IsUnknown() {
-		t.Fatal("router_settings should be known and non-null after read")
-	}
-
-	elems := data.RouterSettings.Elements()
-
-	// Numeric values should be JSON-encoded strings
-	if numRetries, ok := elems["num_retries"].(types.String); ok {
-		if numRetries.ValueString() != "1" {
-			t.Errorf("expected num_retries '1', got %q", numRetries.ValueString())
-		}
-	} else {
-		t.Errorf("expected num_retries to be types.String, got %T", elems["num_retries"])
-	}
-
-	// Array value should be JSON-encoded string
-	if fallbacks, ok := elems["fallbacks"].(types.String); ok {
-		var parsed []interface{}
-		if err := json.Unmarshal([]byte(fallbacks.ValueString()), &parsed); err != nil {
-			t.Errorf("fallbacks should be valid JSON array, got error: %v, value: %q", err, fallbacks.ValueString())
-		} else if len(parsed) != 2 {
-			t.Errorf("expected 2 fallback entries, got %d", len(parsed))
-		}
-	} else {
-		t.Errorf("expected fallbacks to be types.String, got %T", elems["fallbacks"])
-	}
-}
-
-// TestBuildKeyRequestRouterSettingsWithJSON verifies that router_settings values
-// containing JSON strings are decoded to native types in the API request body.
-func TestBuildKeyRequestRouterSettingsWithJSON(t *testing.T) {
-	t.Parallel()
-
-	r := &KeyResource{}
-	data := &KeyResourceModel{
-		RouterSettings: stringMapValue(map[string]string{
-			"num_retries": "1",
-			"timeout":     "4",
-			"fallbacks": `[
-				{"provider-a-model-1":["provider-a-model-2","provider-a-model-3"]},
-				{"provider-b-model-1":["provider-b-model-2","provider-c-model-1"]}
-			]`,
-		}),
-	}
-
-	req := r.buildKeyRequest(context.Background(), data)
-
-	routerSettings, ok := req["router_settings"].(map[string]interface{})
-	if !ok {
-		t.Fatalf("expected router_settings to be map[string]interface{}, got %T", req["router_settings"])
-	}
-
-	// Simple numeric string stays as string
-	if routerSettings["num_retries"] != "1" {
-		t.Errorf("expected num_retries '1', got %v", routerSettings["num_retries"])
-	}
-
-	// JSON array should be native, not a string
-	arr, ok := routerSettings["fallbacks"].([]interface{})
-	if !ok {
-		t.Fatalf("expected fallbacks to be []interface{} (native array), got %T: %v", routerSettings["fallbacks"], routerSettings["fallbacks"])
-	}
-	if len(arr) != 2 {
-		t.Errorf("expected 2 fallback entries, got %d", len(arr))
-	}
-
-	// Verify first fallback entry is a map
-	firstFallback, ok := arr[0].(map[string]interface{})
-	if !ok {
-		t.Fatalf("expected first fallback entry to be map[string]interface{}, got %T", arr[0])
-	}
-	if _, ok := firstFallback["provider-a-model-1"]; !ok {
-		t.Error("expected 'provider-a-model-1' key in first fallback entry")
-	}
-}
-
 // TestServiceAccountIDDefaultsKeyAlias verifies that when service_account_id is
 // set but key_alias is omitted, buildKeyRequest populates key_alias with the
 // service_account_id value — matching the documented behaviour.
@@ -1433,9 +1280,8 @@ func TestUpdateRouterSettingsNullSendsEmptyObject(t *testing.T) {
 	// where RouterSettings is null (user removed it from config), then apply
 	// the same null-injection logic that Update applies.
 	data := &KeyResourceModel{
-		Key:            types.StringValue("sk-update-test"),
-		RouterSettings: types.MapNull(types.StringType),
-		// Remaining fields null to avoid panics in buildKeyRequest
+		Key:                      types.StringValue("sk-update-test"),
+		RouterSettings:           types.ObjectNull(keyRouterSettingsAttrTypes),
 		Models:                   types.ListNull(types.StringType),
 		AllowedRoutes:            types.ListNull(types.StringType),
 		AllowedPassthroughRoutes: types.ListNull(types.StringType),
@@ -1494,11 +1340,11 @@ func TestReadKeyRouterSettingsNullPreservedAfterClear(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name            string
+		name              string
 		apiRouterSettings interface{} // what the API returns for router_settings
 	}{
 		{
-			name:            "API returns empty object after clear",
+			name:              "API returns empty object after clear",
 			apiRouterSettings: map[string]interface{}{},
 		},
 		{
@@ -1545,7 +1391,7 @@ func TestReadKeyRouterSettingsNullPreservedAfterClear(t *testing.T) {
 			data := KeyResourceModel{
 				ID:                       types.StringValue(hashKeyForID("sk-clear-test")),
 				Key:                      types.StringValue("sk-clear-test"),
-				RouterSettings:           types.MapNull(types.StringType),
+				RouterSettings:           types.ObjectNull(keyRouterSettingsAttrTypes),
 				Models:                   types.ListNull(types.StringType),
 				AllowedRoutes:            types.ListNull(types.StringType),
 				AllowedPassthroughRoutes: types.ListNull(types.StringType),
@@ -1580,173 +1426,214 @@ func TestReadKeyRouterSettingsNullPreservedAfterClear(t *testing.T) {
 	}
 }
 
-// TestUpdateRouterSettingsPartialRemovalInjectsZeroValueSentinels verifies that
-// when the user removes a key from within router_settings (e.g. removes fallbacks
-// but keeps timeout and num_retries), the Update path injects a zero-value
-// sentinel for the removed key in the request body.
-//
-// Background: the LiteLLM API validates router_settings with Pydantic and does
-// not support partial updates. If fallbacks was previously set and is now absent,
-// the API fills it with None and raises a 422 ("Input should be a valid list",
-// "input":"null"). Injecting [] for removed list-type keys and {} for removed
-// object-type keys prevents that validation failure.
-func TestUpdateRouterSettingsPartialRemovalInjectsZeroValueSentinels(t *testing.T) {
+// TestBuildKeyRouterSettingsPayload_Scalars verifies that scalar fields are
+// serialized to their correct native types in the API payload.
+func TestBuildKeyRouterSettingsPayload_Scalars(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name           string
-		stateValue     string // the prior state value for the removed key (as stored in tf state)
-		expectedSentinel interface{} // what should be injected
-	}{
-		{
-			name:             "list-type field (fallbacks) gets empty list sentinel",
-			stateValue:       `[{"model-a":["model-b"]}]`,
-			expectedSentinel: []interface{}{},
-		},
-		{
-			name:             "object-type field gets empty object sentinel",
-			stateValue:       `{"nested":"value"}`,
-			expectedSentinel: map[string]interface{}{},
-		},
-		{
-			name:             "scalar field is omitted (API replaces wholesale)",
-			stateValue:       "5",
-			expectedSentinel: nil, // signals the key should be absent
-		},
+	fallbackList := types.ListNull(types.ObjectType{AttrTypes: fallbackEntryAttrTypes})
+	rsAttrs := map[string]attr.Value{
+		"routing_strategy":              types.StringValue("least-busy"),
+		"num_retries":                   types.Int64Value(3),
+		"max_fallbacks":                 types.Int64Null(),
+		"allowed_fails":                 types.Int64Value(2),
+		"retry_after":                   types.Int64Null(),
+		"default_max_parallel_requests": types.Int64Null(),
+		"timeout":                       types.Float64Value(30.5),
+		"stream_timeout":                types.Float64Null(),
+		"cooldown_time":                 types.Float64Null(),
+		"enable_pre_call_checks":        types.BoolValue(true),
+		"set_verbose":                   types.BoolNull(),
+		"enable_tag_filtering":          types.BoolNull(),
+		"tag_filtering_match_any":       types.BoolNull(),
+		"disable_cooldowns":             types.BoolNull(),
+		"fallbacks":                     fallbackList,
+		"context_window_fallbacks":      fallbackList,
+		"content_policy_fallbacks":      fallbackList,
+		"routing_strategy_args":         types.MapNull(types.StringType),
+		"model_group_alias":             types.MapNull(types.StringType),
+		"default_litellm_params":        types.MapNull(types.StringType),
+		"retry_policy":                  types.ObjectNull(keyRetryPolicyAttrTypes),
 	}
+	obj, _ := types.ObjectValue(keyRouterSettingsAttrTypes, rsAttrs)
 
-	for _, tc := range tests {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
+	payload := buildKeyRouterSettingsPayload(context.Background(), obj)
 
-			r := &KeyResource{}
-
-			// Plan: router_settings has timeout + num_retries only ("removed_key" is gone).
-			planSettings := stringMapValue(map[string]string{
-				"timeout":     "5",
-				"num_retries": "1",
-			})
-
-			// State: router_settings had the same keys plus "removed_key".
-			stateSettings := stringMapValue(map[string]string{
-				"timeout":     "5",
-				"num_retries": "1",
-				"removed_key": tc.stateValue,
-			})
-
-			// Build the request from the plan (mirrors what buildKeyRequest does).
-			data := &KeyResourceModel{
-				RouterSettings:           planSettings,
-				Models:                   types.ListNull(types.StringType),
-				AllowedRoutes:            types.ListNull(types.StringType),
-				AllowedPassthroughRoutes: types.ListNull(types.StringType),
-				AllowedCacheControls:     types.ListNull(types.StringType),
-				Guardrails:               types.ListNull(types.StringType),
-				Prompts:                  types.ListNull(types.StringType),
-				EnforcedParams:           types.ListNull(types.StringType),
-				Tags:                     types.ListNull(types.StringType),
-				Metadata:                 types.MapNull(types.StringType),
-				Aliases:                  types.MapNull(types.StringType),
-				Config:                   types.MapNull(types.StringType),
-				Permissions:              types.MapNull(types.StringType),
-				ModelMaxBudget:           types.MapNull(types.Float64Type),
-				ModelRPMLimit:            types.MapNull(types.Int64Type),
-				ModelTPMLimit:            types.MapNull(types.Int64Type),
-			}
-			state := &KeyResourceModel{
-				RouterSettings: stateSettings,
-			}
-
-			updateReq := r.buildKeyRequest(context.Background(), data)
-
-			// Apply the same case-2 logic from Update.
-			if routerMap, ok := updateReq["router_settings"].(map[string]interface{}); ok {
-				if !state.RouterSettings.IsNull() && !state.RouterSettings.IsUnknown() {
-					var stateRouter map[string]string
-					state.RouterSettings.ElementsAs(context.Background(), &stateRouter, false)
-					for k, v := range stateRouter {
-						if _, inPlan := routerMap[k]; !inPlan {
-							trimmed := strings.TrimSpace(v)
-							if strings.HasPrefix(trimmed, "[") {
-								routerMap[k] = []interface{}{}
-							} else if strings.HasPrefix(trimmed, "{") {
-								routerMap[k] = map[string]interface{}{}
-							}
-						}
-					}
-				}
-			}
-
-			routerMap, ok := updateReq["router_settings"].(map[string]interface{})
-			if !ok {
-				t.Fatalf("expected router_settings in request, got %T", updateReq["router_settings"])
-			}
-
-			if tc.expectedSentinel == nil {
-				// Scalar: removed key must be absent from the request.
-				if _, present := routerMap["removed_key"]; present {
-					t.Errorf("scalar removed_key should be omitted from request, got %v", routerMap["removed_key"])
-				}
-			} else {
-				// List/object: sentinel must be present with the correct zero type.
-				val, present := routerMap["removed_key"]
-				if !present {
-					t.Fatalf("expected sentinel for removed_key in request but it was absent")
-				}
-				switch expected := tc.expectedSentinel.(type) {
-				case []interface{}:
-					got, ok := val.([]interface{})
-					if !ok {
-						t.Fatalf("expected []interface{} sentinel, got %T: %v", val, val)
-					}
-					if len(got) != len(expected) {
-						t.Errorf("expected empty slice sentinel, got length %d", len(got))
-					}
-				case map[string]interface{}:
-					got, ok := val.(map[string]interface{})
-					if !ok {
-						t.Fatalf("expected map[string]interface{} sentinel, got %T: %v", val, val)
-					}
-					if len(got) != len(expected) {
-						t.Errorf("expected empty map sentinel, got length %d", len(got))
-					}
-				}
-			}
-		})
+	if payload["routing_strategy"] != "least-busy" {
+		t.Errorf("expected routing_strategy 'least-busy', got %v", payload["routing_strategy"])
+	}
+	if payload["num_retries"] != int64(3) {
+		t.Errorf("expected num_retries int64(3), got %T %v", payload["num_retries"], payload["num_retries"])
+	}
+	if payload["timeout"] != float64(30.5) {
+		t.Errorf("expected timeout 30.5, got %v", payload["timeout"])
+	}
+	if payload["enable_pre_call_checks"] != true {
+		t.Errorf("expected enable_pre_call_checks true, got %v", payload["enable_pre_call_checks"])
+	}
+	if _, exists := payload["max_fallbacks"]; exists {
+		t.Errorf("null max_fallbacks must not appear in payload")
+	}
+	if _, exists := payload["set_verbose"]; exists {
+		t.Errorf("null set_verbose must not appear in payload")
 	}
 }
 
-// TestReadKeyRouterSettingsFiltersToConfiguredKeys verifies that readKey only
-// repopulates keys that are present in the user's current config, ignoring any
-// additional keys returned by the API.
-//
-// When the user removes a key (e.g. fallbacks) from router_settings, the Update
-// path injects a zero-value sentinel (fallbacks=[]) into the request to satisfy
-// Pydantic validation. The API then stores and returns that sentinel. Without
-// filtering, readKey would write fallbacks=[] back into state — causing Terraform
-// to see a new element appearing that wasn't in the plan.
-func TestReadKeyRouterSettingsFiltersToConfiguredKeys(t *testing.T) {
+// TestBuildKeyRouterSettingsPayload_Fallbacks verifies that fallback lists are
+// serialized to the LiteLLM wire format [{"model": ["fb1","fb2"]}].
+func TestBuildKeyRouterSettingsPayload_Fallbacks(t *testing.T) {
 	t.Parallel()
 
-	// API returns the full router_settings including the injected sentinel [].
+	fbModels, _ := types.ListValue(types.StringType, []attr.Value{
+		types.StringValue("gpt-3.5-turbo"),
+		types.StringValue("claude-haiku"),
+	})
+	fbEntry, _ := types.ObjectValue(fallbackEntryAttrTypes, map[string]attr.Value{
+		"model":           types.StringValue("gpt-4"),
+		"fallback_models": fbModels,
+	})
+	fbList, _ := types.ListValue(types.ObjectType{AttrTypes: fallbackEntryAttrTypes}, []attr.Value{fbEntry})
+
+	emptyList := types.ListNull(types.ObjectType{AttrTypes: fallbackEntryAttrTypes})
+	rsAttrs := map[string]attr.Value{
+		"routing_strategy":              types.StringNull(),
+		"num_retries":                   types.Int64Null(),
+		"max_fallbacks":                 types.Int64Null(),
+		"allowed_fails":                 types.Int64Null(),
+		"retry_after":                   types.Int64Null(),
+		"default_max_parallel_requests": types.Int64Null(),
+		"timeout":                       types.Float64Null(),
+		"stream_timeout":                types.Float64Null(),
+		"cooldown_time":                 types.Float64Null(),
+		"enable_pre_call_checks":        types.BoolNull(),
+		"set_verbose":                   types.BoolNull(),
+		"enable_tag_filtering":          types.BoolNull(),
+		"tag_filtering_match_any":       types.BoolNull(),
+		"disable_cooldowns":             types.BoolNull(),
+		"fallbacks":                     fbList,
+		"context_window_fallbacks":      emptyList,
+		"content_policy_fallbacks":      emptyList,
+		"routing_strategy_args":         types.MapNull(types.StringType),
+		"model_group_alias":             types.MapNull(types.StringType),
+		"default_litellm_params":        types.MapNull(types.StringType),
+		"retry_policy":                  types.ObjectNull(keyRetryPolicyAttrTypes),
+	}
+	obj, _ := types.ObjectValue(keyRouterSettingsAttrTypes, rsAttrs)
+
+	payload := buildKeyRouterSettingsPayload(context.Background(), obj)
+
+	fbsRaw, ok := payload["fallbacks"].([]map[string][]string)
+	if !ok {
+		t.Fatalf("expected fallbacks []map[string][]string, got %T: %v", payload["fallbacks"], payload["fallbacks"])
+	}
+	if len(fbsRaw) != 1 {
+		t.Fatalf("expected 1 fallback entry, got %d", len(fbsRaw))
+	}
+	models, ok := fbsRaw[0]["gpt-4"]
+	if !ok {
+		t.Fatal("expected key 'gpt-4' in fallback entry")
+	}
+	if len(models) != 2 || models[0] != "gpt-3.5-turbo" {
+		t.Errorf("unexpected fallback models: %v", models)
+	}
+}
+
+// TestParseKeyRouterSettingsFromAPI_Scalars verifies that float64 API values are
+// parsed into typed Int64/Float64 framework values.
+func TestParseKeyRouterSettingsFromAPI_Scalars(t *testing.T) {
+	t.Parallel()
+
+	rs := map[string]interface{}{
+		"num_retries":            float64(3),
+		"timeout":                float64(30.5),
+		"enable_pre_call_checks": true,
+		"routing_strategy":       "least-busy",
+	}
+
+	obj := parseKeyRouterSettingsFromAPI(rs)
+
+	var model KeyRouterSettingsModel
+	obj.As(context.Background(), &model, basetypes.ObjectAsOptions{})
+
+	if model.NumRetries.ValueInt64() != 3 {
+		t.Errorf("expected num_retries 3, got %d", model.NumRetries.ValueInt64())
+	}
+	if model.Timeout.ValueFloat64() != 30.5 {
+		t.Errorf("expected timeout 30.5, got %f", model.Timeout.ValueFloat64())
+	}
+	if !model.EnablePreCallChecks.ValueBool() {
+		t.Error("expected enable_pre_call_checks true")
+	}
+	if model.RoutingStrategy.ValueString() != "least-busy" {
+		t.Errorf("expected routing_strategy 'least-busy', got %q", model.RoutingStrategy.ValueString())
+	}
+	if !model.MaxFallbacks.IsNull() {
+		t.Error("absent max_fallbacks must be null")
+	}
+}
+
+// TestParseKeyRouterSettingsFromAPI_Fallbacks verifies that wire-format fallback
+// lists are parsed into typed FallbackEntryModel objects.
+func TestParseKeyRouterSettingsFromAPI_Fallbacks(t *testing.T) {
+	t.Parallel()
+
+	rs := map[string]interface{}{
+		"fallbacks": []interface{}{
+			map[string]interface{}{
+				"gpt-4": []interface{}{"gpt-3.5-turbo", "claude-haiku"},
+			},
+		},
+	}
+
+	obj := parseKeyRouterSettingsFromAPI(rs)
+
+	var model KeyRouterSettingsModel
+	obj.As(context.Background(), &model, basetypes.ObjectAsOptions{})
+
+	if model.Fallbacks.IsNull() {
+		t.Fatal("fallbacks should not be null")
+	}
+	var entries []FallbackEntryModel
+	model.Fallbacks.ElementsAs(context.Background(), &entries, false)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if entries[0].Model.ValueString() != "gpt-4" {
+		t.Errorf("expected model 'gpt-4', got %q", entries[0].Model.ValueString())
+	}
+	var fbs []string
+	entries[0].FallbackModels.ElementsAs(context.Background(), &fbs, false)
+	if len(fbs) != 2 || fbs[0] != "gpt-3.5-turbo" {
+		t.Errorf("unexpected fallback_models: %v", fbs)
+	}
+}
+
+// TestReadKeyRouterSettingsTyped verifies that readKey populates a typed
+// RouterSettings object from the API response.
+func TestReadKeyRouterSettingsTyped(t *testing.T) {
+	t.Parallel()
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"key": "sk-typed-test",
 			"info": map[string]interface{}{
-				"token": "sk-partial-test",
+				"token": "sk-typed-test",
 				"router_settings": map[string]interface{}{
-					"timeout":     float64(5),
-					"num_retries": float64(1),
-					// fallbacks is the sentinel injected by Update — must not appear in state.
-					"fallbacks": []interface{}{},
+					"num_retries": float64(2),
+					"timeout":     float64(15.0),
+					"fallbacks": []interface{}{
+						map[string]interface{}{
+							"gpt-4": []interface{}{"gpt-3.5-turbo"},
+						},
+					},
 				},
 			},
 		})
 	}))
 	defer server.Close()
 
-	res := &KeyResource{
+	r := &KeyResource{
 		client: &Client{
 			APIBase:    server.URL,
 			APIKey:     "test-key",
@@ -1754,15 +1641,37 @@ func TestReadKeyRouterSettingsFiltersToConfiguredKeys(t *testing.T) {
 		},
 	}
 
-	// data.RouterSettings reflects the plan: timeout + num_retries only.
-	// fallbacks was removed by the user and must not reappear.
+	// RouterSettings is non-null so readKey will parse the API response.
+	emptyFallbacks := types.ListNull(types.ObjectType{AttrTypes: fallbackEntryAttrTypes})
+	rsAttrs := map[string]attr.Value{
+		"routing_strategy":              types.StringNull(),
+		"num_retries":                   types.Int64Value(0),
+		"max_fallbacks":                 types.Int64Null(),
+		"allowed_fails":                 types.Int64Null(),
+		"retry_after":                   types.Int64Null(),
+		"default_max_parallel_requests": types.Int64Null(),
+		"timeout":                       types.Float64Null(),
+		"stream_timeout":                types.Float64Null(),
+		"cooldown_time":                 types.Float64Null(),
+		"enable_pre_call_checks":        types.BoolNull(),
+		"set_verbose":                   types.BoolNull(),
+		"enable_tag_filtering":          types.BoolNull(),
+		"tag_filtering_match_any":       types.BoolNull(),
+		"disable_cooldowns":             types.BoolNull(),
+		"fallbacks":                     emptyFallbacks,
+		"context_window_fallbacks":      emptyFallbacks,
+		"content_policy_fallbacks":      emptyFallbacks,
+		"routing_strategy_args":         types.MapNull(types.StringType),
+		"model_group_alias":             types.MapNull(types.StringType),
+		"default_litellm_params":        types.MapNull(types.StringType),
+		"retry_policy":                  types.ObjectNull(keyRetryPolicyAttrTypes),
+	}
+	initialRS, _ := types.ObjectValue(keyRouterSettingsAttrTypes, rsAttrs)
+
 	data := KeyResourceModel{
-		ID:  types.StringValue(hashKeyForID("sk-partial-test")),
-		Key: types.StringValue("sk-partial-test"),
-		RouterSettings: stringMapValue(map[string]string{
-			"timeout":     "5",
-			"num_retries": "1",
-		}),
+		ID:                       types.StringValue(hashKeyForID("sk-typed-test")),
+		Key:                      types.StringValue("sk-typed-test"),
+		RouterSettings:           initialRS,
 		Models:                   types.ListNull(types.StringType),
 		AllowedRoutes:            types.ListNull(types.StringType),
 		AllowedPassthroughRoutes: types.ListNull(types.StringType),
@@ -1780,31 +1689,31 @@ func TestReadKeyRouterSettingsFiltersToConfiguredKeys(t *testing.T) {
 		ModelTPMLimit:            types.MapNull(types.Int64Type),
 	}
 
-	if err := res.readKey(context.Background(), &data); err != nil {
+	if err := r.readKey(context.Background(), &data); err != nil {
 		t.Fatalf("readKey returned error: %v", err)
 	}
 
-	if data.RouterSettings.IsNull() || data.RouterSettings.IsUnknown() {
-		t.Fatal("router_settings should be non-null after read (user still has settings configured)")
+	if data.RouterSettings.IsNull() {
+		t.Fatal("router_settings should be non-null after read")
 	}
 
-	elems := data.RouterSettings.Elements()
+	var model KeyRouterSettingsModel
+	data.RouterSettings.As(context.Background(), &model, basetypes.ObjectAsOptions{})
 
-	// timeout and num_retries must be present with the correct values.
-	if v, ok := elems["timeout"].(types.String); !ok || v.ValueString() != "5" {
-		t.Errorf("expected timeout '5', got %v", elems["timeout"])
+	if model.NumRetries.ValueInt64() != 2 {
+		t.Errorf("expected num_retries 2, got %d", model.NumRetries.ValueInt64())
 	}
-	if v, ok := elems["num_retries"].(types.String); !ok || v.ValueString() != "1" {
-		t.Errorf("expected num_retries '1', got %v", elems["num_retries"])
+	if model.Timeout.ValueFloat64() != 15.0 {
+		t.Errorf("expected timeout 15.0, got %f", model.Timeout.ValueFloat64())
 	}
-
-	// fallbacks must not appear — it was a sentinel, not part of the user's config.
-	if _, present := elems["fallbacks"]; present {
-		t.Errorf("fallbacks must not appear in state after readKey — it was a zero-value sentinel injected by Update, not a user-configured key. Got: %v", elems["fallbacks"])
+	if model.Fallbacks.IsNull() {
+		t.Fatal("fallbacks should not be null")
 	}
-
-	// Exactly two keys: timeout and num_retries.
-	if len(elems) != 2 {
-		t.Errorf("expected exactly 2 router_settings keys (timeout, num_retries), got %d: %v", len(elems), elems)
+	var entries []FallbackEntryModel
+	model.Fallbacks.ElementsAs(context.Background(), &entries, false)
+	if len(entries) != 1 || entries[0].Model.ValueString() != "gpt-4" {
+		t.Errorf("unexpected fallbacks: %v", entries)
 	}
 }
+
+

--- a/internal/provider/resource_key_test.go
+++ b/internal/provider/resource_key_test.go
@@ -755,20 +755,174 @@ func TestReadKeyTagsFromMetadata(t *testing.T) {
 	}
 }
 
+// TestReadKeyRouterSettingsWithComplexValues verifies that router_settings values
+// containing nested structures (arrays, objects) are properly handled:
+// - Arrays/objects from API response are JSON-encoded back to strings in state
+// - When building requests, JSON strings are decoded back to native types
+func TestReadKeyRouterSettingsWithComplexValues(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"key": "sk-router-test",
+			"info": map[string]interface{}{
+				"token": "sk-router-test",
+				"router_settings": map[string]interface{}{
+					"num_retries":   float64(1),
+					"timeout":       float64(4),
+					"max_retries":   float64(1),
+					"retry_after":   float64(0),
+					"allowed_fails": float64(1),
+					"fallbacks": []interface{}{
+						map[string]interface{}{
+							"provider-a-model-1": []interface{}{
+								"provider-a-model-2",
+								"provider-a-model-3",
+							},
+						},
+						map[string]interface{}{
+							"provider-b-model-1": []interface{}{
+								"provider-b-model-2",
+								"provider-c-model-1",
+							},
+						},
+					},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	r := &KeyResource{
+		client: &Client{
+			APIBase:    server.URL,
+			APIKey:     "test-key",
+			HTTPClient: server.Client(),
+		},
+	}
+
+	// Simulate user config with these router_settings keys
+	data := KeyResourceModel{
+		ID:  types.StringValue(hashKeyForID("sk-router-test")),
+		Key: types.StringValue("sk-router-test"),
+		RouterSettings: stringMapValue(map[string]string{
+			"num_retries": "1",
+			"timeout":     "4",
+			"fallbacks":   `[{"provider-a-model-1":["provider-a-model-2"]}]`,
+		}),
+		// Initialize other fields to avoid nil panics
+		Models:                   types.ListNull(types.StringType),
+		AllowedRoutes:            types.ListNull(types.StringType),
+		AllowedPassthroughRoutes: types.ListNull(types.StringType),
+		AllowedCacheControls:     types.ListNull(types.StringType),
+		Guardrails:               types.ListNull(types.StringType),
+		Prompts:                  types.ListNull(types.StringType),
+		EnforcedParams:           types.ListNull(types.StringType),
+		Tags:                     types.ListNull(types.StringType),
+		Aliases:                  types.MapNull(types.StringType),
+		Config:                   types.MapNull(types.StringType),
+		Permissions:              types.MapNull(types.StringType),
+		Metadata:                 types.MapNull(types.StringType),
+		ModelMaxBudget:           types.MapNull(types.Float64Type),
+		ModelRPMLimit:            types.MapNull(types.Int64Type),
+		ModelTPMLimit:            types.MapNull(types.Int64Type),
+	}
+
+	if err := r.readKey(context.Background(), &data); err != nil {
+		t.Fatalf("readKey returned error: %v", err)
+	}
+
+	if data.RouterSettings.IsNull() || data.RouterSettings.IsUnknown() {
+		t.Fatal("router_settings should be known and non-null after read")
+	}
+
+	elems := data.RouterSettings.Elements()
+
+	// Numeric values should be JSON-encoded strings
+	if numRetries, ok := elems["num_retries"].(types.String); ok {
+		if numRetries.ValueString() != "1" {
+			t.Errorf("expected num_retries '1', got %q", numRetries.ValueString())
+		}
+	} else {
+		t.Errorf("expected num_retries to be types.String, got %T", elems["num_retries"])
+	}
+
+	// Array value should be JSON-encoded string
+	if fallbacks, ok := elems["fallbacks"].(types.String); ok {
+		var parsed []interface{}
+		if err := json.Unmarshal([]byte(fallbacks.ValueString()), &parsed); err != nil {
+			t.Errorf("fallbacks should be valid JSON array, got error: %v, value: %q", err, fallbacks.ValueString())
+		} else if len(parsed) != 2 {
+			t.Errorf("expected 2 fallback entries, got %d", len(parsed))
+		}
+	} else {
+		t.Errorf("expected fallbacks to be types.String, got %T", elems["fallbacks"])
+	}
+}
+
+// TestBuildKeyRequestRouterSettingsWithJSON verifies that router_settings values
+// containing JSON strings are decoded to native types in the API request body.
+func TestBuildKeyRequestRouterSettingsWithJSON(t *testing.T) {
+	t.Parallel()
+
+	r := &KeyResource{}
+	data := &KeyResourceModel{
+		RouterSettings: stringMapValue(map[string]string{
+			"num_retries": "1",
+			"timeout":     "4",
+			"fallbacks": `[
+				{"provider-a-model-1":["provider-a-model-2","provider-a-model-3"]},
+				{"provider-b-model-1":["provider-b-model-2","provider-c-model-1"]}
+			]`,
+		}),
+	}
+
+	req := r.buildKeyRequest(context.Background(), data)
+
+	routerSettings, ok := req["router_settings"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected router_settings to be map[string]interface{}, got %T", req["router_settings"])
+	}
+
+	// Simple numeric string stays as string
+	if routerSettings["num_retries"] != "1" {
+		t.Errorf("expected num_retries '1', got %v", routerSettings["num_retries"])
+	}
+
+	// JSON array should be native, not a string
+	arr, ok := routerSettings["fallbacks"].([]interface{})
+	if !ok {
+		t.Fatalf("expected fallbacks to be []interface{} (native array), got %T: %v", routerSettings["fallbacks"], routerSettings["fallbacks"])
+	}
+	if len(arr) != 2 {
+		t.Errorf("expected 2 fallback entries, got %d", len(arr))
+	}
+
+	// Verify first fallback entry is a map
+	firstFallback, ok := arr[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected first fallback entry to be map[string]interface{}, got %T", arr[0])
+	}
+	if _, ok := firstFallback["provider-a-model-1"]; !ok {
+		t.Error("expected 'provider-a-model-1' key in first fallback entry")
+	}
+}
+
 // TestServiceAccountIDDefaultsKeyAlias verifies that when service_account_id is
 // set but key_alias is omitted, buildKeyRequest populates key_alias with the
 // service_account_id value — matching the documented behaviour.
 // TestMinimalKeyNoKeyAliasNoServiceAccountID verifies the plain minimal case:
 // neither key_alias nor service_account_id is configured.
 //
-//  resource "litellm_key" "minimal" {}
+//	resource "litellm_key" "minimal" {}
 //
 // Expected behaviour:
-//  - buildKeyRequest must NOT include "key_alias" in the payload.
-//  - readKey with an Unknown key_alias (Computed, unresolved) and an API
-//    response that contains no key_alias must resolve the field to null —
-//    i.e. no "inconsistent result after apply" error and no perpetual
-//    "(known after apply)" on subsequent plans.
+//   - buildKeyRequest must NOT include "key_alias" in the payload.
+//   - readKey with an Unknown key_alias (Computed, unresolved) and an API
+//     response that contains no key_alias must resolve the field to null —
+//     i.e. no "inconsistent result after apply" error and no perpetual
+//     "(known after apply)" on subsequent plans.
 func TestMinimalKeyNoKeyAliasNoServiceAccountID(t *testing.T) {
 	t.Parallel()
 
@@ -1108,8 +1262,8 @@ func TestReadKeyPreservesUserProvidedKey(t *testing.T) {
 			// be hashed; simulate that here.
 			"key": hashedToken,
 			"info": map[string]interface{}{
-				"token":     hashedToken,
-				"key_alias": "my-alias",
+				"token":      hashedToken,
+				"key_alias":  "my-alias",
 				"max_budget": 50.0,
 			},
 		})

--- a/internal/provider/resource_key_test.go
+++ b/internal/provider/resource_key_test.go
@@ -1389,3 +1389,422 @@ func TestReadKeyPopulatesUnknownKey(t *testing.T) {
 		t.Errorf("key should remain %q, got %q", apiReturnedKey, data.Key.ValueString())
 	}
 }
+
+// TestUpdateRouterSettingsNullSendsEmptyObject verifies that when router_settings
+// is null in the plan (user removed it from config), the Update path injects an
+// empty object into the request body rather than omitting the field or sending null.
+//
+// Background: the LiteLLM API rejects `null` for router_settings with a 400
+// (Pydantic union validation). Omitting the field is also wrong — the API treats
+// absence as "no change" and leaves the existing value intact. Sending `{}` is
+// the only way to clear the field.
+func TestUpdateRouterSettingsNullSendsEmptyObject(t *testing.T) {
+	t.Parallel()
+
+	var capturedBody map[string]interface{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/key/update":
+			_ = json.NewDecoder(r.Body).Decode(&capturedBody)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{})
+		default:
+			// readKey call after update — return minimal key info
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"info": map[string]interface{}{
+					"token": "sk-update-test",
+				},
+			})
+		}
+	}))
+	defer server.Close()
+
+	r := &KeyResource{
+		client: &Client{
+			APIBase:    server.URL,
+			APIKey:     "test-key",
+			HTTPClient: server.Client(),
+		},
+	}
+
+	// Simulate what Update does: build the request from the plan-time model
+	// where RouterSettings is null (user removed it from config), then apply
+	// the same null-injection logic that Update applies.
+	data := &KeyResourceModel{
+		Key:            types.StringValue("sk-update-test"),
+		RouterSettings: types.MapNull(types.StringType),
+		// Remaining fields null to avoid panics in buildKeyRequest
+		Models:                   types.ListNull(types.StringType),
+		AllowedRoutes:            types.ListNull(types.StringType),
+		AllowedPassthroughRoutes: types.ListNull(types.StringType),
+		AllowedCacheControls:     types.ListNull(types.StringType),
+		Guardrails:               types.ListNull(types.StringType),
+		Prompts:                  types.ListNull(types.StringType),
+		EnforcedParams:           types.ListNull(types.StringType),
+		Tags:                     types.ListNull(types.StringType),
+		Metadata:                 types.MapNull(types.StringType),
+		Aliases:                  types.MapNull(types.StringType),
+		Config:                   types.MapNull(types.StringType),
+		Permissions:              types.MapNull(types.StringType),
+		ModelMaxBudget:           types.MapNull(types.Float64Type),
+		ModelRPMLimit:            types.MapNull(types.Int64Type),
+		ModelTPMLimit:            types.MapNull(types.Int64Type),
+	}
+
+	updateReq := r.buildKeyRequest(context.Background(), data)
+	updateReq["key"] = data.Key.ValueString()
+
+	// This is the logic under test — mirrors the Update function exactly.
+	if data.RouterSettings.IsNull() {
+		updateReq["router_settings"] = map[string]interface{}{}
+	}
+
+	if err := r.client.DoRequestWithResponse(context.Background(), "POST", "/key/update", updateReq, nil); err != nil {
+		t.Fatalf("POST /key/update: %v", err)
+	}
+
+	// router_settings must be present in the captured request body.
+	routerVal, exists := capturedBody["router_settings"]
+	if !exists {
+		t.Fatal("expected router_settings to be present in request body, but it was omitted")
+	}
+
+	// It must be an empty object, not null, not a non-empty map, not a string.
+	routerMap, ok := routerVal.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected router_settings to be map[string]interface{} (empty object {}), got %T: %v", routerVal, routerVal)
+	}
+	if len(routerMap) != 0 {
+		t.Errorf("expected router_settings to be empty {}, got %v", routerMap)
+	}
+}
+
+// TestReadKeyRouterSettingsNullPreservedAfterClear verifies that readKey does not
+// overwrite a null RouterSettings with data from the API response.
+//
+// After Update sends `{}` to clear router_settings, readKey is called to sync
+// state. At that point data.RouterSettings is null (from the plan). The API may
+// return `"router_settings": {}` (successful clear) or even the old non-empty
+// value (caching delay). Either way, the null must be preserved — writing any
+// non-null value back would contradict the plan and cause Terraform to raise
+// "provider produced inconsistent result after apply".
+func TestReadKeyRouterSettingsNullPreservedAfterClear(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		apiRouterSettings interface{} // what the API returns for router_settings
+	}{
+		{
+			name:            "API returns empty object after clear",
+			apiRouterSettings: map[string]interface{}{},
+		},
+		{
+			name: "API returns stale non-empty value (caching delay)",
+			apiRouterSettings: map[string]interface{}{
+				"timeout":       float64(4),
+				"num_retries":   float64(1),
+				"allowed_fails": float64(1),
+				"fallbacks": []interface{}{
+					map[string]interface{}{
+						"model-a": []interface{}{"model-b"},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{
+					"info": map[string]interface{}{
+						"token":           "sk-clear-test",
+						"router_settings": tc.apiRouterSettings,
+					},
+				})
+			}))
+			defer server.Close()
+
+			res := &KeyResource{
+				client: &Client{
+					APIBase:    server.URL,
+					APIKey:     "test-key",
+					HTTPClient: server.Client(),
+				},
+			}
+
+			// data.RouterSettings is null — simulates the plan after the user
+			// removed router_settings from their Terraform config.
+			data := KeyResourceModel{
+				ID:                       types.StringValue(hashKeyForID("sk-clear-test")),
+				Key:                      types.StringValue("sk-clear-test"),
+				RouterSettings:           types.MapNull(types.StringType),
+				Models:                   types.ListNull(types.StringType),
+				AllowedRoutes:            types.ListNull(types.StringType),
+				AllowedPassthroughRoutes: types.ListNull(types.StringType),
+				AllowedCacheControls:     types.ListNull(types.StringType),
+				Guardrails:               types.ListNull(types.StringType),
+				Prompts:                  types.ListNull(types.StringType),
+				EnforcedParams:           types.ListNull(types.StringType),
+				Tags:                     types.ListNull(types.StringType),
+				Metadata:                 types.MapNull(types.StringType),
+				Aliases:                  types.MapNull(types.StringType),
+				Config:                   types.MapNull(types.StringType),
+				Permissions:              types.MapNull(types.StringType),
+				ModelMaxBudget:           types.MapNull(types.Float64Type),
+				ModelRPMLimit:            types.MapNull(types.Int64Type),
+				ModelTPMLimit:            types.MapNull(types.Int64Type),
+			}
+
+			if err := res.readKey(context.Background(), &data); err != nil {
+				t.Fatalf("readKey returned error: %v", err)
+			}
+
+			// The null must be preserved regardless of what the API returned.
+			if !data.RouterSettings.IsNull() {
+				t.Errorf(
+					"router_settings must remain null after readKey when plan set it to null, "+
+						"but got: %v (API returned: %v)",
+					data.RouterSettings,
+					tc.apiRouterSettings,
+				)
+			}
+		})
+	}
+}
+
+// TestUpdateRouterSettingsPartialRemovalInjectsZeroValueSentinels verifies that
+// when the user removes a key from within router_settings (e.g. removes fallbacks
+// but keeps timeout and num_retries), the Update path injects a zero-value
+// sentinel for the removed key in the request body.
+//
+// Background: the LiteLLM API validates router_settings with Pydantic and does
+// not support partial updates. If fallbacks was previously set and is now absent,
+// the API fills it with None and raises a 422 ("Input should be a valid list",
+// "input":"null"). Injecting [] for removed list-type keys and {} for removed
+// object-type keys prevents that validation failure.
+func TestUpdateRouterSettingsPartialRemovalInjectsZeroValueSentinels(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		stateValue     string // the prior state value for the removed key (as stored in tf state)
+		expectedSentinel interface{} // what should be injected
+	}{
+		{
+			name:             "list-type field (fallbacks) gets empty list sentinel",
+			stateValue:       `[{"model-a":["model-b"]}]`,
+			expectedSentinel: []interface{}{},
+		},
+		{
+			name:             "object-type field gets empty object sentinel",
+			stateValue:       `{"nested":"value"}`,
+			expectedSentinel: map[string]interface{}{},
+		},
+		{
+			name:             "scalar field is omitted (API replaces wholesale)",
+			stateValue:       "5",
+			expectedSentinel: nil, // signals the key should be absent
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := &KeyResource{}
+
+			// Plan: router_settings has timeout + num_retries only ("removed_key" is gone).
+			planSettings := stringMapValue(map[string]string{
+				"timeout":     "5",
+				"num_retries": "1",
+			})
+
+			// State: router_settings had the same keys plus "removed_key".
+			stateSettings := stringMapValue(map[string]string{
+				"timeout":     "5",
+				"num_retries": "1",
+				"removed_key": tc.stateValue,
+			})
+
+			// Build the request from the plan (mirrors what buildKeyRequest does).
+			data := &KeyResourceModel{
+				RouterSettings:           planSettings,
+				Models:                   types.ListNull(types.StringType),
+				AllowedRoutes:            types.ListNull(types.StringType),
+				AllowedPassthroughRoutes: types.ListNull(types.StringType),
+				AllowedCacheControls:     types.ListNull(types.StringType),
+				Guardrails:               types.ListNull(types.StringType),
+				Prompts:                  types.ListNull(types.StringType),
+				EnforcedParams:           types.ListNull(types.StringType),
+				Tags:                     types.ListNull(types.StringType),
+				Metadata:                 types.MapNull(types.StringType),
+				Aliases:                  types.MapNull(types.StringType),
+				Config:                   types.MapNull(types.StringType),
+				Permissions:              types.MapNull(types.StringType),
+				ModelMaxBudget:           types.MapNull(types.Float64Type),
+				ModelRPMLimit:            types.MapNull(types.Int64Type),
+				ModelTPMLimit:            types.MapNull(types.Int64Type),
+			}
+			state := &KeyResourceModel{
+				RouterSettings: stateSettings,
+			}
+
+			updateReq := r.buildKeyRequest(context.Background(), data)
+
+			// Apply the same case-2 logic from Update.
+			if routerMap, ok := updateReq["router_settings"].(map[string]interface{}); ok {
+				if !state.RouterSettings.IsNull() && !state.RouterSettings.IsUnknown() {
+					var stateRouter map[string]string
+					state.RouterSettings.ElementsAs(context.Background(), &stateRouter, false)
+					for k, v := range stateRouter {
+						if _, inPlan := routerMap[k]; !inPlan {
+							trimmed := strings.TrimSpace(v)
+							if strings.HasPrefix(trimmed, "[") {
+								routerMap[k] = []interface{}{}
+							} else if strings.HasPrefix(trimmed, "{") {
+								routerMap[k] = map[string]interface{}{}
+							}
+						}
+					}
+				}
+			}
+
+			routerMap, ok := updateReq["router_settings"].(map[string]interface{})
+			if !ok {
+				t.Fatalf("expected router_settings in request, got %T", updateReq["router_settings"])
+			}
+
+			if tc.expectedSentinel == nil {
+				// Scalar: removed key must be absent from the request.
+				if _, present := routerMap["removed_key"]; present {
+					t.Errorf("scalar removed_key should be omitted from request, got %v", routerMap["removed_key"])
+				}
+			} else {
+				// List/object: sentinel must be present with the correct zero type.
+				val, present := routerMap["removed_key"]
+				if !present {
+					t.Fatalf("expected sentinel for removed_key in request but it was absent")
+				}
+				switch expected := tc.expectedSentinel.(type) {
+				case []interface{}:
+					got, ok := val.([]interface{})
+					if !ok {
+						t.Fatalf("expected []interface{} sentinel, got %T: %v", val, val)
+					}
+					if len(got) != len(expected) {
+						t.Errorf("expected empty slice sentinel, got length %d", len(got))
+					}
+				case map[string]interface{}:
+					got, ok := val.(map[string]interface{})
+					if !ok {
+						t.Fatalf("expected map[string]interface{} sentinel, got %T: %v", val, val)
+					}
+					if len(got) != len(expected) {
+						t.Errorf("expected empty map sentinel, got length %d", len(got))
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestReadKeyRouterSettingsFiltersToConfiguredKeys verifies that readKey only
+// repopulates keys that are present in the user's current config, ignoring any
+// additional keys returned by the API.
+//
+// When the user removes a key (e.g. fallbacks) from router_settings, the Update
+// path injects a zero-value sentinel (fallbacks=[]) into the request to satisfy
+// Pydantic validation. The API then stores and returns that sentinel. Without
+// filtering, readKey would write fallbacks=[] back into state — causing Terraform
+// to see a new element appearing that wasn't in the plan.
+func TestReadKeyRouterSettingsFiltersToConfiguredKeys(t *testing.T) {
+	t.Parallel()
+
+	// API returns the full router_settings including the injected sentinel [].
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"info": map[string]interface{}{
+				"token": "sk-partial-test",
+				"router_settings": map[string]interface{}{
+					"timeout":     float64(5),
+					"num_retries": float64(1),
+					// fallbacks is the sentinel injected by Update — must not appear in state.
+					"fallbacks": []interface{}{},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	res := &KeyResource{
+		client: &Client{
+			APIBase:    server.URL,
+			APIKey:     "test-key",
+			HTTPClient: server.Client(),
+		},
+	}
+
+	// data.RouterSettings reflects the plan: timeout + num_retries only.
+	// fallbacks was removed by the user and must not reappear.
+	data := KeyResourceModel{
+		ID:  types.StringValue(hashKeyForID("sk-partial-test")),
+		Key: types.StringValue("sk-partial-test"),
+		RouterSettings: stringMapValue(map[string]string{
+			"timeout":     "5",
+			"num_retries": "1",
+		}),
+		Models:                   types.ListNull(types.StringType),
+		AllowedRoutes:            types.ListNull(types.StringType),
+		AllowedPassthroughRoutes: types.ListNull(types.StringType),
+		AllowedCacheControls:     types.ListNull(types.StringType),
+		Guardrails:               types.ListNull(types.StringType),
+		Prompts:                  types.ListNull(types.StringType),
+		EnforcedParams:           types.ListNull(types.StringType),
+		Tags:                     types.ListNull(types.StringType),
+		Metadata:                 types.MapNull(types.StringType),
+		Aliases:                  types.MapNull(types.StringType),
+		Config:                   types.MapNull(types.StringType),
+		Permissions:              types.MapNull(types.StringType),
+		ModelMaxBudget:           types.MapNull(types.Float64Type),
+		ModelRPMLimit:            types.MapNull(types.Int64Type),
+		ModelTPMLimit:            types.MapNull(types.Int64Type),
+	}
+
+	if err := res.readKey(context.Background(), &data); err != nil {
+		t.Fatalf("readKey returned error: %v", err)
+	}
+
+	if data.RouterSettings.IsNull() || data.RouterSettings.IsUnknown() {
+		t.Fatal("router_settings should be non-null after read (user still has settings configured)")
+	}
+
+	elems := data.RouterSettings.Elements()
+
+	// timeout and num_retries must be present with the correct values.
+	if v, ok := elems["timeout"].(types.String); !ok || v.ValueString() != "5" {
+		t.Errorf("expected timeout '5', got %v", elems["timeout"])
+	}
+	if v, ok := elems["num_retries"].(types.String); !ok || v.ValueString() != "1" {
+		t.Errorf("expected num_retries '1', got %v", elems["num_retries"])
+	}
+
+	// fallbacks must not appear — it was a sentinel, not part of the user's config.
+	if _, present := elems["fallbacks"]; present {
+		t.Errorf("fallbacks must not appear in state after readKey — it was a zero-value sentinel injected by Update, not a user-configured key. Got: %v", elems["fallbacks"])
+	}
+
+	// Exactly two keys: timeout and num_retries.
+	if len(elems) != 2 {
+		t.Errorf("expected exactly 2 router_settings keys (timeout, num_retries), got %d: %v", len(elems), elems)
+	}
+}

--- a/internal/provider/resource_organization.go
+++ b/internal/provider/resource_organization.go
@@ -332,7 +332,7 @@ func (r *OrganizationResource) buildOrganizationRequest(ctx context.Context, dat
 		var metadata map[string]string
 		data.Metadata.ElementsAs(ctx, &metadata, false)
 		if len(metadata) > 0 {
-			orgReq["metadata"] = convertMetadataToNative(metadata)
+			orgReq["metadata"] = convertJSONStringsToNative(metadata)
 		}
 	}
 
@@ -424,7 +424,7 @@ func (r *OrganizationResource) readOrganization(ctx context.Context, data *Organ
 	if metadata, ok := orgInfo["metadata"].(map[string]interface{}); ok && len(metadata) > 0 {
 		metaMap := make(map[string]attr.Value)
 		for k, v := range metadata {
-			metaMap[k] = types.StringValue(metadataValueToString(v))
+			metaMap[k] = types.StringValue(valueToJSONString(v))
 		}
 		data.Metadata, _ = types.MapValue(types.StringType, metaMap)
 	} else if data.Metadata.IsUnknown() {

--- a/internal/provider/resource_project.go
+++ b/internal/provider/resource_project.go
@@ -341,7 +341,7 @@ func (r *ProjectResource) buildProjectRequest(ctx context.Context, data *Project
 		var metadata map[string]string
 		data.Metadata.ElementsAs(ctx, &metadata, false)
 		if len(metadata) > 0 {
-			req["metadata"] = convertMetadataToNative(metadata)
+			req["metadata"] = convertJSONStringsToNative(metadata)
 		}
 	}
 	if !data.ModelMaxBudget.IsNull() && !data.ModelMaxBudget.IsUnknown() {
@@ -466,7 +466,7 @@ func (r *ProjectResource) readProject(ctx context.Context, data *ProjectResource
 	if metadata, ok := result["metadata"].(map[string]interface{}); ok && len(metadata) > 0 {
 		metaMap := make(map[string]attr.Value)
 		for k, v := range metadata {
-			metaMap[k] = types.StringValue(metadataValueToString(v))
+			metaMap[k] = types.StringValue(valueToJSONString(v))
 		}
 		data.Metadata, _ = types.MapValue(types.StringType, metaMap)
 	} else if data.Metadata.IsUnknown() {

--- a/internal/provider/resource_team.go
+++ b/internal/provider/resource_team.go
@@ -480,7 +480,7 @@ func (r *TeamResource) buildTeamRequest(ctx context.Context, data *TeamResourceM
 		var metadata map[string]string
 		data.Metadata.ElementsAs(ctx, &metadata, false)
 		if len(metadata) > 0 {
-			teamReq["metadata"] = convertMetadataToNative(metadata)
+			teamReq["metadata"] = convertJSONStringsToNative(metadata)
 		}
 	}
 
@@ -651,7 +651,7 @@ func (r *TeamResource) readTeam(ctx context.Context, data *TeamResourceModel) er
 			if len(configuredKeys) > 0 && !configuredKeys[k] {
 				continue
 			}
-			metaMap[k] = types.StringValue(metadataValueToString(v))
+			metaMap[k] = types.StringValue(valueToJSONString(v))
 		}
 		if len(metaMap) > 0 {
 			data.Metadata, _ = types.MapValue(types.StringType, metaMap)


### PR DESCRIPTION
Resolves: https://github.com/ncecere/terraform-provider-litellm/issues/97

## Summary

- Adds fully typed router_settings block to the litellm_key resource and datasource, covering all 21 LiteLLM router fields
- Supports scalars (timeouts, retries, routing strategy, cooldowns, tag filtering), fallback lists (fallbacks, context_window_fallbacks, content_policy_fallbacks), map fields, and a nested retry_policy object
- Per-key router configuration overrides team and global settings at the key level

## Changes

- internal/provider/resource_key.go — router_settings schema, KeyRouterSettingsModel, KeyRetryPolicyModel, buildKeyRouterSettingsPayload, parseKeyRouterSettingsFromAPI, and scalar API helpers
- internal/provider/datasource_key.go — router_settings as a Computed nested attribute with read support via parseKeyRouterSettingsFromAPI
- internal/provider/resource_key_test.go — Tests for payload serialization, API deserialization, and read integration for typed router settings