### PR TITLE
feat: add send_invite_email support for key and user resources

### DIFF
--- a/docs/resources/key.md
+++ b/docs/resources/key.md
@@ -172,6 +172,8 @@ The following arguments are supported:
 
 * `blocked` - (Optional) Whether this key is blocked.
 
+* `send_invite_email` - (Optional) Whether to send an invite email when creating or updating this key. This is an action parameter — it triggers an email side-effect but is not stored as persistent state by LiteLLM. If not specified, no invite email is sent.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/docs/resources/key.md
+++ b/docs/resources/key.md
@@ -174,6 +174,8 @@ The following arguments are supported:
 
 * `blocked` - (Optional) Whether this key is blocked.
 
+* `send_invite_email` - (Optional) Whether to send an invite email when creating or updating this key. This is an action parameter — it triggers an email side-effect but is not stored as persistent state by LiteLLM. If not specified, no invite email is sent.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -48,6 +48,7 @@ The following arguments are supported:
 * `tpm_limit` - (Optional) Tokens per minute limit for the user.
 * `rpm_limit` - (Optional) Requests per minute limit for the user.
 * `auto_create_key` - (Optional) Whether to automatically create an API key when the user is created. Defaults to `true`.
+* `send_invite_email` - (Optional) Whether to send an invite email when creating or updating this user. This is an action parameter — it triggers an email side-effect but is not stored as persistent state by LiteLLM. If not specified, no invite email is sent.
 * `teams` - (Optional) List of team IDs the user belongs to.
 * `models` - (Optional) List of model names the user is allowed to use.
 * `metadata` - (Optional) A map of key-value metadata pairs for the user.

--- a/internal/provider/resource_key.go
+++ b/internal/provider/resource_key.go
@@ -71,6 +71,7 @@ type KeyResourceModel struct {
 	EnforcedParams           types.List    `tfsdk:"enforced_params"`
 	Tags                     types.List    `tfsdk:"tags"`
 	Blocked                  types.Bool    `tfsdk:"blocked"`
+	SendInviteEmail          types.Bool    `tfsdk:"send_invite_email"`
 }
 
 func (r *KeyResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -261,6 +262,10 @@ func (r *KeyResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 				Description: "Whether the key is blocked.",
 				Optional:    true,
 				Computed:    true,
+			},
+			"send_invite_email": schema.BoolAttribute{
+				Description: "Whether to send an invite email when creating or updating this key. This is an action parameter that triggers an email but is not stored as persistent state.",
+				Optional:    true,
 			},
 		},
 	}
@@ -525,6 +530,9 @@ func (r *KeyResource) buildKeyRequest(ctx context.Context, data *KeyResourceMode
 	// Boolean fields - check IsNull and IsUnknown
 	if !data.Blocked.IsNull() && !data.Blocked.IsUnknown() {
 		keyReq["blocked"] = data.Blocked.ValueBool()
+	}
+	if !data.SendInviteEmail.IsNull() && !data.SendInviteEmail.IsUnknown() {
+		keyReq["send_invite_email"] = data.SendInviteEmail.ValueBool()
 	}
 
 	// Models list - special handling for team models

--- a/internal/provider/resource_key.go
+++ b/internal/provider/resource_key.go
@@ -72,6 +72,7 @@ type KeyResourceModel struct {
 	EnforcedParams           types.List    `tfsdk:"enforced_params"`
 	Tags                     types.List    `tfsdk:"tags"`
 	Blocked                  types.Bool    `tfsdk:"blocked"`
+	SendInviteEmail          types.Bool    `tfsdk:"send_invite_email"`
 }
 
 func (r *KeyResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -266,6 +267,10 @@ func (r *KeyResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 				Description: "Whether the key is blocked.",
 				Optional:    true,
 				Computed:    true,
+			},
+			"send_invite_email": schema.BoolAttribute{
+				Description: "Whether to send an invite email when creating or updating this key. This is an action parameter that triggers an email but is not stored as persistent state.",
+				Optional:    true,
 			},
 		},
 	}
@@ -533,6 +538,9 @@ func (r *KeyResource) buildKeyRequest(ctx context.Context, data *KeyResourceMode
 	// Boolean fields - check IsNull and IsUnknown
 	if !data.Blocked.IsNull() && !data.Blocked.IsUnknown() {
 		keyReq["blocked"] = data.Blocked.ValueBool()
+	}
+	if !data.SendInviteEmail.IsNull() && !data.SendInviteEmail.IsUnknown() {
+		keyReq["send_invite_email"] = data.SendInviteEmail.ValueBool()
 	}
 
 	// Models list - special handling for team models

--- a/internal/provider/resource_key_test.go
+++ b/internal/provider/resource_key_test.go
@@ -1235,3 +1235,41 @@ func TestReadKeyPopulatesUnknownKey(t *testing.T) {
 		t.Errorf("key should remain %q, got %q", apiReturnedKey, data.Key.ValueString())
 	}
 }
+
+// TestBuildKeyRequestSendInviteEmail verifies that send_invite_email is included
+// in the API request when set and omitted when null.
+func TestBuildKeyRequestSendInviteEmail(t *testing.T) {
+	t.Parallel()
+
+	r := &KeyResource{}
+
+	t.Run("included when true", func(t *testing.T) {
+		data := &KeyResourceModel{
+			SendInviteEmail: types.BoolValue(true),
+		}
+		req := r.buildKeyRequest(context.Background(), data)
+		if req["send_invite_email"] != true {
+			t.Errorf("expected send_invite_email true, got %v", req["send_invite_email"])
+		}
+	})
+
+	t.Run("included when false", func(t *testing.T) {
+		data := &KeyResourceModel{
+			SendInviteEmail: types.BoolValue(false),
+		}
+		req := r.buildKeyRequest(context.Background(), data)
+		if req["send_invite_email"] != false {
+			t.Errorf("expected send_invite_email false, got %v", req["send_invite_email"])
+		}
+	})
+
+	t.Run("omitted when null", func(t *testing.T) {
+		data := &KeyResourceModel{
+			SendInviteEmail: types.BoolNull(),
+		}
+		req := r.buildKeyRequest(context.Background(), data)
+		if _, exists := req["send_invite_email"]; exists {
+			t.Errorf("send_invite_email should not be in request when null")
+		}
+	})
+}

--- a/internal/provider/resource_key_test.go
+++ b/internal/provider/resource_key_test.go
@@ -1409,3 +1409,41 @@ func TestReadKeyPopulatesUnknownKey(t *testing.T) {
 		t.Errorf("key should remain %q, got %q", apiReturnedKey, data.Key.ValueString())
 	}
 }
+
+// TestBuildKeyRequestSendInviteEmail verifies that send_invite_email is included
+// in the API request when set and omitted when null.
+func TestBuildKeyRequestSendInviteEmail(t *testing.T) {
+	t.Parallel()
+
+	r := &KeyResource{}
+
+	t.Run("included when true", func(t *testing.T) {
+		data := &KeyResourceModel{
+			SendInviteEmail: types.BoolValue(true),
+		}
+		req := r.buildKeyRequest(context.Background(), data)
+		if req["send_invite_email"] != true {
+			t.Errorf("expected send_invite_email true, got %v", req["send_invite_email"])
+		}
+	})
+
+	t.Run("included when false", func(t *testing.T) {
+		data := &KeyResourceModel{
+			SendInviteEmail: types.BoolValue(false),
+		}
+		req := r.buildKeyRequest(context.Background(), data)
+		if req["send_invite_email"] != false {
+			t.Errorf("expected send_invite_email false, got %v", req["send_invite_email"])
+		}
+	})
+
+	t.Run("omitted when null", func(t *testing.T) {
+		data := &KeyResourceModel{
+			SendInviteEmail: types.BoolNull(),
+		}
+		req := r.buildKeyRequest(context.Background(), data)
+		if _, exists := req["send_invite_email"]; exists {
+			t.Errorf("send_invite_email should not be in request when null")
+		}
+	})
+}

--- a/internal/provider/resource_user.go
+++ b/internal/provider/resource_user.go
@@ -39,8 +39,9 @@ type UserResourceModel struct {
 	BudgetDuration types.String  `tfsdk:"budget_duration"`
 	TPMLimit       types.Int64   `tfsdk:"tpm_limit"`
 	RPMLimit       types.Int64   `tfsdk:"rpm_limit"`
-	AutoCreateKey  types.Bool    `tfsdk:"auto_create_key"`
-	Metadata       types.Map     `tfsdk:"metadata"`
+	AutoCreateKey   types.Bool    `tfsdk:"auto_create_key"`
+	SendInviteEmail types.Bool    `tfsdk:"send_invite_email"`
+	Metadata        types.Map     `tfsdk:"metadata"`
 	Key            types.String  `tfsdk:"key"`
 }
 
@@ -123,6 +124,10 @@ func (r *UserResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 				Optional:    true,
 				Computed:    true,
 				Default:     booldefault.StaticBool(true),
+			},
+			"send_invite_email": schema.BoolAttribute{
+				Description: "Whether to send an invite email when creating or updating this user. This is an action parameter that triggers an email but is not stored as persistent state.",
+				Optional:    true,
 			},
 			"metadata": schema.MapAttribute{
 				Description: "Metadata for the user.",
@@ -308,6 +313,9 @@ func (r *UserResource) buildUserRequest(ctx context.Context, data *UserResourceM
 	// Boolean fields - check IsNull and IsUnknown (auto_create_key has default)
 	if !data.AutoCreateKey.IsNull() && !data.AutoCreateKey.IsUnknown() {
 		userReq["auto_create_key"] = data.AutoCreateKey.ValueBool()
+	}
+	if !data.SendInviteEmail.IsNull() && !data.SendInviteEmail.IsUnknown() {
+		userReq["send_invite_email"] = data.SendInviteEmail.ValueBool()
 	}
 
 	// List fields - check IsNull, IsUnknown, and len > 0

--- a/internal/provider/resource_user.go
+++ b/internal/provider/resource_user.go
@@ -28,20 +28,21 @@ type UserResource struct {
 }
 
 type UserResourceModel struct {
-	ID             types.String  `tfsdk:"id"`
-	UserID         types.String  `tfsdk:"user_id"`
-	UserAlias      types.String  `tfsdk:"user_alias"`
-	UserEmail      types.String  `tfsdk:"user_email"`
-	UserRole       types.String  `tfsdk:"user_role"`
-	Teams          types.List    `tfsdk:"teams"`
-	Models         types.List    `tfsdk:"models"`
-	MaxBudget      types.Float64 `tfsdk:"max_budget"`
-	BudgetDuration types.String  `tfsdk:"budget_duration"`
-	TPMLimit       types.Int64   `tfsdk:"tpm_limit"`
-	RPMLimit       types.Int64   `tfsdk:"rpm_limit"`
-	AutoCreateKey  types.Bool    `tfsdk:"auto_create_key"`
-	Metadata       types.Map     `tfsdk:"metadata"`
-	Key            types.String  `tfsdk:"key"`
+	ID              types.String  `tfsdk:"id"`
+	UserID          types.String  `tfsdk:"user_id"`
+	UserAlias       types.String  `tfsdk:"user_alias"`
+	UserEmail       types.String  `tfsdk:"user_email"`
+	UserRole        types.String  `tfsdk:"user_role"`
+	Teams           types.List    `tfsdk:"teams"`
+	Models          types.List    `tfsdk:"models"`
+	MaxBudget       types.Float64 `tfsdk:"max_budget"`
+	BudgetDuration  types.String  `tfsdk:"budget_duration"`
+	TPMLimit        types.Int64   `tfsdk:"tpm_limit"`
+	RPMLimit        types.Int64   `tfsdk:"rpm_limit"`
+	AutoCreateKey   types.Bool    `tfsdk:"auto_create_key"`
+	SendInviteEmail types.Bool    `tfsdk:"send_invite_email"`
+	Metadata        types.Map     `tfsdk:"metadata"`
+	Key             types.String  `tfsdk:"key"`
 }
 
 func (r *UserResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -123,6 +124,10 @@ func (r *UserResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 				Optional:    true,
 				Computed:    true,
 				Default:     booldefault.StaticBool(true),
+			},
+			"send_invite_email": schema.BoolAttribute{
+				Description: "Whether to send an invite email when creating or updating this user. This is an action parameter that triggers an email but is not stored as persistent state.",
+				Optional:    true,
 			},
 			"metadata": schema.MapAttribute{
 				Description: "Metadata for the user.",
@@ -308,6 +313,9 @@ func (r *UserResource) buildUserRequest(ctx context.Context, data *UserResourceM
 	// Boolean fields - check IsNull and IsUnknown (auto_create_key has default)
 	if !data.AutoCreateKey.IsNull() && !data.AutoCreateKey.IsUnknown() {
 		userReq["auto_create_key"] = data.AutoCreateKey.ValueBool()
+	}
+	if !data.SendInviteEmail.IsNull() && !data.SendInviteEmail.IsUnknown() {
+		userReq["send_invite_email"] = data.SendInviteEmail.ValueBool()
 	}
 
 	// List fields - check IsNull, IsUnknown, and len > 0

--- a/internal/provider/resource_user_test.go
+++ b/internal/provider/resource_user_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"context"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -214,5 +215,43 @@ func TestOldBehaviorWouldFail(t *testing.T) {
 			t.Errorf("old behavior created list with %d elements, expected 0", len(oldBehaviorResult.Elements()))
 		}
 		// This empty list != null, which is what Terraform would detect as inconsistent
+	})
+}
+
+// TestBuildUserRequestSendInviteEmail verifies that send_invite_email is included
+// in the API request when set and omitted when null.
+func TestBuildUserRequestSendInviteEmail(t *testing.T) {
+	t.Parallel()
+
+	r := &UserResource{}
+
+	t.Run("included when true", func(t *testing.T) {
+		data := &UserResourceModel{
+			SendInviteEmail: types.BoolValue(true),
+		}
+		req := r.buildUserRequest(context.Background(), data)
+		if req["send_invite_email"] != true {
+			t.Errorf("expected send_invite_email true, got %v", req["send_invite_email"])
+		}
+	})
+
+	t.Run("included when false", func(t *testing.T) {
+		data := &UserResourceModel{
+			SendInviteEmail: types.BoolValue(false),
+		}
+		req := r.buildUserRequest(context.Background(), data)
+		if req["send_invite_email"] != false {
+			t.Errorf("expected send_invite_email false, got %v", req["send_invite_email"])
+		}
+	})
+
+	t.Run("omitted when null", func(t *testing.T) {
+		data := &UserResourceModel{
+			SendInviteEmail: types.BoolNull(),
+		}
+		req := r.buildUserRequest(context.Background(), data)
+		if _, exists := req["send_invite_email"]; exists {
+			t.Errorf("send_invite_email should not be in request when null")
+		}
 	})
 }

--- a/internal/provider/resource_user_test.go
+++ b/internal/provider/resource_user_test.go
@@ -282,3 +282,41 @@ func TestOldBehaviorWouldFail(t *testing.T) {
 		// This empty list != null, which is what Terraform would detect as inconsistent
 	})
 }
+
+// TestBuildUserRequestSendInviteEmail verifies that send_invite_email is included
+// in the API request when set and omitted when null.
+func TestBuildUserRequestSendInviteEmail(t *testing.T) {
+	t.Parallel()
+
+	r := &UserResource{}
+
+	t.Run("included when true", func(t *testing.T) {
+		data := &UserResourceModel{
+			SendInviteEmail: types.BoolValue(true),
+		}
+		req := r.buildUserRequest(context.Background(), data)
+		if req["send_invite_email"] != true {
+			t.Errorf("expected send_invite_email true, got %v", req["send_invite_email"])
+		}
+	})
+
+	t.Run("included when false", func(t *testing.T) {
+		data := &UserResourceModel{
+			SendInviteEmail: types.BoolValue(false),
+		}
+		req := r.buildUserRequest(context.Background(), data)
+		if req["send_invite_email"] != false {
+			t.Errorf("expected send_invite_email false, got %v", req["send_invite_email"])
+		}
+	})
+
+	t.Run("omitted when null", func(t *testing.T) {
+		data := &UserResourceModel{
+			SendInviteEmail: types.BoolNull(),
+		}
+		req := r.buildUserRequest(context.Background(), data)
+		if _, exists := req["send_invite_email"]; exists {
+			t.Errorf("send_invite_email should not be in request when null")
+		}
+	})
+}


### PR DESCRIPTION
Resolves #100

## Summary

Adds an optional `send_invite_email` boolean parameter to the `litellm_key` and `litellm_user` resources. When set to `true`, LiteLLM sends an invite email to the associated user during create/update operations.

## Changes

- **`internal/provider/resource_key.go`** — Added `send_invite_email` to schema and `buildKeyRequest`
- **`internal/provider/resource_user.go`** — Added `send_invite_email` to schema and `buildUserRequest`
- **`internal/provider/resource_key_test.go`** — Unit tests for true/false/null handling
- **`internal/provider/resource_user_test.go`** — Unit tests for true/false/null handling
- **`docs/resources/key.md`** — Documented new attribute
- **`docs/resources/user.md`** — Documented new attribute

## Design Notes

- **Action parameter**: triggers an email side effect but is not stored as persistent state by LiteLLM
- `Optional` only (not `Computed`) — never read back from the API
- Omitted from API requests when unset/`null`, preserving existing behaviour

## Example Usage

```hcl
resource "litellm_user" "onboarded" {
  user_email        = "newuser@example.com"
  user_role         = "internal_user"
  send_invite_email = true
}

resource "litellm_key" "onboarded_key" {
  user_id           = litellm_user.onboarded.user_id
  send_invite_email = true
}
```

## Test Plan

- Unit tests cover `send_invite_email` set to `true`, `false`, and `null` for both resources
- Manual verification with a running LiteLLM proxy confirms `terraform plan` and `terraform apply` work as expected