### PR TITLE
fix: preserve masked guardrail secrets on read and add tests

### DIFF
--- a/docs/resources/guardrail.md
+++ b/docs/resources/guardrail.md
@@ -62,7 +62,7 @@ The following arguments are supported:
 
 - `guardrail_id` - (String, ForceNew) The unique identifier for the guardrail. If not provided, one will be generated automatically. Changing this forces creation of a new resource.
 - `default_on` - (Bool) Whether this guardrail is enabled by default for all requests.
-- `litellm_params` - (String) A JSON-encoded string containing provider-specific parameters. This field stores only additional configuration specific to the guardrail provider (it does not include `guardrail`, `mode`, or `default_on`, which are top-level attributes). When reading back from the API, only the keys originally configured by the user are preserved, preventing the API's default values from appearing in state.
+- `litellm_params` - (String) A JSON-encoded string containing provider-specific parameters. This field stores only additional configuration specific to the guardrail provider (it does not include `guardrail`, `mode`, or `default_on`, which are top-level attributes). When reading back from the API, only keys originally configured by the user are written to state (so extra server-side keys and broad defaults are not added); among those keys, values LiteLLM masks on read keep the configured secrets, and other values use the API response when present.
 - `guardrail_info` - (String) A JSON-encoded string containing additional metadata or information about the guardrail.
 
 ## Attribute Reference

--- a/internal/provider/resource_guardrail.go
+++ b/internal/provider/resource_guardrail.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -278,6 +279,62 @@ func (r *GuardrailResource) buildGuardrailRequest(ctx context.Context, data *Gua
 	}
 }
 
+// guardrailLitellmParamKeyMaskedByLiteLLM returns true if LiteLLM's _get_masked_values would mask
+// this dict key when returning GET /guardrails/{id}/info. The keywords must stay aligned with:
+// litellm/litellm_core_utils/litellm_logging.py — sensitive_keywords in _get_masked_values.
+//
+// Values for such keys are replaced with partial-prefix/suffix + asterisks in the API response;
+// writing those into Terraform state breaks applies for real secrets. We keep the user's value.
+//
+// Note: matching is substring-based (e.g. "key" matches "api_key" and also "monkey"); that mirrors LiteLLM.
+func guardrailLitellmParamKeyMaskedByLiteLLM(key string) bool {
+	kl := strings.ToLower(key)
+	return strings.Contains(kl, "authorization") ||
+		strings.Contains(kl, "token") ||
+		strings.Contains(kl, "key") ||
+		strings.Contains(kl, "secret") ||
+		strings.Contains(kl, "vertex_credentials")
+}
+
+// mergeGuardrailLitellmParamsFromRead rebuilds the litellm_params JSON string for state after a read.
+// For each key the user configured in additional litellm_params (excluding top-level duplicates
+// guardrail, mode, default_on): if LiteLLM would mask that key, keep the user's value; otherwise
+// prefer the API value when present so non-secret fields can reflect server-side updates.
+func mergeGuardrailLitellmParamsFromRead(userJSON string, apiLitellmParams map[string]interface{}) (string, error) {
+	var userParams map[string]interface{}
+	if err := json.Unmarshal([]byte(userJSON), &userParams); err != nil {
+		return "", err
+	}
+
+	merged := make(map[string]interface{})
+	for k := range userParams {
+		if k == "guardrail" || k == "mode" || k == "default_on" {
+			continue
+		}
+		userVal, userOK := userParams[k]
+		apiVal, apiOK := apiLitellmParams[k]
+
+		switch {
+		case guardrailLitellmParamKeyMaskedByLiteLLM(k) && userOK:
+			merged[k] = userVal
+		case apiOK:
+			merged[k] = apiVal
+		case userOK:
+			merged[k] = userVal
+		}
+	}
+
+	if len(merged) == 0 {
+		return "", nil
+	}
+
+	out, err := json.Marshal(merged)
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
 func (r *GuardrailResource) readGuardrail(ctx context.Context, data *GuardrailResourceModel) error {
 	guardrailID := data.GuardrailID.ValueString()
 	if guardrailID == "" {
@@ -323,28 +380,14 @@ func (r *GuardrailResource) readGuardrail(ctx context.Context, data *GuardrailRe
 			}
 		}
 
-		// Store other litellm_params as JSON (excluding guardrail, mode, default_on).
-		// Only update if the user originally configured litellm_params to avoid
-		// adopting the API's massive default parameter set.
-		// Additionally, only preserve the keys the user originally configured to
-		// prevent the API's expanded defaults from being stored in state.
-		if !data.LitellmParams.IsNull() && !data.LitellmParams.IsUnknown() {
-			// Parse the user's original litellm_params to get configured keys
-			var userParams map[string]interface{}
-			if err := json.Unmarshal([]byte(data.LitellmParams.ValueString()), &userParams); err == nil {
-				otherParams := make(map[string]interface{})
-				for k := range userParams {
-					if k != "guardrail" && k != "mode" && k != "default_on" {
-						if v, exists := litellmParams[k]; exists {
-							otherParams[k] = v
-						}
-					}
-				}
-				if len(otherParams) > 0 {
-					if jsonBytes, err := json.Marshal(otherParams); err == nil {
-						data.LitellmParams = types.StringValue(string(jsonBytes))
-					}
-				}
+		// Merge user-configured litellm_params with GET /guardrails/{id}/info for keys the user set.
+		// LiteLLM masks values whose keys match sensitive_keywords in _get_masked_values (see
+		// guardrailLitellmParamKeyMaskedByLiteLLM). For those keys we keep the configured value;
+		// for other keys we take the API value when present so non-secrets can drift with the server.
+		if !data.LitellmParams.IsNull() && !data.LitellmParams.IsUnknown() && data.LitellmParams.ValueString() != "" {
+			merged, err := mergeGuardrailLitellmParamsFromRead(data.LitellmParams.ValueString(), litellmParams)
+			if err == nil && merged != "" {
+				data.LitellmParams = types.StringValue(merged)
 			}
 		}
 	}

--- a/internal/provider/resource_guardrail_test.go
+++ b/internal/provider/resource_guardrail_test.go
@@ -1,0 +1,410 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestGuardrailLitellmParamKeyMaskedByLiteLLM(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		key  string
+		want bool
+	}{
+		{"api_key", true},
+		{"API_KEY", true},
+		{"aws_secret_access_key", true},
+		{"authorization_header", true},
+		{"vertex_credentials", true},
+		{"token_endpoint", true},
+		{"api_base", false},
+		{"guardrailIdentifier", false},
+		{"mode", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			t.Parallel()
+			if got := guardrailLitellmParamKeyMaskedByLiteLLM(tt.key); got != tt.want {
+				t.Errorf("guardrailLitellmParamKeyMaskedByLiteLLM(%q) = %v, want %v", tt.key, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMergeGuardrailLitellmParamsFromRead(t *testing.T) {
+	t.Parallel()
+
+	t.Run("preserves sensitive keys from user and takes non-sensitive from API", func(t *testing.T) {
+		t.Parallel()
+		userJSON := `{"api_key":"real-secret","api_base":"https://new.example"}`
+		api := map[string]interface{}{
+			"api_key":  "sk-****",
+			"api_base": "https://new.example",
+		}
+		out, err := mergeGuardrailLitellmParamsFromRead(userJSON, api)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var m map[string]interface{}
+		if err := json.Unmarshal([]byte(out), &m); err != nil {
+			t.Fatal(err)
+		}
+		if m["api_key"] != "real-secret" {
+			t.Errorf("api_key: got %v", m["api_key"])
+		}
+		if m["api_base"] != "https://new.example" {
+			t.Errorf("api_base: got %v", m["api_base"])
+		}
+	})
+
+	t.Run("empty user object returns empty string", func(t *testing.T) {
+		t.Parallel()
+		out, err := mergeGuardrailLitellmParamsFromRead("{}", map[string]interface{}{"api_base": "x"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if out != "" {
+			t.Errorf("got %q, want empty", out)
+		}
+	})
+
+	t.Run("skips guardrail mode default_on keys in user JSON", func(t *testing.T) {
+		t.Parallel()
+		userJSON := `{"guardrail":"x","mode":"pre_call","default_on":true,"api_base":"https://a"}`
+		api := map[string]interface{}{
+			"guardrail": "bedrock",
+			"mode":      "pre_call",
+			"api_base":  "https://b",
+		}
+		out, err := mergeGuardrailLitellmParamsFromRead(userJSON, api)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var m map[string]interface{}
+		if err := json.Unmarshal([]byte(out), &m); err != nil {
+			t.Fatal(err)
+		}
+		if len(m) != 1 || m["api_base"] != "https://b" {
+			t.Fatalf("unexpected merge: %#v", m)
+		}
+	})
+}
+
+// TestReadGuardrailPreservesSensitiveMergesNonSensitive verifies read merges API values for
+// non-sensitive litellm_params keys while keeping real secrets from config (LiteLLM masks those on GET).
+func TestReadGuardrailPreservesSensitiveMergesNonSensitive(t *testing.T) {
+	t.Parallel()
+
+	const userSecret = "sk-real-secret-from-user"
+	const userBase = "https://crowdstrike.example/v1"
+	const apiBaseUpdated = "https://updated.example/v1"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"guardrail_id":   "11111111-1111-1111-1111-111111111111",
+			"guardrail_name": "crowdstrike-aidr",
+			"created_at":     "2024-01-01T00:00:00Z",
+			"litellm_params": map[string]interface{}{
+				"guardrail":  "crowdstrike_aidr",
+				"mode":       []interface{}{},
+				"default_on": true,
+				"api_key":    "sk-****",
+				"api_base":   apiBaseUpdated,
+			},
+			"guardrail_info": map[string]interface{}{},
+		})
+	}))
+	defer server.Close()
+
+	res := &GuardrailResource{
+		client: &Client{
+			APIBase:    server.URL,
+			APIKey:     "test-key",
+			HTTPClient: server.Client(),
+		},
+	}
+
+	userLitellmParams := `{"api_key":` + jsonString(userSecret) + `,"api_base":` + jsonString(userBase) + `}`
+	data := GuardrailResourceModel{
+		ID:            types.StringValue("11111111-1111-1111-1111-111111111111"),
+		GuardrailID:   types.StringValue("11111111-1111-1111-1111-111111111111"),
+		GuardrailName: types.StringValue("crowdstrike-aidr"),
+		Guardrail:     types.StringValue("crowdstrike_aidr"),
+		Mode:          types.StringValue("[]"),
+		DefaultOn:     types.BoolValue(true),
+		LitellmParams: types.StringValue(userLitellmParams),
+	}
+
+	if err := res.readGuardrail(context.Background(), &data); err != nil {
+		t.Fatalf("readGuardrail: %v", err)
+	}
+
+	var got map[string]interface{}
+	if err := json.Unmarshal([]byte(data.LitellmParams.ValueString()), &got); err != nil {
+		t.Fatalf("parse litellm_params: %v", err)
+	}
+	if got["api_key"] != userSecret {
+		t.Errorf("api_key: got %q, want real secret preserved", got["api_key"])
+	}
+	if got["api_base"] != apiBaseUpdated {
+		t.Errorf("api_base: got %v, want API value %q", got["api_base"], apiBaseUpdated)
+	}
+
+	if data.GuardrailName.ValueString() != "crowdstrike-aidr" {
+		t.Errorf("guardrail_name: got %q", data.GuardrailName.ValueString())
+	}
+	if data.CreatedAt.ValueString() != "2024-01-01T00:00:00Z" {
+		t.Errorf("created_at: got %q", data.CreatedAt.ValueString())
+	}
+}
+
+func jsonString(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}
+
+// TestReadGuardrailUpdatesOtherFieldsWhenLitellmParamsUnset verifies that when litellm_params is not set,
+// read still refreshes guardrail metadata from the API and leaves litellm_params null.
+func TestReadGuardrailUpdatesOtherFieldsWhenLitellmParamsUnset(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"guardrail_id":   "22222222-2222-2222-2222-222222222222",
+			"guardrail_name": "bedrock-guard",
+			"created_at":     "2025-06-15T12:00:00Z",
+			"litellm_params": map[string]interface{}{
+				"guardrail":  "bedrock",
+				"mode":       "pre_call",
+				"default_on": false,
+			},
+		})
+	}))
+	defer server.Close()
+
+	res := &GuardrailResource{
+		client: &Client{
+			APIBase:    server.URL,
+			APIKey:     "test-key",
+			HTTPClient: server.Client(),
+		},
+	}
+
+	data := GuardrailResourceModel{
+		ID:            types.StringValue("22222222-2222-2222-2222-222222222222"),
+		GuardrailID:   types.StringValue("22222222-2222-2222-2222-222222222222"),
+		GuardrailName: types.StringValue("bedrock-guard"),
+		Guardrail:     types.StringValue("bedrock"),
+		Mode:          types.StringValue("pre_call"),
+		LitellmParams: types.StringNull(),
+	}
+
+	if err := res.readGuardrail(context.Background(), &data); err != nil {
+		t.Fatalf("readGuardrail: %v", err)
+	}
+
+	if !data.LitellmParams.IsNull() {
+		t.Errorf("expected litellm_params to stay null, got %v", data.LitellmParams)
+	}
+	if data.Guardrail.ValueString() != "bedrock" {
+		t.Errorf("guardrail: got %q", data.Guardrail.ValueString())
+	}
+	if data.CreatedAt.ValueString() != "2025-06-15T12:00:00Z" {
+		t.Errorf("created_at: got %q", data.CreatedAt.ValueString())
+	}
+}
+
+func TestBuildGuardrailRequest(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	r := &GuardrailResource{}
+
+	t.Run("mode as JSON array string", func(t *testing.T) {
+		t.Parallel()
+		data := GuardrailResourceModel{
+			GuardrailName: types.StringValue("g"),
+			Guardrail:     types.StringValue("crowdstrike_aidr"),
+			Mode:          types.StringValue(`[]`),
+			DefaultOn:     types.BoolValue(true),
+			LitellmParams: types.StringValue(`{"api_base":"https://x"}`),
+		}
+		body := r.buildGuardrailRequest(ctx, &data)
+		g := body["guardrail"].(map[string]interface{})
+		lp := g["litellm_params"].(map[string]interface{})
+		mode := lp["mode"]
+		arr, ok := mode.([]string)
+		if !ok || len(arr) != 0 {
+			t.Fatalf("mode: got %#v, want empty []string", mode)
+		}
+		if lp["guardrail"] != "crowdstrike_aidr" || lp["default_on"] != true {
+			t.Fatalf("litellm_params: %#v", lp)
+		}
+		if lp["api_base"] != "https://x" {
+			t.Errorf("api_base merge: %v", lp["api_base"])
+		}
+	})
+
+	t.Run("mode as scalar string", func(t *testing.T) {
+		t.Parallel()
+		data := GuardrailResourceModel{
+			GuardrailName: types.StringValue("g"),
+			Guardrail:     types.StringValue("lakera"),
+			Mode:          types.StringValue("pre_call"),
+			LitellmParams: types.StringNull(),
+		}
+		body := r.buildGuardrailRequest(ctx, &data)
+		lp := body["guardrail"].(map[string]interface{})["litellm_params"].(map[string]interface{})
+		if lp["mode"] != "pre_call" {
+			t.Errorf("mode: %v", lp["mode"])
+		}
+	})
+
+	t.Run("optional guardrail_id and guardrail_info", func(t *testing.T) {
+		t.Parallel()
+		data := GuardrailResourceModel{
+			GuardrailID:   types.StringValue("uuid-here"),
+			GuardrailName: types.StringValue("n"),
+			Guardrail:     types.StringValue("bedrock"),
+			Mode:          types.StringValue("pre_call"),
+			GuardrailInfo: types.StringValue(`{"description":"d"}`),
+		}
+		body := r.buildGuardrailRequest(ctx, &data)
+		g := body["guardrail"].(map[string]interface{})
+		if g["guardrail_id"] != "uuid-here" {
+			t.Errorf("guardrail_id: %v", g["guardrail_id"])
+		}
+		info := g["guardrail_info"].(map[string]interface{})
+		if info["description"] != "d" {
+			t.Errorf("guardrail_info: %#v", info)
+		}
+	})
+
+	t.Run("invalid litellm_params JSON is skipped", func(t *testing.T) {
+		t.Parallel()
+		data := GuardrailResourceModel{
+			GuardrailName: types.StringValue("g"),
+			Guardrail:     types.StringValue("x"),
+			Mode:          types.StringValue("pre_call"),
+			LitellmParams: types.StringValue(`not-json`),
+		}
+		body := r.buildGuardrailRequest(ctx, &data)
+		lp := body["guardrail"].(map[string]interface{})["litellm_params"].(map[string]interface{})
+		if _, ok := lp["not"]; ok {
+			t.Fatal("unexpected merge from invalid JSON")
+		}
+	})
+}
+
+// TestReadGuardrailUpdatesGuardrailInfoFromAPI verifies guardrail_info is refreshed from GET.
+func TestReadGuardrailUpdatesGuardrailInfoFromAPI(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"guardrail_id":   "33333333-3333-3333-3333-333333333333",
+			"guardrail_name": "gi",
+			"created_at":     "2020-01-01T00:00:00Z",
+			"litellm_params": map[string]interface{}{
+				"guardrail": "aporia",
+				"mode":      "pre_call",
+			},
+			"guardrail_info": map[string]interface{}{
+				"description": "from-api",
+				"extra":       float64(1),
+			},
+		})
+	}))
+	defer server.Close()
+
+	res := &GuardrailResource{
+		client: &Client{
+			APIBase:    server.URL,
+			APIKey:     "test-key",
+			HTTPClient: server.Client(),
+		},
+	}
+
+	data := GuardrailResourceModel{
+		ID:            types.StringValue("33333333-3333-3333-3333-333333333333"),
+		GuardrailID:   types.StringValue("33333333-3333-3333-3333-333333333333"),
+		GuardrailName: types.StringValue("gi"),
+		Guardrail:     types.StringValue("aporia"),
+		Mode:          types.StringValue("pre_call"),
+		LitellmParams: types.StringNull(),
+		GuardrailInfo: types.StringValue(`{"description":"old"}`),
+	}
+
+	if err := res.readGuardrail(context.Background(), &data); err != nil {
+		t.Fatalf("readGuardrail: %v", err)
+	}
+
+	var info map[string]interface{}
+	if err := json.Unmarshal([]byte(data.GuardrailInfo.ValueString()), &info); err != nil {
+		t.Fatal(err)
+	}
+	if info["description"] != "from-api" || info["extra"] != float64(1) {
+		t.Fatalf("guardrail_info: %#v", info)
+	}
+}
+
+// TestReadGuardrailModeArrayRoundTrip checks mode [] serializes consistently after read.
+func TestReadGuardrailModeArrayRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"guardrail_id":   "44444444-4444-4444-4444-444444444444",
+			"guardrail_name": "m",
+			"litellm_params": map[string]interface{}{
+				"guardrail": "g",
+				"mode":      []interface{}{"pre_call", "post_call"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	res := &GuardrailResource{
+		client: &Client{
+			APIBase:    server.URL,
+			APIKey:     "test-key",
+			HTTPClient: server.Client(),
+		},
+	}
+
+	data := GuardrailResourceModel{
+		ID:            types.StringValue("44444444-4444-4444-4444-444444444444"),
+		GuardrailID:   types.StringValue("44444444-4444-4444-4444-444444444444"),
+		GuardrailName: types.StringValue("m"),
+		Guardrail:     types.StringValue("g"),
+		Mode:          types.StringValue(`["pre_call","post_call"]`),
+		LitellmParams: types.StringNull(),
+	}
+
+	if err := res.readGuardrail(context.Background(), &data); err != nil {
+		t.Fatalf("readGuardrail: %v", err)
+	}
+
+	var want []interface{}
+	_ = json.Unmarshal([]byte(`["pre_call","post_call"]`), &want)
+	var got []interface{}
+	if err := json.Unmarshal([]byte(data.Mode.ValueString()), &got); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("mode: got %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
This PR improves `litellm_guardrail` state handling for `litellm_params` when LiteLLM masks sensitive values on read.

Previously, during `Read`, the provider could write masked API values (for example `sk-****`) into Terraform state for sensitive keys, which could cause drift/noisy plans and break idempotency for secret-backed configs.

This change updates the read merge behavior so that:

- only keys originally configured by the user in `litellm_params` are considered
- top-level keys (`guardrail`, `mode`, `default_on`) are excluded from `litellm_params` merge logic
- for keys LiteLLM masks on read (e.g. key/token/secret/authorization-related), the configured user value is preserved in state
- for non-sensitive keys, API response values are preferred when present so non-secret fields can still reflect server-side updates
- if no user keys remain after filtering, `litellm_params` stays empty

## Why
LiteLLM masks sensitive values in guardrail responses, which is good for security, but those masked values should not overwrite real configured secrets in Terraform state. This PR keeps state stable and avoids unnecessary diffs while still allowing non-sensitive values to refresh from the API.

## Changes
- Updated guardrail read/merge logic in `internal/provider/resource_guardrail.go`
  - added sensitive-key matcher for LiteLLM masking behavior
  - added merge helper for user-configured `litellm_params` keys
- Added guardrail unit tests in `internal/provider/resource_guardrail_test.go` covering:
  - sensitive key detection
  - merge behavior (sensitive preserved, non-sensitive refreshed)
  - skipping `guardrail` / `mode` / `default_on` keys
  - behavior when `litellm_params` is unset/null
  - mode round-trip behavior
  - guardrail_info refresh behavior
- Updated docs in `docs/resources/guardrail.md` to reflect new read-state behavior for masked secrets and non-sensitive keys

## Test Plan
- `go test ./internal/provider -run Guardrail -count=1`
- Manual smoke run (existing flow) to ensure no regression in provider lifecycle behavior
