### PR TITLE
Fix: send explicit null to clear team budget and nullable fields

### DIFF
--- a/internal/provider/resource_team.go
+++ b/internal/provider/resource_team.go
@@ -315,31 +315,7 @@ func (r *TeamResource) Update(ctx context.Context, req resource.UpdateRequest, r
 
 	data.ID = state.ID
 	teamReq := r.buildTeamRequest(ctx, &data, data.ID.ValueString())
-
-	// Detect fields cleared in this update (non-null in state → null in plan).
-	// Send explicit nil so json.Marshal produces JSON null, which tells the
-	// LiteLLM API (Pydantic exclude_unset=True) to actually clear the value.
-	if !state.MaxBudget.IsNull() && data.MaxBudget.IsNull() {
-		teamReq["max_budget"] = nil
-	}
-	if !state.BudgetDuration.IsNull() && data.BudgetDuration.IsNull() {
-		teamReq["budget_duration"] = nil
-	}
-	if !state.TPMLimit.IsNull() && data.TPMLimit.IsNull() {
-		teamReq["tpm_limit"] = nil
-	}
-	if !state.RPMLimit.IsNull() && data.RPMLimit.IsNull() {
-		teamReq["rpm_limit"] = nil
-	}
-	if !state.TeamMemberBudget.IsNull() && data.TeamMemberBudget.IsNull() {
-		teamReq["team_member_budget"] = nil
-	}
-	if !state.TeamMemberRPMLimit.IsNull() && data.TeamMemberRPMLimit.IsNull() {
-		teamReq["team_member_rpm_limit"] = nil
-	}
-	if !state.TeamMemberTPMLimit.IsNull() && data.TeamMemberTPMLimit.IsNull() {
-		teamReq["team_member_tpm_limit"] = nil
-	}
+	applyTeamNullableClears(teamReq, &state, &data)
 
 	if err := r.client.DoRequestWithResponse(ctx, "POST", "/team/update", teamReq, nil); err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update team: %s", err))
@@ -518,6 +494,35 @@ func (r *TeamResource) buildTeamRequest(ctx context.Context, data *TeamResourceM
 	return teamReq
 }
 
+// applyTeamNullableClears mutates teamReq to send explicit JSON null for nullable
+// fields that transition from set (non-null in state) to cleared (null in plan).
+// Without this, json.Marshal omits the field entirely; the LiteLLM API uses Pydantic
+// exclude_unset=True and ignores omitted fields, so the prior value persists and
+// Terraform sees "Provider produced inconsistent result after apply".
+func applyTeamNullableClears(teamReq map[string]interface{}, state, plan *TeamResourceModel) {
+	if !state.MaxBudget.IsNull() && plan.MaxBudget.IsNull() {
+		teamReq["max_budget"] = nil
+	}
+	if !state.BudgetDuration.IsNull() && plan.BudgetDuration.IsNull() {
+		teamReq["budget_duration"] = nil
+	}
+	if !state.TPMLimit.IsNull() && plan.TPMLimit.IsNull() {
+		teamReq["tpm_limit"] = nil
+	}
+	if !state.RPMLimit.IsNull() && plan.RPMLimit.IsNull() {
+		teamReq["rpm_limit"] = nil
+	}
+	if !state.TeamMemberBudget.IsNull() && plan.TeamMemberBudget.IsNull() {
+		teamReq["team_member_budget"] = nil
+	}
+	if !state.TeamMemberRPMLimit.IsNull() && plan.TeamMemberRPMLimit.IsNull() {
+		teamReq["team_member_rpm_limit"] = nil
+	}
+	if !state.TeamMemberTPMLimit.IsNull() && plan.TeamMemberTPMLimit.IsNull() {
+		teamReq["team_member_tpm_limit"] = nil
+	}
+}
+
 // buildRouterSettingsPayload converts the Terraform router_settings object into
 // the LiteLLM API wire format where each fallback entry is a single-key dict:
 // [{"primary_model": ["fallback1", "fallback2"]}]
@@ -577,9 +582,13 @@ func (r *TeamResource) readTeam(ctx context.Context, data *TeamResourceModel) er
 	}
 	if tpm, ok := teamInfo["tpm_limit"].(float64); ok {
 		data.TPMLimit = types.Int64Value(int64(tpm))
+	} else {
+		data.TPMLimit = types.Int64Null()
 	}
 	if rpm, ok := teamInfo["rpm_limit"].(float64); ok {
 		data.RPMLimit = types.Int64Value(int64(rpm))
+	} else {
+		data.RPMLimit = types.Int64Null()
 	}
 	if maxBudget, ok := teamInfo["max_budget"].(float64); ok {
 		data.MaxBudget = types.Float64Value(maxBudget)

--- a/internal/provider/resource_team.go
+++ b/internal/provider/resource_team.go
@@ -316,6 +316,31 @@ func (r *TeamResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	data.ID = state.ID
 	teamReq := r.buildTeamRequest(ctx, &data, data.ID.ValueString())
 
+	// Detect fields cleared in this update (non-null in state → null in plan).
+	// Send explicit nil so json.Marshal produces JSON null, which tells the
+	// LiteLLM API (Pydantic exclude_unset=True) to actually clear the value.
+	if !state.MaxBudget.IsNull() && data.MaxBudget.IsNull() {
+		teamReq["max_budget"] = nil
+	}
+	if !state.BudgetDuration.IsNull() && data.BudgetDuration.IsNull() {
+		teamReq["budget_duration"] = nil
+	}
+	if !state.TPMLimit.IsNull() && data.TPMLimit.IsNull() {
+		teamReq["tpm_limit"] = nil
+	}
+	if !state.RPMLimit.IsNull() && data.RPMLimit.IsNull() {
+		teamReq["rpm_limit"] = nil
+	}
+	if !state.TeamMemberBudget.IsNull() && data.TeamMemberBudget.IsNull() {
+		teamReq["team_member_budget"] = nil
+	}
+	if !state.TeamMemberRPMLimit.IsNull() && data.TeamMemberRPMLimit.IsNull() {
+		teamReq["team_member_rpm_limit"] = nil
+	}
+	if !state.TeamMemberTPMLimit.IsNull() && data.TeamMemberTPMLimit.IsNull() {
+		teamReq["team_member_tpm_limit"] = nil
+	}
+
 	if err := r.client.DoRequestWithResponse(ctx, "POST", "/team/update", teamReq, nil); err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update team: %s", err))
 		return
@@ -558,9 +583,13 @@ func (r *TeamResource) readTeam(ctx context.Context, data *TeamResourceModel) er
 	}
 	if maxBudget, ok := teamInfo["max_budget"].(float64); ok {
 		data.MaxBudget = types.Float64Value(maxBudget)
+	} else {
+		data.MaxBudget = types.Float64Null()
 	}
 	if budgetDuration, ok := teamInfo["budget_duration"].(string); ok && budgetDuration != "" {
 		data.BudgetDuration = types.StringValue(budgetDuration)
+	} else {
+		data.BudgetDuration = types.StringNull()
 	}
 	if blocked, ok := teamInfo["blocked"].(bool); ok {
 		data.Blocked = types.BoolValue(blocked)
@@ -573,12 +602,18 @@ func (r *TeamResource) readTeam(ctx context.Context, data *TeamResourceModel) er
 	}
 	if teamMemberBudget, ok := teamInfo["team_member_budget"].(float64); ok {
 		data.TeamMemberBudget = types.Float64Value(teamMemberBudget)
+	} else {
+		data.TeamMemberBudget = types.Float64Null()
 	}
 	if teamMemberRPMLimit, ok := teamInfo["team_member_rpm_limit"].(float64); ok {
 		data.TeamMemberRPMLimit = types.Int64Value(int64(teamMemberRPMLimit))
+	} else {
+		data.TeamMemberRPMLimit = types.Int64Null()
 	}
 	if teamMemberTPMLimit, ok := teamInfo["team_member_tpm_limit"].(float64); ok {
 		data.TeamMemberTPMLimit = types.Int64Value(int64(teamMemberTPMLimit))
+	} else {
+		data.TeamMemberTPMLimit = types.Int64Null()
 	}
 
 	// Handle models list - preserve null when API returns empty and config didn't specify models

--- a/internal/provider/resource_team_member.go
+++ b/internal/provider/resource_team_member.go
@@ -166,10 +166,7 @@ func (r *TeamMemberResource) Update(ctx context.Context, req resource.UpdateRequ
 		updateReq["max_budget_in_team"] = data.MaxBudgetInTeam.ValueFloat64()
 	}
 
-	// Send explicit null when budget is being cleared (was set, now removed)
-	if !state.MaxBudgetInTeam.IsNull() && data.MaxBudgetInTeam.IsNull() {
-		updateReq["max_budget_in_team"] = nil
-	}
+	applyTeamMemberNullableClears(updateReq, &state, &data)
 
 	if err := r.client.DoRequestWithResponse(ctx, "POST", "/team/member_update", updateReq, nil); err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update team member: %s", err))
@@ -212,4 +209,13 @@ func (r *TeamMemberResource) ImportState(ctx context.Context, req resource.Impor
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("team_id"), parts[0])...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("user_id"), parts[1])...)
+}
+
+// applyTeamMemberNullableClears mutates updateReq to send explicit JSON null for
+// nullable fields that transition from set (non-null in state) to cleared (null in
+// plan). See applyTeamNullableClears in resource_team.go for the rationale.
+func applyTeamMemberNullableClears(updateReq map[string]interface{}, state, plan *TeamMemberResourceModel) {
+	if !state.MaxBudgetInTeam.IsNull() && plan.MaxBudgetInTeam.IsNull() {
+		updateReq["max_budget_in_team"] = nil
+	}
 }

--- a/internal/provider/resource_team_member.go
+++ b/internal/provider/resource_team_member.go
@@ -166,6 +166,11 @@ func (r *TeamMemberResource) Update(ctx context.Context, req resource.UpdateRequ
 		updateReq["max_budget_in_team"] = data.MaxBudgetInTeam.ValueFloat64()
 	}
 
+	// Send explicit null when budget is being cleared (was set, now removed)
+	if !state.MaxBudgetInTeam.IsNull() && data.MaxBudgetInTeam.IsNull() {
+		updateReq["max_budget_in_team"] = nil
+	}
+
 	if err := r.client.DoRequestWithResponse(ctx, "POST", "/team/member_update", updateReq, nil); err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update team member: %s", err))
 		return

--- a/internal/provider/resource_team_member_test.go
+++ b/internal/provider/resource_team_member_test.go
@@ -1,0 +1,71 @@
+package provider
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// TestApplyTeamMemberNullableClears_TransitionToNull verifies that clearing
+// max_budget_in_team in plan (was set in state) results in explicit JSON null
+// on the wire — required because the LiteLLM API ignores omitted fields under
+// Pydantic exclude_unset=True.
+func TestApplyTeamMemberNullableClears_TransitionToNull(t *testing.T) {
+	t.Parallel()
+
+	state := &TeamMemberResourceModel{
+		MaxBudgetInTeam: types.Float64Value(50),
+	}
+	plan := &TeamMemberResourceModel{
+		MaxBudgetInTeam: types.Float64Null(),
+	}
+
+	updateReq := map[string]interface{}{"team_id": "team-1", "user_id": "user-1"}
+	applyTeamMemberNullableClears(updateReq, state, plan)
+
+	v, ok := updateReq["max_budget_in_team"]
+	if !ok {
+		t.Fatal("updateReq missing max_budget_in_team after clear; expected explicit nil")
+	}
+	if v != nil {
+		t.Errorf("updateReq[max_budget_in_team] = %v, want nil", v)
+	}
+
+	body, err := json.Marshal(updateReq)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+	if !strings.Contains(string(body), `"max_budget_in_team":null`) {
+		t.Errorf("request body missing \"max_budget_in_team\":null; got %s", string(body))
+	}
+}
+
+// TestApplyTeamMemberNullableClears_NoTransition_NoOp verifies the helper does
+// not inject the key when state and plan agree.
+func TestApplyTeamMemberNullableClears_NoTransition_NoOp(t *testing.T) {
+	t.Parallel()
+
+	// Both null: no key injected.
+	state := &TeamMemberResourceModel{MaxBudgetInTeam: types.Float64Null()}
+	plan := &TeamMemberResourceModel{MaxBudgetInTeam: types.Float64Null()}
+
+	updateReq := map[string]interface{}{}
+	applyTeamMemberNullableClears(updateReq, state, plan)
+
+	if _, ok := updateReq["max_budget_in_team"]; ok {
+		t.Errorf("helper added max_budget_in_team when no transition; got %v", updateReq)
+	}
+
+	// Both set (stable value): existing value preserved.
+	state = &TeamMemberResourceModel{MaxBudgetInTeam: types.Float64Value(50)}
+	plan = &TeamMemberResourceModel{MaxBudgetInTeam: types.Float64Value(75)}
+
+	updateReq = map[string]interface{}{"max_budget_in_team": float64(75)}
+	applyTeamMemberNullableClears(updateReq, state, plan)
+
+	if v := updateReq["max_budget_in_team"]; v != float64(75) {
+		t.Errorf("helper overwrote stable max_budget_in_team; got %v, want 75", v)
+	}
+}

--- a/internal/provider/resource_team_test.go
+++ b/internal/provider/resource_team_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -501,5 +502,102 @@ func TestReadTeam_DetectsDriftWhenAPIStillHasFallbacks(t *testing.T) {
 	// so Terraform detects the drift and plans to clear it.
 	if data.RouterSettings.IsNull() {
 		t.Fatal("router_settings should NOT be null -- API still has fallbacks, Terraform must detect drift")
+	}
+}
+
+// TestApplyTeamNullableClears_AllTransitionsEmitNull verifies that when each
+// nullable field transitions from set in state → null in plan, the resulting
+// map carries explicit nil and json.Marshal serializes it as JSON null.
+// This guards against regressions where omitting the field instead of sending
+// null would let the LiteLLM API (Pydantic exclude_unset=True) keep stale values.
+func TestApplyTeamNullableClears_AllTransitionsEmitNull(t *testing.T) {
+	t.Parallel()
+
+	state := &TeamResourceModel{
+		MaxBudget:          types.Float64Value(100),
+		BudgetDuration:     types.StringValue("30d"),
+		TPMLimit:           types.Int64Value(1000),
+		RPMLimit:           types.Int64Value(60),
+		TeamMemberBudget:   types.Float64Value(50),
+		TeamMemberRPMLimit: types.Int64Value(10),
+		TeamMemberTPMLimit: types.Int64Value(500),
+	}
+	plan := &TeamResourceModel{
+		MaxBudget:          types.Float64Null(),
+		BudgetDuration:     types.StringNull(),
+		TPMLimit:           types.Int64Null(),
+		RPMLimit:           types.Int64Null(),
+		TeamMemberBudget:   types.Float64Null(),
+		TeamMemberRPMLimit: types.Int64Null(),
+		TeamMemberTPMLimit: types.Int64Null(),
+	}
+
+	teamReq := map[string]interface{}{"team_id": "team-123"}
+	applyTeamNullableClears(teamReq, state, plan)
+
+	expectedNullKeys := []string{
+		"max_budget", "budget_duration", "tpm_limit", "rpm_limit",
+		"team_member_budget", "team_member_rpm_limit", "team_member_tpm_limit",
+	}
+	for _, k := range expectedNullKeys {
+		v, ok := teamReq[k]
+		if !ok {
+			t.Errorf("teamReq missing key %q after clear; expected explicit nil", k)
+			continue
+		}
+		if v != nil {
+			t.Errorf("teamReq[%q] = %v, want nil", k, v)
+		}
+	}
+
+	body, err := json.Marshal(teamReq)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+	bodyStr := string(body)
+	for _, k := range expectedNullKeys {
+		needle := `"` + k + `":null`
+		if !strings.Contains(bodyStr, needle) {
+			t.Errorf("request body missing %s; got %s", needle, bodyStr)
+		}
+	}
+}
+
+// TestApplyTeamNullableClears_NoTransition_NoOp verifies the helper does not
+// inject keys when state and plan agree (both null, or both set) — only the
+// non-null → null transition triggers explicit clears.
+func TestApplyTeamNullableClears_NoTransition_NoOp(t *testing.T) {
+	t.Parallel()
+
+	// Both null (field never set): helper must not introduce keys.
+	state := &TeamResourceModel{
+		MaxBudget:      types.Float64Null(),
+		BudgetDuration: types.StringNull(),
+		TPMLimit:       types.Int64Null(),
+		RPMLimit:       types.Int64Null(),
+	}
+	plan := &TeamResourceModel{
+		MaxBudget:      types.Float64Null(),
+		BudgetDuration: types.StringNull(),
+		TPMLimit:       types.Int64Null(),
+		RPMLimit:       types.Int64Null(),
+	}
+
+	teamReq := map[string]interface{}{}
+	applyTeamNullableClears(teamReq, state, plan)
+
+	if len(teamReq) != 0 {
+		t.Errorf("teamReq should be empty when no transitions; got %v", teamReq)
+	}
+
+	// Both set (stable value): helper must not overwrite to nil.
+	state = &TeamResourceModel{MaxBudget: types.Float64Value(100)}
+	plan = &TeamResourceModel{MaxBudget: types.Float64Value(200)}
+
+	teamReq = map[string]interface{}{"max_budget": float64(200)}
+	applyTeamNullableClears(teamReq, state, plan)
+
+	if v := teamReq["max_budget"]; v != float64(200) {
+		t.Errorf("helper overwrote stable max_budget; got %v, want 200", v)
 	}
 }


### PR DESCRIPTION
Fixes #99 — see issue for full description.

When nullable fields are removed from Terraform config, the provider now sends explicit JSON null instead of omitting the field. This is required because the LiteLLM API uses Pydantic `exclude_unset=True` and ignores omitted fields, so the old value persists and Terraform sees `Provider produced inconsistent result after apply`.

Also fixes `readTeam()` to properly reset state to null when the API returns null.

## Changes

- `resource_team.go`:
  - `Update()` sends explicit `nil` for 7 nullable fields when transitioning non-null → null: `max_budget`, `budget_duration`, `tpm_limit`, `rpm_limit`, `team_member_budget`, `team_member_rpm_limit`, `team_member_tpm_limit`
  - `readTeam()` adds `else`-null branches for 5 fields so state is reset when API returns null: `max_budget`, `budget_duration`, `team_member_budget`, `team_member_rpm_limit`, `team_member_tpm_limit`
- `resource_team_member.go`:
  - `Update()` sends explicit `nil` for `max_budget_in_team` when cleared

## Verification

- `go build ./...` — clean
- `go test ./...` — all tests pass