### PR TITLE
fix(team_member): treat 'already in team' as idempotent success

### DIFF
--- a/internal/provider/resource_team_member.go
+++ b/internal/provider/resource_team_member.go
@@ -118,6 +118,12 @@ func (r *TeamMemberResource) Create(ctx context.Context, req resource.CreateRequ
 	}
 
 	if err := r.client.DoRequestWithResponse(ctx, "POST", "/team/member_add", memberReq, nil); err != nil {
+		// If user is already in team, treat as success (idempotent create).
+		if contains(err.Error(), "status 400") && contains(err.Error(), "team_member_already_in_team") {
+			data.ID = types.StringValue(fmt.Sprintf("%s:%s", data.TeamID.ValueString(), data.UserID.ValueString()))
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+			return
+		}
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to add team member: %s", err))
 		return
 	}


### PR DESCRIPTION
- Fix: handle "already in team" as idempotent create in `litellm_team_member`
    - When creating a litellm_team_member for a user that is already in the team (e.g., added manually via UI or by a previous run with lost state), the provider currently fails with:
  API request failed with status 400: {"type":"team_member_already_in_team"...}
  
    This requires manual terraform import to recover, which is problematic for e.g. automated pipelines.
    This change catches the "already in team" error during Create and treats it as success - saving the existing membership to state.
    
- Note: When adopting an existing membership, the state uses the user_id from the Terraform config, which may differ from the actual user_id in LiteLLM. This is consistent with the current behavior where the Read function preserves state as-is without re-fetching from the API.
  