### PR TITLE
fix(model): carry forward additional_litellm_params keys the API omits on read

### DIFF
--- a/internal/provider/resource_model.go
+++ b/internal/provider/resource_model.go
@@ -667,6 +667,25 @@ func (r *ModelResource) readModel(ctx context.Context, data *ModelResourceModel)
 			}
 		}
 
+		// Carry forward keys the user configured in additional_litellm_params
+		// that the API does not echo back in litellm_params (e.g. tags,
+		// max_retries, timeout, stream_timeout). Without this, those keys are
+		// dropped on read-back and Terraform fails the post-apply consistency
+		// check with "element <key> has vanished" ("Provider produced
+		// inconsistent result after apply"). We only do this during normal
+		// Read (filterByState), preserving the value from prior state; on
+		// Import we intentionally reflect the full API state instead.
+		if filterByState {
+			priorParams := data.AdditionalLiteLLMParams.Elements()
+			for k := range stateKeys {
+				if _, present := additionalParams[k]; !present {
+					if prior, ok := priorParams[k]; ok {
+						additionalParams[k] = prior
+					}
+				}
+			}
+		}
+
 		// Set additional_litellm_params from API response to detect drift
 		// for keys that the user configured.
 		data.AdditionalLiteLLMParams, _ = types.MapValue(types.StringType, additionalParams)


### PR DESCRIPTION
## What

During `Read`, `litellm_model` rebuilds `additional_litellm_params` solely from the keys present in the API's `litellm_params`. Params that LiteLLM accepts on write but does not echo back in `/model/info` (e.g. `tags`, `max_retries`, `timeout`, `stream_timeout`) are therefore dropped on read-back.

Since the attribute is `Optional + Computed` and the user configured it, Terraform requires an exact round-trip and fails with:

```
Error: Provider produced inconsistent result after apply
.additional_litellm_params: element "<key>" has vanished.
```

The apply already reached the API, so the resource can never converge — every apply fails on the consistency check.

Fixes #120.

## Change

During normal `Read` (`filterByState`), carry forward any user-configured keys (present in prior state) that the API did not return, instead of silently dropping them. Import behaviour is unchanged — it still reflects the full API state.

```go
if filterByState {
    priorParams := data.AdditionalLiteLLMParams.Elements()
    for k := range stateKeys {
        if _, present := additionalParams[k]; !present {
            if prior, ok := priorParams[k]; ok {
                additionalParams[k] = prior
            }
        }
    }
}
```

## Why this is safe

- Only runs when the user configured `additional_litellm_params` (`filterByState`); a resource that doesn't set it is unaffected.
- Only fills keys that are **absent** from the API response — it never overrides a value the API did return, so genuine drift is still detected.
- Uses the value already in prior state, so no fabricated data enters state.
- Import path (state null/unknown) is untouched.

## Testing

The bug is reproduced against a self-hosted LiteLLM OSS proxy with the config in the linked issue — every apply fails with the "vanished" errors for `tags` / `max_retries` / `timeout` / `stream_timeout`.

Full disclosure: I have not been able to run the provider's test suite or a live apply with the patched binary in my environment. The change is small and self-contained; I'd appreciate a maintainer running CI / an acceptance test against it. Happy to iterate on the approach (e.g. gate it behind the existing known-params handling differently) if preferred.
