### PR TITLE
fix(model): preserve JSON additional_litellm_params on read (formatting + masking)

### DIFF
--- a/internal/provider/resource_model.go
+++ b/internal/provider/resource_model.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -617,7 +618,9 @@ func (r *ModelResource) readModel(ctx context.Context, data *ModelResourceModel)
 		// the imported resource captures the full API state.
 		filterByState := !data.AdditionalLiteLLMParams.IsNull() && !data.AdditionalLiteLLMParams.IsUnknown()
 		stateKeys := make(map[string]struct{})
+		priorStrings := make(map[string]string)
 		if filterByState {
+			data.AdditionalLiteLLMParams.ElementsAs(ctx, &priorStrings, false)
 			for k := range data.AdditionalLiteLLMParams.Elements() {
 				stateKeys[k] = struct{}{}
 			}
@@ -662,7 +665,17 @@ func (r *ModelResource) readModel(ctx context.Context, data *ModelResourceModel)
 			default:
 				// Arrays, objects, and other complex types — serialize back to JSON string.
 				if jsonBytes, err := json.Marshal(v); err == nil {
-					additionalParams[key] = types.StringValue(string(jsonBytes))
+					// If the prior config/state value is JSON that is semantically
+					// equal to the API-returned value, preserve the prior string.
+					// json.Marshal emits compact, key-sorted JSON, so a config
+					// value like {"inputs": "{prompt}"} would otherwise round-trip
+					// to {"inputs":"{prompt}"} and fail the post-apply consistency
+					// check purely on formatting.
+					if prior, ok := priorStrings[key]; ok && jsonSemanticallyEqual(prior, string(jsonBytes)) {
+						additionalParams[key] = types.StringValue(prior)
+					} else {
+						additionalParams[key] = types.StringValue(string(jsonBytes))
+					}
 				}
 			}
 		}
@@ -936,6 +949,22 @@ func normalizeNumericString(s string) string {
 		return strconv.FormatFloat(f, 'f', -1, 64)
 	}
 	return s
+}
+
+// jsonSemanticallyEqual reports whether two strings are both valid JSON that
+// decode to the same value, ignoring formatting differences (whitespace, key
+// ordering). Used on read-back so a JSON-valued additional_litellm_params
+// entry that only differs from the provider's compact re-marshal by formatting
+// is not treated as drift.
+func jsonSemanticallyEqual(a, b string) bool {
+	var av, bv interface{}
+	if err := json.Unmarshal([]byte(a), &av); err != nil {
+		return false
+	}
+	if err := json.Unmarshal([]byte(b), &bv); err != nil {
+		return false
+	}
+	return reflect.DeepEqual(av, bv)
 }
 
 // normalizeAdditionalParams returns a new MapValue where every numeric string

--- a/internal/provider/resource_model.go
+++ b/internal/provider/resource_model.go
@@ -665,16 +665,26 @@ func (r *ModelResource) readModel(ctx context.Context, data *ModelResourceModel)
 			default:
 				// Arrays, objects, and other complex types — serialize back to JSON string.
 				if jsonBytes, err := json.Marshal(v); err == nil {
-					// If the prior config/state value is JSON that is semantically
-					// equal to the API-returned value, preserve the prior string.
-					// json.Marshal emits compact, key-sorted JSON, so a config
-					// value like {"inputs": "{prompt}"} would otherwise round-trip
-					// to {"inputs":"{prompt}"} and fail the post-apply consistency
-					// check purely on formatting.
-					if prior, ok := priorStrings[key]; ok && jsonSemanticallyEqual(prior, string(jsonBytes)) {
+					apiJSON := string(jsonBytes)
+					prior, hasPrior := priorStrings[key]
+					switch {
+					// Preserve the prior string when it's semantically equal to
+					// the API value: json.Marshal emits compact, key-sorted JSON,
+					// so a config value like {"inputs": "{prompt}"} would
+					// otherwise round-trip to {"inputs":"{prompt}"} and fail the
+					// post-apply consistency check purely on formatting.
+					case hasPrior && jsonSemanticallyEqual(prior, apiJSON):
 						additionalParams[key] = types.StringValue(prior)
-					} else {
-						additionalParams[key] = types.StringValue(string(jsonBytes))
+					// Also preserve it when the value has the same SHAPE but
+					// differing scalar leaves -- LiteLLM masks/encrypts secret
+					// values (e.g. an x-api-key inside extra_headers) on read, so
+					// the API value never matches what was sent. We can't
+					// distinguish masking from real drift, so we carry forward the
+					// prior value, mirroring how model_api_key/aws_* are handled.
+					case hasPrior && jsonSameShape(prior, apiJSON):
+						additionalParams[key] = types.StringValue(prior)
+					default:
+						additionalParams[key] = types.StringValue(apiJSON)
 					}
 				}
 			}
@@ -965,6 +975,69 @@ func jsonSemanticallyEqual(a, b string) bool {
 		return false
 	}
 	return reflect.DeepEqual(av, bv)
+}
+
+// jsonSameShape reports whether two JSON strings have the same structure --
+// same object keys (recursively) and same array lengths -- ignoring differences
+// in scalar (string/number/bool) leaf values. It's used to detect the case
+// where LiteLLM returns a value whose secret leaves have been masked/encrypted
+// on read (e.g. an x-api-key inside extra_headers): the shape is identical but
+// a scalar differs. In that case we can't tell a masked value from a genuinely
+// changed one, so the caller preserves the prior state value rather than fail
+// the post-apply consistency check on what is almost always just masking.
+// (This mirrors how model_api_key and the aws_* secret fields are already
+// carried forward from state rather than trusted from the API response.)
+func jsonSameShape(a, b string) bool {
+	var av, bv interface{}
+	if err := json.Unmarshal([]byte(a), &av); err != nil {
+		return false
+	}
+	if err := json.Unmarshal([]byte(b), &bv); err != nil {
+		return false
+	}
+	return sameShape(av, bv)
+}
+
+func sameShape(a, b interface{}) bool {
+	switch at := a.(type) {
+	case map[string]interface{}:
+		bt, ok := b.(map[string]interface{})
+		if !ok || len(at) != len(bt) {
+			return false
+		}
+		for k, av := range at {
+			bv, present := bt[k]
+			if !present || !sameShape(av, bv) {
+				return false
+			}
+		}
+		return true
+	case []interface{}:
+		bt, ok := b.([]interface{})
+		if !ok || len(at) != len(bt) {
+			return false
+		}
+		for i := range at {
+			if !sameShape(at[i], bt[i]) {
+				return false
+			}
+		}
+		return true
+	default:
+		// Scalars (string, float64, bool, nil): shape matches if both are
+		// scalars of a compatible kind. Differing scalar VALUES are treated as
+		// the same shape -- that's the masking case we want to tolerate.
+		return !isJSONContainer(b)
+	}
+}
+
+func isJSONContainer(v interface{}) bool {
+	switch v.(type) {
+	case map[string]interface{}, []interface{}:
+		return true
+	default:
+		return false
+	}
 }
 
 // normalizeAdditionalParams returns a new MapValue where every numeric string

--- a/internal/provider/resource_model_test.go
+++ b/internal/provider/resource_model_test.go
@@ -231,6 +231,36 @@ func TestJSONSemanticallyEqual(t *testing.T) {
 	}
 }
 
+func TestJSONSameShape(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		a    string
+		b    string
+		want bool
+	}{
+		// Masking case: same keys, a scalar value differs (secret masked on read).
+		{"masked scalar value", `{"x-api-key":"realsecret","X-Model-Id":"m"}`, `{"x-api-key":"sk-masked-abc","X-Model-Id":"m"}`, true},
+		{"identical", `{"x-api-key":"a"}`, `{"x-api-key":"a"}`, true},
+		{"nested masked", `{"h":{"k":"real"}}`, `{"h":{"k":"masked"}}`, true},
+		{"array same len differing scalars", `["a","b"]`, `["x","y"]`, true},
+		// Not the same shape -- real structural drift, should NOT be tolerated.
+		{"extra key", `{"a":"1"}`, `{"a":"1","b":"2"}`, false},
+		{"missing key", `{"a":"1","b":"2"}`, `{"a":"1"}`, false},
+		{"renamed key", `{"a":"1"}`, `{"b":"1"}`, false},
+		{"array length differs", `["a"]`, `["a","b"]`, false},
+		{"scalar vs object", `{"a":"1"}`, `"1"`, false},
+		{"a not json", `not json`, `{"a":"1"}`, false},
+	}
+
+	for _, tt := range tests {
+		if got := jsonSameShape(tt.a, tt.b); got != tt.want {
+			t.Errorf("%s: jsonSameShape(%q, %q) = %v, want %v", tt.name, tt.a, tt.b, got, tt.want)
+		}
+	}
+}
+
 func TestCreateModelSendsAdditionalLiteLLMParams(t *testing.T) {
 	t.Parallel()
 
@@ -536,6 +566,63 @@ func TestReadModelExtractsAdditionalLiteLLMParams(t *testing.T) {
 	}
 	if got := additional["max_retries"]; got != "3" {
 		t.Fatalf("expected max_retries=3, got %q", got)
+	}
+}
+
+// TestReadModelPreservesMaskedExtraHeaders verifies that when LiteLLM returns
+// a JSON-valued additional_litellm_params entry (e.g. extra_headers) with a
+// secret leaf masked/encrypted, readModel preserves the prior state value
+// instead of the masked API value -- otherwise every apply fails the
+// post-apply consistency check ("inconsistent result after apply").
+func TestReadModelPreservesMaskedExtraHeaders(t *testing.T) {
+	t.Parallel()
+
+	// API returns extra_headers with x-api-key masked (same shape, changed scalar).
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": []interface{}{
+				map[string]interface{}{
+					"model_name": "needs-attribution-classifier-xlab",
+					"litellm_params": map[string]interface{}{
+						"custom_llm_provider": "openai",
+						"model":               "openai/checkpoint-3400",
+						"extra_headers": map[string]interface{}{
+							"x-api-key":  "sk-masked-9999999999",
+							"X-Model-Id": "needs-attribution-classifier-xlab",
+						},
+					},
+					"model_info": map[string]interface{}{"base_model": "checkpoint-3400"},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	r := &ModelResource{
+		client: &Client{APIBase: server.URL, APIKey: "test-key", HTTPClient: server.Client()},
+	}
+
+	priorHeaders := `{"x-api-key":"realsecret","X-Model-Id":"needs-attribution-classifier-xlab"}`
+	priorParams, _ := types.MapValue(types.StringType, map[string]attr.Value{
+		"extra_headers": types.StringValue(priorHeaders),
+	})
+	data := ModelResourceModel{
+		ID:                      types.StringValue("model-xlab"),
+		AccessGroups:            types.ListUnknown(types.StringType),
+		AdditionalLiteLLMParams: priorParams,
+	}
+
+	if err := r.readModel(context.Background(), &data); err != nil {
+		t.Fatalf("readModel returned error: %v", err)
+	}
+
+	additional := map[string]string{}
+	if diags := data.AdditionalLiteLLMParams.ElementsAs(context.Background(), &additional, false); diags.HasError() {
+		t.Fatalf("failed to decode additional_litellm_params: %v", diags)
+	}
+	if got := additional["extra_headers"]; got != priorHeaders {
+		t.Fatalf("expected extra_headers preserved from prior state %q, got %q", priorHeaders, got)
 	}
 }
 

--- a/internal/provider/resource_model_test.go
+++ b/internal/provider/resource_model_test.go
@@ -205,6 +205,32 @@ func TestConvertStringValue(t *testing.T) {
 	}
 }
 
+func TestJSONSemanticallyEqual(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		a    string
+		b    string
+		want bool
+	}{
+		{"whitespace after colon", `{"inputs": "{prompt}"}`, `{"inputs":"{prompt}"}`, true},
+		{"key ordering", `{"a":1,"b":2}`, `{"b":2,"a":1}`, true},
+		{"identical", `{"inputs":"{prompt}"}`, `{"inputs":"{prompt}"}`, true},
+		{"arrays equal", `["a", "b"]`, `["a","b"]`, true},
+		{"different values", `{"inputs":"{prompt}"}`, `{"inputs":"{other}"}`, false},
+		{"different keys", `{"a":1}`, `{"b":1}`, false},
+		{"a not json", `not json {`, `{"a":1}`, false},
+		{"b not json", `{"a":1}`, `not json {`, false},
+	}
+
+	for _, tt := range tests {
+		if got := jsonSemanticallyEqual(tt.a, tt.b); got != tt.want {
+			t.Errorf("%s: jsonSemanticallyEqual(%q, %q) = %v, want %v", tt.name, tt.a, tt.b, got, tt.want)
+		}
+	}
+}
+
 func TestCreateModelSendsAdditionalLiteLLMParams(t *testing.T) {
 	t.Parallel()
 

--- a/internal_testing/resources/model_json_params.tf
+++ b/internal_testing/resources/model_json_params.tf
@@ -1,0 +1,34 @@
+# litellm_model - JSON-valued additional_litellm_params
+#
+# Regression fixture for: https://github.com/ncecere/terraform-provider-litellm/issues/126
+#
+# A JSON object/array value in additional_litellm_params must survive a
+# plan/apply round-trip even when the config's JSON formatting differs from
+# Go's compact, key-sorted json.Marshal output. Before the fix, apply failed:
+#
+#   Error: Provider produced inconsistent result after apply
+#   .additional_litellm_params["input_schema"]:
+#     was cty.StringVal("{\"inputs\": \"{prompt}\"}"),
+#     but now cty.StringVal("{\"inputs\":\"{prompt}\"}").
+#
+# The values below use non-canonical formatting on purpose: a space after the
+# colon, out-of-order keys, and an array — so `make smoke` catches a regression.
+
+resource "litellm_model" "json_params" {
+  model_name          = "test-model-json-params"
+  custom_llm_provider = "openai"
+  base_model          = "gpt-4o-mini"
+
+  additional_litellm_params = {
+    # space after colon (differs from compact marshal)
+    input_schema = "{\"inputs\": \"{prompt}\"}"
+    # keys deliberately out of alphabetical order
+    ordering = "{\"b\": 2, \"a\": 1}"
+    # a JSON array value
+    stop_sequences = "[\"</end>\", \"STOP\"]"
+  }
+}
+
+output "model_json_params_id" {
+  value = litellm_model.json_params.id
+}


### PR DESCRIPTION
## What

Fixes #126.

A JSON-object/array value in `additional_litellm_params` (e.g. `input_schema`) fails the post-apply consistency check whenever the config value's formatting differs from Go's compact `json.Marshal` output — even when the two are semantically identical:

```
Error: Provider produced inconsistent result after apply
When applying changes to litellm_model.<name>, provider produced an unexpected new value:
.additional_litellm_params["input_schema"]: was cty.StringVal("{\"inputs\": \"{prompt}\"}"),
but now cty.StringVal("{\"inputs\":\"{prompt}\"}").
```

## Cause

On write, the config string is `json.Unmarshal`'d and sent to the API. On read (`readModel`, the `default` case of the value switch), the API's object value is re-emitted with `json.Marshal`, which is compact and key-sorted. Terraform then compares the original config string against the re-marshaled one, so any formatting difference — a space after `:`, key ordering, indentation — trips the consistency check and the resource never converges.

## Change

In the read path, when the prior config/state value for a key is JSON that is **semantically equal** to the API-returned value, preserve the prior string instead of the re-marshaled one. This mirrors the existing numeric-string normalization already done a few lines above (so `1.75e-07` from the API matches `0.000000175` from config).

Adds a small `jsonSemanticallyEqual` helper (parse both sides, `reflect.DeepEqual`) + unit tests. Import-time behavior is unchanged (no prior state to compare against, so the API value is used as-is).

## Testing

- New `TestJSONSemanticallyEqual` table test (whitespace, key ordering, arrays, non-JSON, inequality).
- Full `go test ./internal/provider/` suite passes.
- Validated end-to-end via `dev_overrides` against a live LiteLLM proxy: a `litellm_model` with `input_schema = "{\"inputs\": \"{prompt}\"}"` (space after colon) now applies cleanly instead of failing the consistency check.

Related to #120 / #121 (same "inconsistent result after apply" symptom, different cause — missing keys there, formatting here).