### PR TITLE
chore: gofmt

### DIFF
--- a/internal/provider/datasource_agent.go
+++ b/internal/provider/datasource_agent.go
@@ -22,21 +22,21 @@ type AgentDataSource struct {
 }
 
 type AgentDataSourceModel struct {
-	ID               types.String `tfsdk:"id"`
-	AgentName        types.String `tfsdk:"agent_name"`
-	AgentCardParams  types.Map    `tfsdk:"agent_card_params"`
-	LiteLLMParams    types.Map    `tfsdk:"litellm_params"`
-	TPMLimit         types.Int64  `tfsdk:"tpm_limit"`
-	RPMLimit         types.Int64  `tfsdk:"rpm_limit"`
-	SessionTPMLimit  types.Int64  `tfsdk:"session_tpm_limit"`
-	SessionRPMLimit  types.Int64  `tfsdk:"session_rpm_limit"`
-	StaticHeaders    types.Map    `tfsdk:"static_headers"`
-	ExtraHeaders     types.List   `tfsdk:"extra_headers"`
-	Spend            types.Float64 `tfsdk:"spend"`
-	CreatedAt        types.String `tfsdk:"created_at"`
-	UpdatedAt        types.String `tfsdk:"updated_at"`
-	CreatedBy        types.String `tfsdk:"created_by"`
-	UpdatedBy        types.String `tfsdk:"updated_by"`
+	ID              types.String  `tfsdk:"id"`
+	AgentName       types.String  `tfsdk:"agent_name"`
+	AgentCardParams types.Map     `tfsdk:"agent_card_params"`
+	LiteLLMParams   types.Map     `tfsdk:"litellm_params"`
+	TPMLimit        types.Int64   `tfsdk:"tpm_limit"`
+	RPMLimit        types.Int64   `tfsdk:"rpm_limit"`
+	SessionTPMLimit types.Int64   `tfsdk:"session_tpm_limit"`
+	SessionRPMLimit types.Int64   `tfsdk:"session_rpm_limit"`
+	StaticHeaders   types.Map     `tfsdk:"static_headers"`
+	ExtraHeaders    types.List    `tfsdk:"extra_headers"`
+	Spend           types.Float64 `tfsdk:"spend"`
+	CreatedAt       types.String  `tfsdk:"created_at"`
+	UpdatedAt       types.String  `tfsdk:"updated_at"`
+	CreatedBy       types.String  `tfsdk:"created_by"`
+	UpdatedBy       types.String  `tfsdk:"updated_by"`
 }
 
 func (d *AgentDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {

--- a/internal/provider/datasource_project.go
+++ b/internal/provider/datasource_project.go
@@ -22,21 +22,21 @@ type ProjectDataSource struct {
 }
 
 type ProjectDataSourceModel struct {
-	ID             types.String  `tfsdk:"id"`
-	ProjectAlias   types.String  `tfsdk:"project_alias"`
-	Description    types.String  `tfsdk:"description"`
-	TeamID         types.String  `tfsdk:"team_id"`
-	Models         types.List    `tfsdk:"models"`
-	Metadata       types.Map     `tfsdk:"metadata"`
-	Tags           types.List    `tfsdk:"tags"`
-	Blocked        types.Bool    `tfsdk:"blocked"`
-	Spend          types.Float64 `tfsdk:"spend"`
-	ModelRPMLimit  types.Map     `tfsdk:"model_rpm_limit"`
-	ModelTPMLimit  types.Map     `tfsdk:"model_tpm_limit"`
-	CreatedAt      types.String  `tfsdk:"created_at"`
-	UpdatedAt      types.String  `tfsdk:"updated_at"`
-	CreatedBy      types.String  `tfsdk:"created_by"`
-	UpdatedBy      types.String  `tfsdk:"updated_by"`
+	ID            types.String  `tfsdk:"id"`
+	ProjectAlias  types.String  `tfsdk:"project_alias"`
+	Description   types.String  `tfsdk:"description"`
+	TeamID        types.String  `tfsdk:"team_id"`
+	Models        types.List    `tfsdk:"models"`
+	Metadata      types.Map     `tfsdk:"metadata"`
+	Tags          types.List    `tfsdk:"tags"`
+	Blocked       types.Bool    `tfsdk:"blocked"`
+	Spend         types.Float64 `tfsdk:"spend"`
+	ModelRPMLimit types.Map     `tfsdk:"model_rpm_limit"`
+	ModelTPMLimit types.Map     `tfsdk:"model_tpm_limit"`
+	CreatedAt     types.String  `tfsdk:"created_at"`
+	UpdatedAt     types.String  `tfsdk:"updated_at"`
+	CreatedBy     types.String  `tfsdk:"created_by"`
+	UpdatedBy     types.String  `tfsdk:"updated_by"`
 }
 
 func (d *ProjectDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {

--- a/internal/provider/resource_agent_test.go
+++ b/internal/provider/resource_agent_test.go
@@ -69,11 +69,11 @@ func TestBuildAgentRequest_Full(t *testing.T) {
 	data := &AgentResourceModel{
 		AgentName: types.StringValue("full-agent"),
 		AgentCard: &AgentCardModel{
-			Name:            types.StringValue("Full Agent"),
-			Description:     types.StringValue("A fully configured agent"),
-			URL:             types.StringValue("https://agent.example.com/a2a"),
-			Version:         types.StringValue("1.0.0"),
-			ProtocolVersion: types.StringValue("0.2.6"),
+			Name:               types.StringValue("Full Agent"),
+			Description:        types.StringValue("A fully configured agent"),
+			URL:                types.StringValue("https://agent.example.com/a2a"),
+			Version:            types.StringValue("1.0.0"),
+			ProtocolVersion:    types.StringValue("0.2.6"),
 			DefaultInputModes:  stringListValue("application/json"),
 			DefaultOutputModes: stringListValue("application/json", "text/plain"),
 			PreferredTransport: types.StringValue("httpsse"),

--- a/internal/provider/resource_model_test.go
+++ b/internal/provider/resource_model_test.go
@@ -430,7 +430,7 @@ func TestPatchModelSendsTeamPublicModelNameWhenTeamIDSet(t *testing.T) {
 		TeamID:            types.StringValue(wantTeamID),
 		Tier:              types.StringNull(),
 		Mode:              types.StringNull(),
-		AccessGroups:     types.ListNull(types.StringType),
+		AccessGroups:      types.ListNull(types.StringType),
 	}
 
 	err := r.patchModel(context.Background(), data)


### PR DESCRIPTION
Apply `gofmt` to four files that were not formatted:

- `internal/provider/datasource_agent.go`
- `internal/provider/datasource_project.go`
- `internal/provider/resource_agent_test.go`
- `internal/provider/resource_model_test.go`

These are whitespace-only struct-field alignment changes — no behavior change. `go build`, `go vet`, and `go test ./...` all pass.

This clears the way for a `gofmt` check in a follow-up CI workflow PR (otherwise that check would fail on first run against these pre-existing files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)