### PR TITLE
test: broaden unit coverage of provider surface (~15.7% → ~37%)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,9 @@ install: build
 	mv terraform-provider-${NAME} ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}/terraform-provider-${NAME}_v${VERSION}
 
 test:
-	go test ./...
+	go test -covermode=atomic -coverprofile=coverage.out ./...
+	@printf 'Total coverage: %s\n' "$$(go tool cover -func=coverage.out | tail -1 | awk '{print $$NF}')"
+	@echo "HTML report: go tool cover -html=coverage.out"
 
 fmt:
 	go fmt ./...

--- a/internal/provider/build_request_test.go
+++ b/internal/provider/build_request_test.go
@@ -1,0 +1,376 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// These tests cover the pure buildXxxRequest helpers — the functions that
+// translate a Terraform resource model into the map[string]interface{} payload
+// sent to the LiteLLM API. They are side-effect-free, so they can be exercised
+// directly without an HTTP client.
+
+func TestBuildBudgetRequest(t *testing.T) {
+	t.Parallel()
+
+	r := &BudgetResource{}
+	data := &BudgetResourceModel{
+		BudgetID:            types.StringValue("budget-1"),
+		BudgetDuration:      types.StringValue("30d"),
+		MaxBudget:           types.Float64Value(100),
+		SoftBudget:          types.Float64Value(80),
+		MaxParallelRequests: types.Int64Value(5),
+		TPMLimit:            types.Int64Value(1000),
+		RPMLimit:            types.Int64Value(60),
+		ModelMaxBudget:      types.StringValue(`{"gpt-4o":10}`),
+	}
+
+	req := r.buildBudgetRequest(context.Background(), data)
+
+	if req["budget_id"] != "budget-1" {
+		t.Errorf("budget_id = %v", req["budget_id"])
+	}
+	if req["budget_duration"] != "30d" {
+		t.Errorf("budget_duration = %v", req["budget_duration"])
+	}
+	if req["max_budget"] != float64(100) {
+		t.Errorf("max_budget = %v", req["max_budget"])
+	}
+	if req["tpm_limit"] != int64(1000) {
+		t.Errorf("tpm_limit = %v", req["tpm_limit"])
+	}
+	mmb, ok := req["model_max_budget"].(map[string]interface{})
+	if !ok || mmb["gpt-4o"] != float64(10) {
+		t.Errorf("model_max_budget = %#v", req["model_max_budget"])
+	}
+}
+
+func TestBuildBudgetRequestOmitsUnset(t *testing.T) {
+	t.Parallel()
+
+	r := &BudgetResource{}
+	data := &BudgetResourceModel{
+		BudgetID:            types.StringNull(),
+		BudgetDuration:      types.StringNull(),
+		MaxBudget:           types.Float64Null(),
+		SoftBudget:          types.Float64Null(),
+		MaxParallelRequests: types.Int64Null(),
+		TPMLimit:            types.Int64Null(),
+		RPMLimit:            types.Int64Null(),
+		ModelMaxBudget:      types.StringNull(),
+	}
+
+	req := r.buildBudgetRequest(context.Background(), data)
+	if len(req) != 0 {
+		t.Errorf("expected empty request when all fields null, got %#v", req)
+	}
+}
+
+func TestBuildTagRequest(t *testing.T) {
+	t.Parallel()
+
+	r := &TagResource{}
+	data := &TagResourceModel{
+		Name:        types.StringValue("prod"),
+		Description: types.StringValue("production tag"),
+		Models:      stringListValue("gpt-4o", "gpt-4o-mini"),
+		MaxBudget:   types.Float64Value(50),
+	}
+
+	req := r.buildTagRequest(context.Background(), data)
+
+	if req["name"] != "prod" {
+		t.Errorf("name = %v", req["name"])
+	}
+	if req["description"] != "production tag" {
+		t.Errorf("description = %v", req["description"])
+	}
+	models, ok := req["models"].([]string)
+	if !ok || len(models) != 2 || models[0] != "gpt-4o" {
+		t.Errorf("models = %#v", req["models"])
+	}
+}
+
+func TestBuildCredentialRequest(t *testing.T) {
+	t.Parallel()
+
+	r := &CredentialResource{}
+	data := &CredentialResourceModel{
+		CredentialName:   types.StringValue("openai-prod"),
+		ModelID:          types.StringValue("model-1"),
+		CredentialInfo:   stringMapValue(map[string]string{"env": "prod"}),
+		CredentialValues: stringMapValue(map[string]string{"api_key": "sk-secret"}),
+	}
+
+	req := r.buildCredentialRequest(context.Background(), data)
+
+	if req["credential_name"] != "openai-prod" {
+		t.Errorf("credential_name = %v", req["credential_name"])
+	}
+	if req["model_id"] != "model-1" {
+		t.Errorf("model_id = %v", req["model_id"])
+	}
+	info, ok := req["credential_info"].(map[string]interface{})
+	if !ok || info["env"] != "prod" {
+		t.Errorf("credential_info = %#v", req["credential_info"])
+	}
+	vals, ok := req["credential_values"].(map[string]interface{})
+	if !ok || vals["api_key"] != "sk-secret" {
+		t.Errorf("credential_values = %#v", req["credential_values"])
+	}
+}
+
+func TestBuildGuardrailRequest(t *testing.T) {
+	t.Parallel()
+
+	r := &GuardrailResource{}
+	data := &GuardrailResourceModel{
+		GuardrailName: types.StringValue("pii"),
+		Guardrail:     types.StringValue("presidio"),
+		Mode:          types.StringValue("pre_call"),
+		DefaultOn:     types.BoolValue(true),
+	}
+
+	req := r.buildGuardrailRequest(context.Background(), data)
+
+	guardrail, ok := req["guardrail"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("guardrail wrapper missing: %#v", req)
+	}
+	if guardrail["guardrail_name"] != "pii" {
+		t.Errorf("guardrail_name = %v", guardrail["guardrail_name"])
+	}
+	params, ok := guardrail["litellm_params"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("litellm_params missing: %#v", guardrail)
+	}
+	if params["guardrail"] != "presidio" {
+		t.Errorf("litellm_params.guardrail = %v", params["guardrail"])
+	}
+	if params["mode"] != "pre_call" {
+		t.Errorf("mode = %v", params["mode"])
+	}
+	if params["default_on"] != true {
+		t.Errorf("default_on = %v", params["default_on"])
+	}
+}
+
+func TestBuildGuardrailRequestParsesModeArray(t *testing.T) {
+	t.Parallel()
+
+	r := &GuardrailResource{}
+	data := &GuardrailResourceModel{
+		GuardrailName: types.StringValue("pii"),
+		Guardrail:     types.StringValue("presidio"),
+		Mode:          types.StringValue(`["pre_call","post_call"]`),
+	}
+
+	req := r.buildGuardrailRequest(context.Background(), data)
+	guardrail := req["guardrail"].(map[string]interface{})
+	params := guardrail["litellm_params"].(map[string]interface{})
+	modes, ok := params["mode"].([]string)
+	if !ok || len(modes) != 2 || modes[1] != "post_call" {
+		t.Errorf("mode array = %#v", params["mode"])
+	}
+}
+
+func TestBuildOrganizationRequest(t *testing.T) {
+	t.Parallel()
+
+	r := &OrganizationResource{}
+	data := &OrganizationResourceModel{
+		OrganizationAlias: types.StringValue("acme"),
+		OrganizationID:    types.StringValue("org-1"),
+		Models:            stringListValue("gpt-4o"),
+		MaxBudget:         types.Float64Value(500),
+		TPMLimit:          types.Int64Value(2000),
+		Blocked:           types.BoolValue(false),
+		Tags:              stringListValue("team-a"),
+	}
+
+	req := r.buildOrganizationRequest(context.Background(), data)
+
+	if req["organization_alias"] != "acme" {
+		t.Errorf("organization_alias = %v", req["organization_alias"])
+	}
+	if req["organization_id"] != "org-1" {
+		t.Errorf("organization_id = %v", req["organization_id"])
+	}
+	if req["max_budget"] != float64(500) {
+		t.Errorf("max_budget = %v", req["max_budget"])
+	}
+	if req["blocked"] != false {
+		t.Errorf("blocked = %v", req["blocked"])
+	}
+	models, ok := req["models"].([]string)
+	if !ok || len(models) != 1 {
+		t.Errorf("models = %#v", req["models"])
+	}
+}
+
+func TestBuildPromptRequest(t *testing.T) {
+	t.Parallel()
+
+	r := &PromptResource{}
+	data := &PromptResourceModel{
+		PromptID:                 types.StringValue("prompt-1"),
+		PromptIntegration:        types.StringValue("langfuse"),
+		APIBase:                  types.StringValue("https://cloud.langfuse.com"),
+		IgnorePromptManagerModel: types.BoolValue(true),
+		PromptType:               types.StringValue("chat"),
+	}
+
+	req := r.buildPromptRequest(context.Background(), data)
+
+	if req["prompt_id"] != "prompt-1" {
+		t.Errorf("prompt_id = %v", req["prompt_id"])
+	}
+	params, ok := req["litellm_params"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("litellm_params missing: %#v", req)
+	}
+	if params["prompt_integration"] != "langfuse" {
+		t.Errorf("prompt_integration = %v", params["prompt_integration"])
+	}
+	if params["api_base"] != "https://cloud.langfuse.com" {
+		t.Errorf("api_base = %v", params["api_base"])
+	}
+	if params["ignore_prompt_manager_model"] != true {
+		t.Errorf("ignore_prompt_manager_model = %v", params["ignore_prompt_manager_model"])
+	}
+	info, ok := req["prompt_info"].(map[string]interface{})
+	if !ok || info["prompt_type"] != "chat" {
+		t.Errorf("prompt_info = %#v", req["prompt_info"])
+	}
+}
+
+func TestBuildSearchToolRequest(t *testing.T) {
+	t.Parallel()
+
+	r := &SearchToolResource{}
+	data := &SearchToolResourceModel{
+		SearchToolName: types.StringValue("tavily"),
+		SearchProvider: types.StringValue("tavily"),
+		APIKey:         types.StringValue("tvly-secret"),
+		APIBase:        types.StringValue("https://api.tavily.com"),
+		Timeout:        types.Float64Value(30),
+		MaxRetries:     types.Int64Value(3),
+	}
+
+	req := r.buildSearchToolRequest(context.Background(), data)
+
+	if req["search_tool_name"] != "tavily" {
+		t.Errorf("search_tool_name = %v", req["search_tool_name"])
+	}
+	params, ok := req["litellm_params"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("litellm_params missing: %#v", req)
+	}
+	if params["search_provider"] != "tavily" {
+		t.Errorf("search_provider = %v", params["search_provider"])
+	}
+	if params["api_key"] != "tvly-secret" {
+		t.Errorf("api_key = %v", params["api_key"])
+	}
+	if params["timeout"] != float64(30) {
+		t.Errorf("timeout = %v", params["timeout"])
+	}
+	if params["max_retries"] != int64(3) {
+		t.Errorf("max_retries = %v", params["max_retries"])
+	}
+}
+
+func TestBuildUserRequest(t *testing.T) {
+	t.Parallel()
+
+	r := &UserResource{}
+	data := &UserResourceModel{
+		UserID:        types.StringValue("user-1"),
+		UserAlias:     types.StringValue("Alice"),
+		UserEmail:     types.StringValue("alice@example.com"),
+		UserRole:      types.StringValue("internal_user"),
+		Teams:         stringListValue("team-a", "team-b"),
+		Models:        stringListValue("gpt-4o"),
+		MaxBudget:     types.Float64Value(25),
+		TPMLimit:      types.Int64Value(500),
+		AutoCreateKey: types.BoolValue(false),
+		Metadata:      stringMapValue(map[string]string{"dept": "eng"}),
+	}
+
+	req := r.buildUserRequest(context.Background(), data)
+
+	if req["user_id"] != "user-1" {
+		t.Errorf("user_id = %v", req["user_id"])
+	}
+	if req["user_email"] != "alice@example.com" {
+		t.Errorf("user_email = %v", req["user_email"])
+	}
+	if req["auto_create_key"] != false {
+		t.Errorf("auto_create_key = %v", req["auto_create_key"])
+	}
+	teams, ok := req["teams"].([]string)
+	if !ok || len(teams) != 2 {
+		t.Errorf("teams = %#v", req["teams"])
+	}
+	meta, ok := req["metadata"].(map[string]string)
+	if !ok || meta["dept"] != "eng" {
+		t.Errorf("metadata = %#v", req["metadata"])
+	}
+}
+
+func TestBuildVectorStoreRequest(t *testing.T) {
+	t.Parallel()
+
+	r := &VectorStoreResource{}
+	data := &VectorStoreResourceModel{
+		VectorStoreName:        types.StringValue("kb"),
+		CustomLLMProvider:      types.StringValue("bedrock"),
+		VectorStoreDescription: types.StringValue("knowledge base"),
+		VectorStoreMetadata:    stringMapValue(map[string]string{"team": "docs"}),
+		LiteLLMParams:          types.MapNull(types.StringType),
+	}
+
+	req := r.buildVectorStoreRequest(context.Background(), data)
+
+	if req["vector_store_name"] != "kb" {
+		t.Errorf("vector_store_name = %v", req["vector_store_name"])
+	}
+	if req["custom_llm_provider"] != "bedrock" {
+		t.Errorf("custom_llm_provider = %v", req["custom_llm_provider"])
+	}
+	meta, ok := req["vector_store_metadata"].(map[string]interface{})
+	if !ok || meta["team"] != "docs" {
+		t.Errorf("vector_store_metadata = %#v", req["vector_store_metadata"])
+	}
+	// litellm_params is always present (API requires it), even when null.
+	if _, ok := req["litellm_params"]; !ok {
+		t.Errorf("litellm_params should always be present, got %#v", req)
+	}
+}
+
+func TestBuildUnifiedAccessGroupRequest(t *testing.T) {
+	t.Parallel()
+
+	data := &UnifiedAccessGroupResourceModel{
+		AccessGroupName:  types.StringValue("ag-1"),
+		Description:      types.StringValue("access group one"),
+		AccessModelNames: stringListValue("gpt-4o"),
+	}
+
+	// includeOptionalName=true path
+	req := buildUnifiedAccessGroupRequest(context.Background(), data, true)
+	if req["access_group_name"] != "ag-1" {
+		t.Errorf("access_group_name = %v", req["access_group_name"])
+	}
+	if req["description"] != "access group one" {
+		t.Errorf("description = %v", req["description"])
+	}
+
+	// includeOptionalName=false with a set name still includes it (non-empty).
+	req2 := buildUnifiedAccessGroupRequest(context.Background(), data, false)
+	if req2["access_group_name"] != "ag-1" {
+		t.Errorf("access_group_name (false path) = %v", req2["access_group_name"])
+	}
+}

--- a/internal/provider/helpers_test.go
+++ b/internal/provider/helpers_test.go
@@ -1,0 +1,80 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestIsNotFoundError(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"not found phrase", errors.New("resource not found"), true},
+		{"404 status", errors.New("request failed with status 404"), true},
+		{"does not exist", errors.New("the key does not exist"), true},
+		{"unrelated", errors.New("internal server error"), false},
+	}
+	for _, tc := range cases {
+		if got := IsNotFoundError(tc.err); got != tc.want {
+			t.Errorf("%s: IsNotFoundError(%v) = %v, want %v", tc.name, tc.err, got, tc.want)
+		}
+	}
+}
+
+func TestNormalizeAdditionalParams(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	// Null / unknown pass through unchanged.
+	if got := normalizeAdditionalParams(ctx, types.MapNull(types.StringType)); !got.IsNull() {
+		t.Errorf("null map should stay null, got %v", got)
+	}
+	if got := normalizeAdditionalParams(ctx, types.MapUnknown(types.StringType)); !got.IsUnknown() {
+		t.Errorf("unknown map should stay unknown, got %v", got)
+	}
+
+	in, _ := types.MapValue(types.StringType, map[string]attr.Value{
+		"temperature": types.StringValue("1.50"),
+		"max_tokens":  types.StringValue("500"),
+		"model":       types.StringValue("gpt-4o"),
+	})
+	out := normalizeAdditionalParams(ctx, in)
+
+	var got map[string]string
+	if diags := out.ElementsAs(ctx, &got, false); diags.HasError() {
+		t.Fatalf("decoding result: %v", diags)
+	}
+	if got["temperature"] != "1.5" {
+		t.Errorf("temperature = %q, want 1.5", got["temperature"])
+	}
+	if got["max_tokens"] != "500" {
+		t.Errorf("max_tokens = %q, want 500", got["max_tokens"])
+	}
+	if got["model"] != "gpt-4o" {
+		t.Errorf("model = %q, want gpt-4o", got["model"])
+	}
+}
+
+func TestMemberObjectType(t *testing.T) {
+	t.Parallel()
+
+	ot := MemberObjectType()
+	for _, attrName := range []string{"user_id", "user_email", "role"} {
+		if _, ok := ot.AttrTypes[attrName]; !ok {
+			t.Errorf("MemberObjectType missing attribute %q", attrName)
+		}
+	}
+	if len(ot.AttrTypes) != 3 {
+		t.Errorf("MemberObjectType has %d attrs, want 3", len(ot.AttrTypes))
+	}
+}

--- a/internal/provider/provider_smoke_test.go
+++ b/internal/provider/provider_smoke_test.go
@@ -1,0 +1,392 @@
+package provider
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	fwdatasourceschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	fwresourceschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// These tests exercise the mechanical, side-effect-free surface that every
+// resource and data source implements — Metadata, Schema, Configure and
+// (for resources) ImportState — by iterating the provider's own factory lists.
+// They assert the framework contracts hold uniformly across every type, and in
+// doing so give broad coverage of otherwise-untested boilerplate.
+
+func newTestProvider() provider.Provider {
+	return New("test")()
+}
+
+func providerFactory(t *testing.T) *LiteLLMProvider {
+	t.Helper()
+	p, ok := newTestProvider().(*LiteLLMProvider)
+	if !ok {
+		t.Fatalf("New(...) did not return *LiteLLMProvider")
+	}
+	return p
+}
+
+func TestProviderMetadata(t *testing.T) {
+	t.Parallel()
+
+	p := providerFactory(t)
+	resp := &provider.MetadataResponse{}
+	p.Metadata(context.Background(), provider.MetadataRequest{}, resp)
+
+	if resp.TypeName != "litellm" {
+		t.Errorf("expected TypeName 'litellm', got %q", resp.TypeName)
+	}
+	if resp.Version != "test" {
+		t.Errorf("expected Version 'test', got %q", resp.Version)
+	}
+}
+
+func TestProviderSchema(t *testing.T) {
+	t.Parallel()
+
+	p := providerFactory(t)
+	resp := &provider.SchemaResponse{}
+	p.Schema(context.Background(), provider.SchemaRequest{}, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("provider schema diagnostics: %v", resp.Diagnostics.Errors())
+	}
+	for _, attr := range []string{"api_base", "api_key", "insecure_skip_verify", "litellm_changed_by"} {
+		if _, ok := resp.Schema.Attributes[attr]; !ok {
+			t.Errorf("provider schema missing attribute %q", attr)
+		}
+	}
+}
+
+// TestResourcesMetadataAndSchema iterates every registered resource and checks
+// Metadata, Schema and Configure behave per the framework contract.
+func TestResourcesMetadataAndSchema(t *testing.T) {
+	t.Parallel()
+
+	p := providerFactory(t)
+	factories := p.Resources(context.Background())
+	if len(factories) == 0 {
+		t.Fatal("provider registered no resources")
+	}
+
+	seen := map[string]bool{}
+	for i, factory := range factories {
+		res := factory()
+
+		// Metadata: type name must be non-empty, litellm-prefixed and unique.
+		metaResp := &resource.MetadataResponse{}
+		res.Metadata(
+			context.Background(),
+			resource.MetadataRequest{ProviderTypeName: "litellm"},
+			metaResp,
+		)
+		if metaResp.TypeName == "" {
+			t.Errorf("resource #%d: empty type name", i)
+		}
+		if !strings.HasPrefix(metaResp.TypeName, "litellm_") {
+			t.Errorf("resource %q: type name should have 'litellm_' prefix", metaResp.TypeName)
+		}
+		if seen[metaResp.TypeName] {
+			t.Errorf("duplicate resource type name %q", metaResp.TypeName)
+		}
+		seen[metaResp.TypeName] = true
+
+		// Schema: must not error and must define at least one attribute or block.
+		schemaResp := &resource.SchemaResponse{}
+		res.Schema(context.Background(), resource.SchemaRequest{}, schemaResp)
+		if schemaResp.Diagnostics.HasError() {
+			t.Errorf("resource %q schema diagnostics: %v", metaResp.TypeName, schemaResp.Diagnostics.Errors())
+		}
+		if !hasResourceFields(schemaResp.Schema) {
+			t.Errorf("resource %q schema defines no attributes or blocks", metaResp.TypeName)
+		}
+
+		// Configure with nil ProviderData must be a no-op (framework calls it
+		// this way during early lifecycle) and must not error.
+		if configurable, ok := res.(resource.ResourceWithConfigure); ok {
+			cfgResp := &resource.ConfigureResponse{}
+			configurable.Configure(context.Background(), resource.ConfigureRequest{}, cfgResp)
+			if cfgResp.Diagnostics.HasError() {
+				t.Errorf("resource %q Configure(nil) errored: %v", metaResp.TypeName, cfgResp.Diagnostics.Errors())
+			}
+		}
+	}
+}
+
+// TestResourcesConfigureRejectsWrongProviderData verifies the type-assertion
+// guard in each resource's Configure surfaces an error rather than panicking
+// when handed the wrong ProviderData type.
+func TestResourcesConfigureRejectsWrongProviderData(t *testing.T) {
+	t.Parallel()
+
+	p := providerFactory(t)
+	for _, factory := range p.Resources(context.Background()) {
+		res := factory()
+		configurable, ok := res.(resource.ResourceWithConfigure)
+		if !ok {
+			continue
+		}
+		metaResp := &resource.MetadataResponse{}
+		res.Metadata(context.Background(), resource.MetadataRequest{ProviderTypeName: "litellm"}, metaResp)
+
+		cfgResp := &resource.ConfigureResponse{}
+		configurable.Configure(
+			context.Background(),
+			resource.ConfigureRequest{ProviderData: "not-a-client"},
+			cfgResp,
+		)
+		if !cfgResp.Diagnostics.HasError() {
+			t.Errorf("resource %q Configure did not reject wrong ProviderData type", metaResp.TypeName)
+		}
+	}
+}
+
+// TestResourcesConfigureAcceptsClient verifies Configure accepts a *Client.
+func TestResourcesConfigureAcceptsClient(t *testing.T) {
+	t.Parallel()
+
+	client := &Client{APIBase: "https://example.com", APIKey: "test-key"}
+	p := providerFactory(t)
+	for _, factory := range p.Resources(context.Background()) {
+		res := factory()
+		configurable, ok := res.(resource.ResourceWithConfigure)
+		if !ok {
+			continue
+		}
+		metaResp := &resource.MetadataResponse{}
+		res.Metadata(context.Background(), resource.MetadataRequest{ProviderTypeName: "litellm"}, metaResp)
+
+		cfgResp := &resource.ConfigureResponse{}
+		configurable.Configure(
+			context.Background(),
+			resource.ConfigureRequest{ProviderData: client},
+			cfgResp,
+		)
+		if cfgResp.Diagnostics.HasError() {
+			t.Errorf("resource %q Configure(*Client) errored: %v", metaResp.TypeName, cfgResp.Diagnostics.Errors())
+		}
+	}
+}
+
+// TestDataSourcesMetadataAndSchema mirrors TestResourcesMetadataAndSchema for
+// every registered data source.
+func TestDataSourcesMetadataAndSchema(t *testing.T) {
+	t.Parallel()
+
+	p := providerFactory(t)
+	factories := p.DataSources(context.Background())
+	if len(factories) == 0 {
+		t.Fatal("provider registered no data sources")
+	}
+
+	seen := map[string]bool{}
+	for i, factory := range factories {
+		ds := factory()
+
+		metaResp := &datasource.MetadataResponse{}
+		ds.Metadata(
+			context.Background(),
+			datasource.MetadataRequest{ProviderTypeName: "litellm"},
+			metaResp,
+		)
+		if metaResp.TypeName == "" {
+			t.Errorf("data source #%d: empty type name", i)
+		}
+		if !strings.HasPrefix(metaResp.TypeName, "litellm_") {
+			t.Errorf("data source %q: type name should have 'litellm_' prefix", metaResp.TypeName)
+		}
+		if seen[metaResp.TypeName] {
+			t.Errorf("duplicate data source type name %q", metaResp.TypeName)
+		}
+		seen[metaResp.TypeName] = true
+
+		schemaResp := &datasource.SchemaResponse{}
+		ds.Schema(context.Background(), datasource.SchemaRequest{}, schemaResp)
+		if schemaResp.Diagnostics.HasError() {
+			t.Errorf("data source %q schema diagnostics: %v", metaResp.TypeName, schemaResp.Diagnostics.Errors())
+		}
+		if !hasDataSourceFields(schemaResp.Schema) {
+			t.Errorf("data source %q schema defines no attributes or blocks", metaResp.TypeName)
+		}
+
+		if configurable, ok := ds.(datasource.DataSourceWithConfigure); ok {
+			cfgResp := &datasource.ConfigureResponse{}
+			configurable.Configure(context.Background(), datasource.ConfigureRequest{}, cfgResp)
+			if cfgResp.Diagnostics.HasError() {
+				t.Errorf("data source %q Configure(nil) errored: %v", metaResp.TypeName, cfgResp.Diagnostics.Errors())
+			}
+		}
+	}
+}
+
+// TestDataSourcesConfigureRejectsWrongProviderData verifies the guard in each
+// data source's Configure.
+func TestDataSourcesConfigureRejectsWrongProviderData(t *testing.T) {
+	t.Parallel()
+
+	p := providerFactory(t)
+	for _, factory := range p.DataSources(context.Background()) {
+		ds := factory()
+		configurable, ok := ds.(datasource.DataSourceWithConfigure)
+		if !ok {
+			continue
+		}
+		metaResp := &datasource.MetadataResponse{}
+		ds.Metadata(context.Background(), datasource.MetadataRequest{ProviderTypeName: "litellm"}, metaResp)
+
+		cfgResp := &datasource.ConfigureResponse{}
+		configurable.Configure(
+			context.Background(),
+			datasource.ConfigureRequest{ProviderData: 12345},
+			cfgResp,
+		)
+		if !cfgResp.Diagnostics.HasError() {
+			t.Errorf("data source %q Configure did not reject wrong ProviderData type", metaResp.TypeName)
+		}
+	}
+}
+
+// TestResourcesImportState calls ImportState on every resource that supports
+// it, using a valid import ID. The ID uses "a:b" form so that resources parsing
+// a composite "id1:id2" import ID succeed; passthrough resources ignore the
+// colon. Each resource is first Configured with a client pointed at a stub HTTP
+// server, since a few resources (e.g. fallback) perform a read during import.
+// It asserts import succeeds and populates a non-empty "id" attribute (some
+// resources, like key, derive id from the import ID rather than copying it).
+func TestResourcesImportState(t *testing.T) {
+	t.Parallel()
+
+	const importID = "import-a:import-b"
+
+	// Stub server returns a benign JSON object for any read performed during
+	// import, so resources that fetch during ImportState don't hit a nil client.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+	client := &Client{APIBase: server.URL, APIKey: "test-key", HTTPClient: server.Client()}
+
+	p := providerFactory(t)
+	for _, factory := range p.Resources(context.Background()) {
+		res := factory()
+		importer, ok := res.(resource.ResourceWithImportState)
+		if !ok {
+			continue
+		}
+		if configurable, ok := res.(resource.ResourceWithConfigure); ok {
+			configurable.Configure(context.Background(), resource.ConfigureRequest{ProviderData: client}, &resource.ConfigureResponse{})
+		}
+
+		metaResp := &resource.MetadataResponse{}
+		res.Metadata(context.Background(), resource.MetadataRequest{ProviderTypeName: "litellm"}, metaResp)
+
+		// litellm_fallback's ImportState performs a live read and rebuilds the
+		// whole state from the API response, so it can't be exercised against a
+		// synthetic null state / stub the way passthrough importers can.
+		if metaResp.TypeName == "litellm_fallback" {
+			continue
+		}
+
+		schemaResp := &resource.SchemaResponse{}
+		res.Schema(context.Background(), resource.SchemaRequest{}, schemaResp)
+		if schemaResp.Diagnostics.HasError() {
+			t.Errorf("resource %q schema diagnostics: %v", metaResp.TypeName, schemaResp.Diagnostics.Errors())
+			continue
+		}
+
+		nullState, err := nullStateFor(schemaResp.Schema)
+		if err != nil {
+			t.Errorf("resource %q: building null state: %v", metaResp.TypeName, err)
+			continue
+		}
+
+		importResp := &resource.ImportStateResponse{State: nullState}
+		importer.ImportState(
+			context.Background(),
+			resource.ImportStateRequest{ID: importID},
+			importResp,
+		)
+		if importResp.Diagnostics.HasError() {
+			t.Errorf("resource %q ImportState(%q) errored: %v", metaResp.TypeName, importID, importResp.Diagnostics.Errors())
+			continue
+		}
+
+		var id string
+		if diags := importResp.State.GetAttribute(context.Background(), path.Root("id"), &id); diags.HasError() {
+			t.Errorf("resource %q: reading imported id: %v", metaResp.TypeName, diags.Errors())
+			continue
+		}
+		if id == "" {
+			t.Errorf("resource %q: ImportState did not populate id", metaResp.TypeName)
+		}
+	}
+}
+
+// TestResourcesImportStateRejectsMalformedID feeds a bare ID with no separator
+// to every importer. Composite-ID resources must surface an error; passthrough
+// resources accept it. The point of the test is that neither path panics.
+func TestResourcesImportStateRejectsMalformedID(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+	client := &Client{APIBase: server.URL, APIKey: "test-key", HTTPClient: server.Client()}
+
+	p := providerFactory(t)
+	for _, factory := range p.Resources(context.Background()) {
+		res := factory()
+		importer, ok := res.(resource.ResourceWithImportState)
+		if !ok {
+			continue
+		}
+		if configurable, ok := res.(resource.ResourceWithConfigure); ok {
+			configurable.Configure(context.Background(), resource.ConfigureRequest{ProviderData: client}, &resource.ConfigureResponse{})
+		}
+
+		schemaResp := &resource.SchemaResponse{}
+		res.Schema(context.Background(), resource.SchemaRequest{}, schemaResp)
+		nullState, err := nullStateFor(schemaResp.Schema)
+		if err != nil {
+			continue
+		}
+
+		importResp := &resource.ImportStateResponse{State: nullState}
+		importer.ImportState(
+			context.Background(),
+			resource.ImportStateRequest{ID: "single-token-id"},
+			importResp,
+		)
+		_ = importResp.Diagnostics.HasError()
+	}
+}
+
+// nullStateFor builds an empty (all-null) tfsdk.State for a resource schema so
+// ImportState's SetAttribute calls have a typed object to write into.
+func nullStateFor(s fwresourceschema.Schema) (tfsdk.State, error) {
+	ctx := context.Background()
+	objType := s.Type().TerraformType(ctx)
+	raw := tftypes.NewValue(objType, nil)
+	return tfsdk.State{Raw: raw, Schema: s}, nil
+}
+
+func hasResourceFields(s fwresourceschema.Schema) bool {
+	return len(s.Attributes) > 0 || len(s.Blocks) > 0
+}
+
+func hasDataSourceFields(s fwdatasourceschema.Schema) bool {
+	return len(s.Attributes) > 0 || len(s.Blocks) > 0
+}

--- a/internal/provider/read_test.go
+++ b/internal/provider/read_test.go
@@ -1,0 +1,372 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// These tests exercise the readXxx helpers against a stub HTTP server, covering
+// the response-parsing paths that translate an API payload back into the
+// Terraform resource model. They complement the buildXxxRequest tests, which
+// cover the outbound direction.
+
+// jsonServer returns an httptest server that responds to every request with the
+// given JSON-encodable body, plus a *Client wired to it.
+func jsonServer(t *testing.T, body interface{}) (*httptest.Server, *Client) {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(body)
+	}))
+	client := &Client{APIBase: server.URL, APIKey: "test-key", HTTPClient: server.Client()}
+	return server, client
+}
+
+func TestReadBudget(t *testing.T) {
+	t.Parallel()
+
+	// /budget/info returns an array of budget objects.
+	server, client := jsonServer(t, []map[string]interface{}{{
+		"budget_id":             "budget-1",
+		"max_budget":            100.0,
+		"soft_budget":           80.0,
+		"max_parallel_requests": 5.0,
+		"tpm_limit":             1000.0,
+		"rpm_limit":             60.0,
+		"budget_duration":       "30d",
+	}})
+	defer server.Close()
+
+	r := &BudgetResource{client: client}
+	data := &BudgetResourceModel{BudgetID: types.StringValue("budget-1")}
+	if err := r.readBudget(context.Background(), data); err != nil {
+		t.Fatalf("readBudget: %v", err)
+	}
+
+	if data.ID.ValueString() != "budget-1" {
+		t.Errorf("id = %q", data.ID.ValueString())
+	}
+	if data.MaxBudget.ValueFloat64() != 100 {
+		t.Errorf("max_budget = %v", data.MaxBudget.ValueFloat64())
+	}
+	if data.TPMLimit.ValueInt64() != 1000 {
+		t.Errorf("tpm_limit = %v", data.TPMLimit.ValueInt64())
+	}
+	if data.BudgetDuration.ValueString() != "30d" {
+		t.Errorf("budget_duration = %q", data.BudgetDuration.ValueString())
+	}
+}
+
+func TestReadBudgetNotFound(t *testing.T) {
+	t.Parallel()
+
+	server, client := jsonServer(t, []map[string]interface{}{})
+	defer server.Close()
+
+	r := &BudgetResource{client: client}
+	data := &BudgetResourceModel{BudgetID: types.StringValue("missing")}
+	if err := r.readBudget(context.Background(), data); err == nil {
+		t.Fatal("expected error for empty budget result")
+	}
+}
+
+func TestReadTag(t *testing.T) {
+	t.Parallel()
+
+	// /tag/info returns a map keyed by tag name.
+	server, client := jsonServer(t, map[string]interface{}{
+		"prod": map[string]interface{}{
+			"name":            "prod",
+			"description":     "production",
+			"budget_id":       "b-1",
+			"max_budget":      50.0,
+			"tpm_limit":       500.0,
+			"budget_duration": "7d",
+		},
+	})
+	defer server.Close()
+
+	r := &TagResource{client: client}
+	data := &TagResourceModel{Name: types.StringValue("prod")}
+	if err := r.readTag(context.Background(), data); err != nil {
+		t.Fatalf("readTag: %v", err)
+	}
+
+	if data.ID.ValueString() != "prod" {
+		t.Errorf("id = %q", data.ID.ValueString())
+	}
+	if data.Description.ValueString() != "production" {
+		t.Errorf("description = %q", data.Description.ValueString())
+	}
+	if data.MaxBudget.ValueFloat64() != 50 {
+		t.Errorf("max_budget = %v", data.MaxBudget.ValueFloat64())
+	}
+}
+
+func TestReadCredential(t *testing.T) {
+	t.Parallel()
+
+	server, client := jsonServer(t, map[string]interface{}{
+		"credential_name": "openai-prod",
+		"credential_info": map[string]interface{}{"env": "prod"},
+	})
+	defer server.Close()
+
+	r := &CredentialResource{client: client}
+	data := &CredentialResourceModel{
+		CredentialName: types.StringValue("openai-prod"),
+		CredentialInfo: stringMapValue(map[string]string{"env": "old"}),
+	}
+	if err := r.readCredential(context.Background(), data); err != nil {
+		t.Fatalf("readCredential: %v", err)
+	}
+
+	if data.ID.ValueString() != "openai-prod" {
+		t.Errorf("id = %q", data.ID.ValueString())
+	}
+	var info map[string]string
+	data.CredentialInfo.ElementsAs(context.Background(), &info, false)
+	if info["env"] != "prod" {
+		t.Errorf("credential_info[env] = %q", info["env"])
+	}
+}
+
+func TestReadOrganization(t *testing.T) {
+	t.Parallel()
+
+	// Response nested under "organization_info".
+	server, client := jsonServer(t, map[string]interface{}{
+		"organization_info": map[string]interface{}{
+			"organization_id":    "org-1",
+			"organization_alias": "acme",
+			"max_budget":         500.0,
+			"tpm_limit":          2000.0,
+		},
+	})
+	defer server.Close()
+
+	r := &OrganizationResource{client: client}
+	data := &OrganizationResourceModel{OrganizationID: types.StringValue("org-1")}
+	if err := r.readOrganization(context.Background(), data); err != nil {
+		t.Fatalf("readOrganization: %v", err)
+	}
+
+	if data.ID.ValueString() != "org-1" {
+		t.Errorf("id = %q", data.ID.ValueString())
+	}
+	if data.OrganizationAlias.ValueString() != "acme" {
+		t.Errorf("organization_alias = %q", data.OrganizationAlias.ValueString())
+	}
+}
+
+func TestReadAccessGroup(t *testing.T) {
+	t.Parallel()
+
+	server, client := jsonServer(t, map[string]interface{}{
+		"access_group": "ag-1",
+		"model_names":  []interface{}{"gpt-4o", "gpt-4o-mini"},
+	})
+	defer server.Close()
+
+	r := &AccessGroupResource{client: client}
+	data := &AccessGroupResourceModel{AccessGroup: types.StringValue("ag-1")}
+	if err := r.readAccessGroup(context.Background(), data); err != nil {
+		t.Fatalf("readAccessGroup: %v", err)
+	}
+
+	if data.ID.ValueString() != "ag-1" {
+		t.Errorf("id = %q", data.ID.ValueString())
+	}
+	var models []string
+	data.ModelNames.ElementsAs(context.Background(), &models, false)
+	if len(models) != 2 || models[0] != "gpt-4o" {
+		t.Errorf("model_names = %#v", models)
+	}
+}
+
+func TestReadGuardrail(t *testing.T) {
+	t.Parallel()
+
+	server, client := jsonServer(t, map[string]interface{}{
+		"guardrail_id":   "g-1",
+		"guardrail_name": "pii",
+		"created_at":     "2024-01-01T00:00:00Z",
+		"litellm_params": map[string]interface{}{
+			"guardrail":  "presidio",
+			"mode":       "pre_call",
+			"default_on": true,
+		},
+	})
+	defer server.Close()
+
+	r := &GuardrailResource{client: client}
+	data := &GuardrailResourceModel{
+		GuardrailID: types.StringValue("g-1"),
+		DefaultOn:   types.BoolValue(false),
+	}
+	if err := r.readGuardrail(context.Background(), data); err != nil {
+		t.Fatalf("readGuardrail: %v", err)
+	}
+
+	if data.ID.ValueString() != "g-1" {
+		t.Errorf("id = %q", data.ID.ValueString())
+	}
+	if data.GuardrailName.ValueString() != "pii" {
+		t.Errorf("guardrail_name = %q", data.GuardrailName.ValueString())
+	}
+	if data.Guardrail.ValueString() != "presidio" {
+		t.Errorf("guardrail = %q", data.Guardrail.ValueString())
+	}
+	if data.Mode.ValueString() != "pre_call" {
+		t.Errorf("mode = %q", data.Mode.ValueString())
+	}
+}
+
+func TestReadSearchTool(t *testing.T) {
+	t.Parallel()
+
+	server, client := jsonServer(t, map[string]interface{}{
+		"search_tool_id":   "st-1",
+		"search_tool_name": "tavily",
+		"litellm_params": map[string]interface{}{
+			"search_provider": "tavily",
+			"api_base":        "https://api.tavily.com",
+			"timeout":         30.0,
+			"max_retries":     3.0,
+		},
+	})
+	defer server.Close()
+
+	r := &SearchToolResource{client: client}
+	data := &SearchToolResourceModel{SearchToolID: types.StringValue("st-1")}
+	if err := r.readSearchTool(context.Background(), data); err != nil {
+		t.Fatalf("readSearchTool: %v", err)
+	}
+
+	if data.ID.ValueString() != "st-1" {
+		t.Errorf("id = %q", data.ID.ValueString())
+	}
+	if data.SearchProvider.ValueString() != "tavily" {
+		t.Errorf("search_provider = %q", data.SearchProvider.ValueString())
+	}
+	if data.Timeout.ValueFloat64() != 30 {
+		t.Errorf("timeout = %v", data.Timeout.ValueFloat64())
+	}
+	if data.MaxRetries.ValueInt64() != 3 {
+		t.Errorf("max_retries = %v", data.MaxRetries.ValueInt64())
+	}
+}
+
+func TestReadVectorStore(t *testing.T) {
+	t.Parallel()
+
+	// Response nested under "vector_store".
+	server, client := jsonServer(t, map[string]interface{}{
+		"vector_store": map[string]interface{}{
+			"vector_store_id":          "vs-1",
+			"vector_store_name":        "kb",
+			"custom_llm_provider":      "bedrock",
+			"vector_store_description": "knowledge base",
+		},
+	})
+	defer server.Close()
+
+	r := &VectorStoreResource{client: client}
+	data := &VectorStoreResourceModel{VectorStoreID: types.StringValue("vs-1")}
+	if err := r.readVectorStore(context.Background(), data); err != nil {
+		t.Fatalf("readVectorStore: %v", err)
+	}
+
+	if data.ID.ValueString() != "vs-1" {
+		t.Errorf("id = %q", data.ID.ValueString())
+	}
+	if data.VectorStoreName.ValueString() != "kb" {
+		t.Errorf("vector_store_name = %q", data.VectorStoreName.ValueString())
+	}
+	if data.CustomLLMProvider.ValueString() != "bedrock" {
+		t.Errorf("custom_llm_provider = %q", data.CustomLLMProvider.ValueString())
+	}
+}
+
+// TestReadCredentialWithRetrySucceedsFirstTry verifies the retry wrapper returns
+// immediately (no sleep) when the underlying read succeeds.
+func TestReadCredentialWithRetrySucceedsFirstTry(t *testing.T) {
+	t.Parallel()
+
+	server, client := jsonServer(t, map[string]interface{}{
+		"credential_name": "cred-1",
+	})
+	defer server.Close()
+
+	r := &CredentialResource{client: client}
+	data := &CredentialResourceModel{CredentialName: types.StringValue("cred-1")}
+	if err := r.readCredentialWithRetry(context.Background(), data, 3); err != nil {
+		t.Fatalf("readCredentialWithRetry: %v", err)
+	}
+	if data.ID.ValueString() != "cred-1" {
+		t.Errorf("id = %q", data.ID.ValueString())
+	}
+}
+
+// TestReadCredentialWithRetryReturnsNonNotFoundImmediately verifies a non-404
+// error is returned without retrying (so the test doesn't sleep).
+func TestReadCredentialWithRetryReturnsNonNotFoundImmediately(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "server exploded", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+	client := &Client{APIBase: server.URL, APIKey: "test-key", HTTPClient: server.Client()}
+
+	r := &CredentialResource{client: client}
+	data := &CredentialResourceModel{CredentialName: types.StringValue("cred-1")}
+	// maxRetries=3, but a non-not-found error must short-circuit on the first
+	// attempt without sleeping.
+	if err := r.readCredentialWithRetry(context.Background(), data, 3); err == nil {
+		t.Fatal("expected error to propagate")
+	}
+}
+
+// TestReadPromptWithRetrySucceedsFirstTry mirrors the credential retry success
+// path for the prompt resource.
+func TestReadPromptWithRetrySucceedsFirstTry(t *testing.T) {
+	t.Parallel()
+
+	server, client := jsonServer(t, map[string]interface{}{
+		"prompt_id": "prompt-1",
+		"litellm_params": map[string]interface{}{
+			"prompt_integration": "langfuse",
+		},
+	})
+	defer server.Close()
+
+	r := &PromptResource{client: client}
+	data := &PromptResourceModel{PromptID: types.StringValue("prompt-1")}
+	if err := r.readPromptWithRetry(context.Background(), data, 3); err != nil {
+		t.Fatalf("readPromptWithRetry: %v", err)
+	}
+}
+
+// TestReadPropagatesClientError verifies readXxx surfaces transport errors from
+// the API (here, a 500 that DoRequestWithResponse turns into an error).
+func TestReadPropagatesClientError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+	client := &Client{APIBase: server.URL, APIKey: "test-key", HTTPClient: server.Client()}
+
+	r := &SearchToolResource{client: client}
+	data := &SearchToolResourceModel{SearchToolID: types.StringValue("st-1")}
+	if err := r.readSearchTool(context.Background(), data); err == nil {
+		t.Fatal("expected error from 500 response")
+	}
+}


### PR DESCRIPTION
Adds unit tests that cover large, previously-untested parts of the `internal/provider` package — **raising whole-module statement coverage from ~15.7% to ~30.1%** (and the live `internal/provider` package specifically from ~15.7% to ~37.2%). Tests only; no production code changes.

### What's added
- **`provider_smoke_test.go`** — table-driven tests that iterate the provider's own resource/data-source factory lists and assert the framework contract for every registered type:
  - `Metadata` (non-empty, `litellm_`-prefixed, unique type names),
  - `Schema` (no diagnostics, defines attributes/blocks),
  - `Configure` (no-op on nil ProviderData, errors on wrong type, accepts `*Client`),
  - `ImportState` (valid ID populates `id`; malformed ID handled without panic).
- **`build_request_test.go`** — the pure `buildXxxRequest` payload builders for budget, tag, credential, guardrail (incl. array-mode parsing), organization, prompt, search_tool, user, vector_store, and unified_access_group.
- **`read_test.go`** — the `readXxx` response-parsing helpers (budget, tag, credential, organization, access_group, guardrail, search_tool, vector_store) driven by a stub HTTP server, plus not-found / error-propagation cases and the credential/prompt retry wrappers on their fast paths.
- **`helpers_test.go`** — `IsNotFoundError`, `normalizeAdditionalParams`, `MemberObjectType`.

### Notes
- Focused on `internal/provider` (the package `main.go` wires up). The separate top-level `litellm/` package appears to be unused/legacy — I left it alone rather than test dead code; happy to remove it in a separate PR if that's the intent.
- The remaining uncovered code is mostly the `Create`/`Read`/`Update`/`Delete` resource methods, which drive the full plugin-framework request/response lifecycle and are better exercised by acceptance tests (`resource.Test`) than unit tests. Retry paths that call `time.Sleep` with backoff are covered only on their non-sleeping branches to keep the suite fast.
- All new tests pass under `go test -race`.

### Local testing

```
$ make test
go test -covermode=atomic -coverprofile=coverage.out ./...
	github.com/nicholas-cecere/terraform-provider-litellm		coverage: 0.0% of statements
ok  	github.com/nicholas-cecere/terraform-provider-litellm/internal/provider	(cached)	coverage: 37.2% of statements
	github.com/nicholas-cecere/terraform-provider-litellm/litellm		coverage: 0.0% of statements
Total coverage: 30.1%
HTML report: go tool cover -html=coverage.out
```

### Verified in CI
Ran on my fork with the coverage-reporting workflow — 144 tests pass (open the **Summary** tab):
https://github.com/msabramo/terraform-provider-litellm/actions/runs/29799314391

The run (and `make test`) report **30.1%**, whole-module. Note this includes the unused/legacy top-level `litellm/` package (~1346 statements at 0%, not imported by `main.go`); coverage of just the live `internal/provider` package is ~37.2%. I've kept the reported number whole-module for consistency with CI — see the comment below re: removing `litellm/`, which would raise it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


