### PR TITLE
fix(smoke): generate `dev_overrides` config at runtime (`make smoke` works on any machine)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ dev_testing/e2e/*
 # Smoke test workspace (generated; per-file state and copied .tf removed between files, directory kept)
 internal_testing/.smoke/
 
+# Generated dev_overrides CLI config for the manual smoke walkthrough
+internal_testing/.dev.tfrc
+
 # .tfstate files
 *.tfstate
 *.tfstate.*

--- a/internal_testing/README.md
+++ b/internal_testing/README.md
@@ -21,8 +21,16 @@ docker compose logs -f litellm          # wait for "LiteLLM Proxy is running"
 cd ..
 go build -o terraform-provider-litellm
 
-# 3. Set TF_CLI_CONFIG_FILE to use the dev_overrides terraformrc
-export TF_CLI_CONFIG_FILE="$(pwd)/internal_testing/terraformrc"
+# 3. Point Terraform at the local binary via a dev_overrides CLI config.
+#    (The `make smoke` flow generates this automatically; for the manual
+#    walkthrough, create one pointing at the repo root.)
+cat > internal_testing/.dev.tfrc <<EOF
+provider_installation {
+  dev_overrides { "ncecere/litellm" = "$(pwd)" }
+  direct {}
+}
+EOF
+export TF_CLI_CONFIG_FILE="$(pwd)/internal_testing/.dev.tfrc"
 
 # 4. Create your tfvars (one-time -- defaults match docker-compose)
 cp internal_testing/terraform.tfvars.example internal_testing/terraform.tfvars
@@ -69,7 +77,6 @@ docker compose down -v
 internal_testing/
   docker-compose.yml           # LiteLLM + Postgres stack
   litellm-config.yaml          # minimal LiteLLM proxy config
-  terraformrc                  # dev_overrides pointing at local binary
   provider.tf                  # provider + required_providers block
   variables.tf                 # api_base and api_key variables
   terraform.tfvars.example     # copy to terraform.tfvars (defaults work)

--- a/internal_testing/smoke.sh
+++ b/internal_testing/smoke.sh
@@ -33,7 +33,20 @@ exec 3>&1
 exec >"$SMOKE_LOG" 2>&1
 cp "${INTERNAL_TESTING}/provider.tf" "${INTERNAL_TESTING}/variables.tf" "${SMOKE_DIR}/"
 cp "${INTERNAL_TESTING}/terraform.tfvars.example" "${SMOKE_DIR}/terraform.tfvars"
-cp "${INTERNAL_TESTING}/terraformrc" "${SMOKE_DIR}/"
+
+# Generate the CLI config with a dev_override pointing at the provider binary
+# built by `make build` (at the repo root). Generated at runtime because Terraform
+# CLI config files can't interpolate paths, and hard-coding an absolute path only
+# works on one machine. PROVIDER_DIR may be overridden to point elsewhere.
+PROVIDER_DIR="${PROVIDER_DIR:-$REPO_ROOT}"
+cat >"${SMOKE_DIR}/terraformrc" <<EOF
+provider_installation {
+  dev_overrides {
+    "ncecere/litellm" = "${PROVIDER_DIR}"
+  }
+  direct {}
+}
+EOF
 export TF_CLI_CONFIG_FILE="${SMOKE_DIR}/terraformrc"
 export TF_CLI_ARGS="-no-color"
 

--- a/internal_testing/terraformrc
+++ b/internal_testing/terraformrc
@@ -1,6 +1,0 @@
-provider_installation {
-  dev_overrides {
-    "ncecere/litellm" = "/Users/nickcecere/Projects/Terraform/terraform-provider-litellm"
-  }
-  direct {}
-}


### PR DESCRIPTION
## Problem

The smoke-test harness (`make smoke`) copies a static `internal_testing/terraformrc` whose `dev_overrides` path is hard-coded to one contributor's machine:

```hcl
provider_installation {
  dev_overrides {
    "ncecere/litellm" = "/Users/nickcecere/Projects/Terraform/terraform-provider-litellm"
  }
  direct {}
}
```

So on any other machine `make smoke` fails before running anything:

```
Error: Failed to load plugin schemas
Error while loading schemas for plugin components: Failed to obtain provider
  .../nickcecere/...: no such file
```

## Fix

Generate the CLI config in `smoke.sh` at runtime, pointing `dev_overrides` at the provider binary `make build` produces at the repo root (`$REPO_ROOT`, which the script already computes). It's generated rather than templated because Terraform CLI config files can't interpolate paths/env vars. An escape hatch (`PROVIDER_DIR`) lets you point it elsewhere.

- `internal_testing/smoke.sh` — generate `terraformrc` in the smoke workspace instead of copying the static one.
- `internal_testing/terraformrc` — removed (machine-specific, no longer used).
- `internal_testing/README.md` — the manual walkthrough now generates its own `.dev.tfrc` (gitignored) instead of pointing at the deleted file.
- `.gitignore` — ignore the generated `.dev.tfrc`.

## Verified

Against the bundled `internal_testing` docker compose LiteLLM, on a machine that is **not** the hard-coded path:

```
make local
make smoke resources=tag_minimal.tf                    # Smoke passed
make smoke resources=model_minimal.tf,budget_minimal.tf # Smoke passed
```

The generated config now correctly points at the local checkout, and apply/destroy complete cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
