### PR TITLE
test(smoke): add configs for `agent` and `unified_access_group`

### DIFF
--- a/internal_testing/datasources/agent.tf
+++ b/internal_testing/datasources/agent.tf
@@ -1,0 +1,10 @@
+# data.litellm_agent - Looks up an agent by id
+# Note: references the agent created by resources/agent_minimal.tf
+
+data "litellm_agent" "lookup" {
+  id = litellm_agent.minimal.id
+}
+
+output "ds_agent_name" {
+  value = data.litellm_agent.lookup.agent_name
+}

--- a/internal_testing/datasources/agents_list.tf
+++ b/internal_testing/datasources/agents_list.tf
@@ -1,0 +1,8 @@
+# data.litellm_agents - Lists all agents
+
+data "litellm_agents" "all" {
+}
+
+output "ds_agents_list" {
+  value = data.litellm_agents.all
+}

--- a/internal_testing/datasources/unified_access_group.tf
+++ b/internal_testing/datasources/unified_access_group.tf
@@ -1,0 +1,10 @@
+# data.litellm_unified_access_group - Looks up a unified access group by id
+# Note: references the group created by resources/unified_access_group_minimal.tf
+
+data "litellm_unified_access_group" "lookup" {
+  access_group_id = litellm_unified_access_group.minimal.id
+}
+
+output "ds_unified_access_group_name" {
+  value = data.litellm_unified_access_group.lookup.access_group_name
+}

--- a/internal_testing/datasources/unified_access_groups_list.tf
+++ b/internal_testing/datasources/unified_access_groups_list.tf
@@ -1,0 +1,8 @@
+# data.litellm_unified_access_groups - Lists all unified access groups
+
+data "litellm_unified_access_groups" "all" {
+}
+
+output "ds_unified_access_groups_list" {
+  value = data.litellm_unified_access_groups.all
+}

--- a/internal_testing/resources/agent_minimal.tf
+++ b/internal_testing/resources/agent_minimal.tf
@@ -1,0 +1,15 @@
+# litellm_agent - Minimal
+# Only required attributes: agent_name and an agent_card block (name + url).
+
+resource "litellm_agent" "minimal" {
+  agent_name = "test-agent-minimal"
+
+  agent_card {
+    name = "Test Agent Minimal"
+    url  = "https://agent.example.com/a2a"
+  }
+}
+
+output "agent_minimal_id" {
+  value = litellm_agent.minimal.id
+}

--- a/internal_testing/resources/unified_access_group_minimal.tf
+++ b/internal_testing/resources/unified_access_group_minimal.tf
@@ -1,0 +1,11 @@
+# litellm_unified_access_group - Minimal
+# Only the required attribute: access_group_name. Uses the current
+# /v1/access_group API.
+
+resource "litellm_unified_access_group" "minimal" {
+  access_group_name = "test-unified-access-group-minimal"
+}
+
+output "unified_access_group_minimal_id" {
+  value = litellm_unified_access_group.minimal.id
+}


### PR DESCRIPTION
## Gap

I audited the smoke configs in `internal_testing/` against the provider's registered resources/data sources. Coverage is broad, but three newer resources had **no** smoke config at all: `agent`, `project`, and `unified_access_group` (plus their data sources).

This PR fills two of them.

## Added

- `resources/agent_minimal.tf` + `datasources/agent.tf`, `datasources/agents_list.tf`
- `resources/unified_access_group_minimal.tf` + `datasources/unified_access_group.tf`, `datasources/unified_access_groups_list.tf`

Configs follow the existing minimal-config conventions (comment header, required attributes only, an `output` for the id).

## Verified

Each was run end-to-end against the bundled `internal_testing` docker compose LiteLLM — resource applies, reads back through both its single and list data source, re-plans with **no drift**, and destroys cleanly. (The unified-access-group data source correctly resolved `access_group_name = "test-unified-access-group-minimal"`.)

## Left out: `litellm_project`

`litellm_project` is the third gap, but I left it out deliberately: `/project/new` returns

```
403 "Project management is an enterprise feature. You must be a LiteLLM Enterprise user..."
```

on the open-source proxy, so a project smoke config would fail `make smoke` for anyone without an enterprise license. Worth a separate decision (e.g. gate it behind `LITELLM_LICENSE`) rather than adding a config that can't run against the standard local backend.

> Note: running `make smoke` locally currently also needs the hard-coded-path fix in #135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
