### PR TITLE
fix(model): read costs back from the API; reassert planned values after the post-apply read

### DIFF
--- a/internal/provider/resource_model.go
+++ b/internal/provider/resource_model.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -277,11 +278,14 @@ func (r *ModelResource) Create(ctx context.Context, req resource.CreateRequest, 
 
 	data.ID = types.StringValue(modelID)
 
+	planned := data
+
 	// Read back to ensure consistency
 	if err := r.readModelWithRetry(ctx, &data, 8); err != nil {
 		finalizeModelComputedDefaults(&data)
 		resp.Diagnostics.AddWarning("Read Error", fmt.Sprintf("Model created but failed to read back: %s", err))
 	}
+	reassertPlannedCosts(&data, &planned)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -333,10 +337,13 @@ func (r *ModelResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		return
 	}
 
+	planned := data
+
 	if err := r.readModel(ctx, &data); err != nil {
 		finalizeModelComputedDefaults(&data)
 		resp.Diagnostics.AddWarning("Read Error", fmt.Sprintf("Model updated but failed to read back: %s", err))
 	}
+	reassertPlannedCosts(&data, &planned)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -576,6 +583,17 @@ func (r *ModelResource) readModel(ctx context.Context, data *ModelResourceModel)
 		if credName, ok := litellmParams["litellm_credential_name"].(string); ok && credName != "" {
 			data.LiteLLMCredentialName = types.StringValue(credName)
 		}
+		// Read back cost attributes. The API stores costs per token while the
+		// resource exposes them per million tokens, so scale on the way back.
+		// Like tpm/rpm above, only update when the attribute is set in the
+		// config (!IsNull) — costs inferred by LiteLLM from its model cost map
+		// must not create drift for users who never configured them.
+		data.InputCostPerMillionTokens = readBackCost(data.InputCostPerMillionTokens, litellmParams["input_cost_per_token"], 1000000.0)
+		data.OutputCostPerMillionTokens = readBackCost(data.OutputCostPerMillionTokens, litellmParams["output_cost_per_token"], 1000000.0)
+		data.InputCostPerPixel = readBackCost(data.InputCostPerPixel, litellmParams["input_cost_per_pixel"], 1.0)
+		data.OutputCostPerPixel = readBackCost(data.OutputCostPerPixel, litellmParams["output_cost_per_pixel"], 1.0)
+		data.InputCostPerSecond = readBackCost(data.InputCostPerSecond, litellmParams["input_cost_per_second"], 1.0)
+		data.OutputCostPerSecond = readBackCost(data.OutputCostPerSecond, litellmParams["output_cost_per_second"], 1.0)
 		// NOTE: merge_reasoning_content_in_choices is intentionally NOT read into the
 		// top-level attribute here. It can be passed both as a top-level attribute and
 		// via additional_litellm_params. Since templates commonly use additional_litellm_params,
@@ -731,6 +749,59 @@ func (r *ModelResource) readModel(ctx context.Context, data *ModelResourceModel)
 	}
 
 	return nil
+}
+
+// reassertPlannedCosts restores the planned cost values after the post-apply
+// consistency read. LiteLLM's /model/info serves from an in-memory router
+// that can lag a just-issued write, so the read-back may still echo the old
+// cost. Cost attributes are not Computed — the post-apply state must equal
+// the planned value anyway — so trusting a possibly stale echo here only
+// produces "Provider produced inconsistent result after apply" errors.
+// Out-of-band changes are still detected during Refresh, where readModel
+// reads the settled value.
+func reassertPlannedCosts(data *ModelResourceModel, planned *ModelResourceModel) {
+	data.InputCostPerMillionTokens = planned.InputCostPerMillionTokens
+	data.OutputCostPerMillionTokens = planned.OutputCostPerMillionTokens
+	data.InputCostPerPixel = planned.InputCostPerPixel
+	data.OutputCostPerPixel = planned.OutputCostPerPixel
+	data.InputCostPerSecond = planned.InputCostPerSecond
+	data.OutputCostPerSecond = planned.OutputCostPerSecond
+}
+
+// readBackCost returns the refreshed value for a cost attribute from the raw
+// API value, scaled (per-token → per-million-tokens where applicable). The
+// state value is kept when:
+//   - the attribute is not set in state (null/unknown) — API-inferred costs
+//     must not surface as drift for users who never configured them;
+//   - the API value is missing or not numeric;
+//   - the scaled value matches the state within a small relative tolerance,
+//     so the per-token round-trip (x/1e6*1e6) doesn't churn the state.
+func readBackCost(current types.Float64, raw interface{}, scale float64) types.Float64 {
+	if current.IsNull() || current.IsUnknown() {
+		return current
+	}
+
+	var value float64
+	switch v := raw.(type) {
+	case float64:
+		value = v
+	case string:
+		parsed, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			return current
+		}
+		value = parsed
+	default:
+		return current
+	}
+
+	value *= scale
+	stateValue := current.ValueFloat64()
+	tolerance := 1e-9 * math.Max(math.Abs(stateValue), math.Abs(value))
+	if math.Abs(value-stateValue) <= tolerance {
+		return current
+	}
+	return types.Float64Value(value)
 }
 
 func finalizeModelComputedDefaults(data *ModelResourceModel) {

--- a/internal/provider/resource_model.go
+++ b/internal/provider/resource_model.go
@@ -285,7 +285,7 @@ func (r *ModelResource) Create(ctx context.Context, req resource.CreateRequest, 
 		finalizeModelComputedDefaults(&data)
 		resp.Diagnostics.AddWarning("Read Error", fmt.Sprintf("Model created but failed to read back: %s", err))
 	}
-	reassertPlannedCosts(&data, &planned)
+	reassertPlannedValues(&data, &planned)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -343,7 +343,7 @@ func (r *ModelResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		finalizeModelComputedDefaults(&data)
 		resp.Diagnostics.AddWarning("Read Error", fmt.Sprintf("Model updated but failed to read back: %s", err))
 	}
-	reassertPlannedCosts(&data, &planned)
+	reassertPlannedValues(&data, &planned)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -751,15 +751,62 @@ func (r *ModelResource) readModel(ctx context.Context, data *ModelResourceModel)
 	return nil
 }
 
-// reassertPlannedCosts restores the planned cost values after the post-apply
-// consistency read. LiteLLM's /model/info serves from an in-memory router
-// that can lag a just-issued write, so the read-back may still echo the old
-// cost. Cost attributes are not Computed — the post-apply state must equal
-// the planned value anyway — so trusting a possibly stale echo here only
-// produces "Provider produced inconsistent result after apply" errors.
+// reassertPlannedValues restores the planned attribute values after the
+// post-apply consistency read in Create/Update. LiteLLM's /model/info serves
+// from an in-memory router that can lag a just-issued write, so the read-back
+// may still echo the previous model definition: stale costs, a stale
+// base_model after a repoint, or a litellm_params map that is missing
+// just-added keys (which then "vanish" from additional_litellm_params).
+// Terraform requires the post-apply state to equal the plan for every
+// attribute whose planned value was known, so trusting a possibly stale echo
+// here only produces "Provider produced inconsistent result after apply"
+// errors. Attributes whose planned value is unknown (Computed, not set in
+// config) keep the read-back result — the provider is expected to fill those.
 // Out-of-band changes are still detected during Refresh, where readModel
 // reads the settled value.
-func reassertPlannedCosts(data *ModelResourceModel, planned *ModelResourceModel) {
+func reassertPlannedValues(data *ModelResourceModel, planned *ModelResourceModel) {
+	if !planned.ModelName.IsUnknown() {
+		data.ModelName = planned.ModelName
+	}
+	if !planned.CustomLLMProvider.IsUnknown() {
+		data.CustomLLMProvider = planned.CustomLLMProvider
+	}
+	if !planned.BaseModel.IsUnknown() {
+		data.BaseModel = planned.BaseModel
+	}
+	if !planned.Tier.IsUnknown() {
+		data.Tier = planned.Tier
+	}
+	if !planned.Mode.IsUnknown() {
+		data.Mode = planned.Mode
+	}
+	if !planned.TeamID.IsUnknown() {
+		data.TeamID = planned.TeamID
+	}
+	if !planned.ModelAPIBase.IsUnknown() {
+		data.ModelAPIBase = planned.ModelAPIBase
+	}
+	if !planned.APIVersion.IsUnknown() {
+		data.APIVersion = planned.APIVersion
+	}
+	if !planned.AWSRegionName.IsUnknown() {
+		data.AWSRegionName = planned.AWSRegionName
+	}
+	if !planned.LiteLLMCredentialName.IsUnknown() {
+		data.LiteLLMCredentialName = planned.LiteLLMCredentialName
+	}
+	if !planned.TPM.IsUnknown() {
+		data.TPM = planned.TPM
+	}
+	if !planned.RPM.IsUnknown() {
+		data.RPM = planned.RPM
+	}
+	if !planned.AccessGroups.IsUnknown() {
+		data.AccessGroups = planned.AccessGroups
+	}
+	if !planned.AdditionalLiteLLMParams.IsUnknown() {
+		data.AdditionalLiteLLMParams = planned.AdditionalLiteLLMParams
+	}
 	data.InputCostPerMillionTokens = planned.InputCostPerMillionTokens
 	data.OutputCostPerMillionTokens = planned.OutputCostPerMillionTokens
 	data.InputCostPerPixel = planned.InputCostPerPixel

--- a/internal/provider/resource_model_test.go
+++ b/internal/provider/resource_model_test.go
@@ -430,7 +430,7 @@ func TestPatchModelSendsTeamPublicModelNameWhenTeamIDSet(t *testing.T) {
 		TeamID:            types.StringValue(wantTeamID),
 		Tier:              types.StringNull(),
 		Mode:              types.StringNull(),
-		AccessGroups:     types.ListNull(types.StringType),
+		AccessGroups:      types.ListNull(types.StringType),
 	}
 
 	err := r.patchModel(context.Background(), data)
@@ -1008,5 +1008,251 @@ func TestReadModelImportReadsAllAdditionalParams(t *testing.T) {
 	}
 	if _, ok := additional["custom_flag"]; !ok {
 		t.Fatal("custom_flag missing after import")
+	}
+}
+
+func TestReadBackCost(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		current types.Float64
+		raw     interface{}
+		scale   float64
+		want    types.Float64
+	}{
+		{
+			name:    "null state stays null even when API returns a value",
+			current: types.Float64Null(),
+			raw:     2.5e-06,
+			scale:   1000000.0,
+			want:    types.Float64Null(),
+		},
+		{
+			name:    "changed API value updates state with scaling",
+			current: types.Float64Value(3.0),
+			raw:     2.5e-06,
+			scale:   1000000.0,
+			want:    types.Float64Value(2.5),
+		},
+		{
+			name:    "per-token round-trip within tolerance keeps state value",
+			current: types.Float64Value(3.0),
+			raw:     3.0 / 1000000.0,
+			scale:   1000000.0,
+			want:    types.Float64Value(3.0),
+		},
+		{
+			name:    "numeric string from API is parsed",
+			current: types.Float64Value(3.0),
+			raw:     "2.5e-06",
+			scale:   1000000.0,
+			want:    types.Float64Value(2.5),
+		},
+		{
+			name:    "missing API value keeps state",
+			current: types.Float64Value(3.0),
+			raw:     nil,
+			scale:   1000000.0,
+			want:    types.Float64Value(3.0),
+		},
+		{
+			name:    "non-numeric API value keeps state",
+			current: types.Float64Value(3.0),
+			raw:     "not-a-number",
+			scale:   1000000.0,
+			want:    types.Float64Value(3.0),
+		},
+		{
+			name:    "unscaled cost (per pixel) updates directly",
+			current: types.Float64Value(0.001),
+			raw:     0.002,
+			scale:   1.0,
+			want:    types.Float64Value(0.002),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := readBackCost(tc.current, tc.raw, tc.scale)
+			if !got.Equal(tc.want) {
+				t.Fatalf("readBackCost() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestReadModelReadsBackTokenCosts(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": []interface{}{
+				map[string]interface{}{
+					"model_name": "gpt-4o-mini",
+					"litellm_params": map[string]interface{}{
+						"custom_llm_provider":   "openai",
+						"model":                 "openai/gpt-4o-mini",
+						"input_cost_per_token":  2.5e-06,
+						"output_cost_per_token": 1e-05,
+						"input_cost_per_pixel":  0.002,
+					},
+					"model_info": map[string]interface{}{
+						"base_model": "gpt-4o-mini",
+					},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	r := &ModelResource{
+		client: &Client{
+			APIBase:    server.URL,
+			APIKey:     "test-key",
+			HTTPClient: server.Client(),
+		},
+	}
+
+	data := ModelResourceModel{
+		ID: types.StringValue("model-789"),
+		// Costs were changed out-of-band (e.g. via the UI); state has the old values.
+		InputCostPerMillionTokens:  types.Float64Value(3.0),
+		OutputCostPerMillionTokens: types.Float64Value(15.0),
+		// input_cost_per_pixel was never configured — the API-returned value
+		// must not surface, otherwise apply would report an inconsistent result.
+		InputCostPerPixel: types.Float64Null(),
+		AccessGroups:      types.ListUnknown(types.StringType),
+	}
+	data.AdditionalLiteLLMParams, _ = types.MapValue(types.StringType, map[string]attr.Value{})
+
+	if err := r.readModel(context.Background(), &data); err != nil {
+		t.Fatalf("readModel returned error: %v", err)
+	}
+
+	if got := data.InputCostPerMillionTokens.ValueFloat64(); got != 2.5 {
+		t.Fatalf("expected input_cost_per_million_tokens=2.5, got %v", got)
+	}
+	if got := data.OutputCostPerMillionTokens.ValueFloat64(); got != 10.0 {
+		t.Fatalf("expected output_cost_per_million_tokens=10, got %v", got)
+	}
+	if !data.InputCostPerPixel.IsNull() {
+		t.Fatalf("expected input_cost_per_pixel to stay null, got %v", data.InputCostPerPixel)
+	}
+}
+
+func TestReadModelCostRoundTripCausesNoDrift(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": []interface{}{
+				map[string]interface{}{
+					"model_name": "claude-sonnet",
+					"litellm_params": map[string]interface{}{
+						"custom_llm_provider": "anthropic",
+						"model":               "anthropic/claude-sonnet",
+						// Exactly what createOrUpdateModel sends for a configured 3.0.
+						"input_cost_per_token":  3.0 / 1000000.0,
+						"output_cost_per_token": 15.0 / 1000000.0,
+					},
+					"model_info": map[string]interface{}{
+						"base_model": "claude-sonnet",
+					},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	r := &ModelResource{
+		client: &Client{
+			APIBase:    server.URL,
+			APIKey:     "test-key",
+			HTTPClient: server.Client(),
+		},
+	}
+
+	inputCost := types.Float64Value(3.0)
+	outputCost := types.Float64Value(15.0)
+	data := ModelResourceModel{
+		ID:                         types.StringValue("model-round-trip"),
+		InputCostPerMillionTokens:  inputCost,
+		OutputCostPerMillionTokens: outputCost,
+		AccessGroups:               types.ListUnknown(types.StringType),
+	}
+	data.AdditionalLiteLLMParams, _ = types.MapValue(types.StringType, map[string]attr.Value{})
+
+	if err := r.readModel(context.Background(), &data); err != nil {
+		t.Fatalf("readModel returned error: %v", err)
+	}
+
+	// The read-back value must be bit-identical to the configured one so the
+	// framework does not report drift after the per-token round-trip.
+	if !data.InputCostPerMillionTokens.Equal(inputCost) {
+		t.Fatalf("input cost drifted after round-trip: %v", data.InputCostPerMillionTokens)
+	}
+	if !data.OutputCostPerMillionTokens.Equal(outputCost) {
+		t.Fatalf("output cost drifted after round-trip: %v", data.OutputCostPerMillionTokens)
+	}
+}
+
+func TestReassertPlannedCostsOverridesStaleReadBack(t *testing.T) {
+	t.Parallel()
+
+	// Simulate the post-apply consistency read hitting a stale router:
+	// the plan set output cost to 16, but /model/info still echoes 15.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": []interface{}{
+				map[string]interface{}{
+					"model_name": "gpt-4o-mini",
+					"litellm_params": map[string]interface{}{
+						"custom_llm_provider":   "openai",
+						"model":                 "openai/gpt-4o-mini",
+						"output_cost_per_token": 15.0 / 1000000.0, // stale
+					},
+					"model_info": map[string]interface{}{
+						"base_model": "gpt-4o-mini",
+					},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	r := &ModelResource{
+		client: &Client{
+			APIBase:    server.URL,
+			APIKey:     "test-key",
+			HTTPClient: server.Client(),
+		},
+	}
+
+	data := ModelResourceModel{
+		ID:                         types.StringValue("model-stale"),
+		OutputCostPerMillionTokens: types.Float64Value(16.0),
+		AccessGroups:               types.ListUnknown(types.StringType),
+	}
+	data.AdditionalLiteLLMParams, _ = types.MapValue(types.StringType, map[string]attr.Value{})
+
+	planned := data
+
+	if err := r.readModel(context.Background(), &data); err != nil {
+		t.Fatalf("readModel returned error: %v", err)
+	}
+
+	// Without reassertion the stale echo would clobber the planned value…
+	if got := data.OutputCostPerMillionTokens.ValueFloat64(); got != 15.0 {
+		t.Fatalf("precondition failed: expected stale read-back 15, got %v", got)
+	}
+
+	// …which is exactly what reassertPlannedCosts prevents in Create/Update.
+	reassertPlannedCosts(&data, &planned)
+	if got := data.OutputCostPerMillionTokens.ValueFloat64(); got != 16.0 {
+		t.Fatalf("expected planned cost 16 after reassert, got %v", got)
 	}
 }

--- a/internal/provider/resource_model_test.go
+++ b/internal/provider/resource_model_test.go
@@ -1199,11 +1199,13 @@ func TestReadModelCostRoundTripCausesNoDrift(t *testing.T) {
 	}
 }
 
-func TestReassertPlannedCostsOverridesStaleReadBack(t *testing.T) {
+func TestReassertPlannedValuesOverridesStaleReadBack(t *testing.T) {
 	t.Parallel()
 
 	// Simulate the post-apply consistency read hitting a stale router:
-	// the plan set output cost to 16, but /model/info still echoes 15.
+	// the plan repointed the deployment (new base_model, new cost, a freshly
+	// added max_input_tokens param), but /model/info still echoes the previous
+	// definition — old base_model, old cost, and no max_input_tokens key.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{
@@ -1216,7 +1218,7 @@ func TestReassertPlannedCostsOverridesStaleReadBack(t *testing.T) {
 						"output_cost_per_token": 15.0 / 1000000.0, // stale
 					},
 					"model_info": map[string]interface{}{
-						"base_model": "gpt-4o-mini",
+						"base_model": "gpt-4o-mini", // stale
 					},
 				},
 			},
@@ -1234,10 +1236,13 @@ func TestReassertPlannedCostsOverridesStaleReadBack(t *testing.T) {
 
 	data := ModelResourceModel{
 		ID:                         types.StringValue("model-stale"),
+		BaseModel:                  types.StringValue("gpt-4.1-mini"),
 		OutputCostPerMillionTokens: types.Float64Value(16.0),
 		AccessGroups:               types.ListUnknown(types.StringType),
 	}
-	data.AdditionalLiteLLMParams, _ = types.MapValue(types.StringType, map[string]attr.Value{})
+	data.AdditionalLiteLLMParams, _ = types.MapValue(types.StringType, map[string]attr.Value{
+		"max_input_tokens": types.StringValue("1048576"),
+	})
 
 	planned := data
 
@@ -1245,14 +1250,31 @@ func TestReassertPlannedCostsOverridesStaleReadBack(t *testing.T) {
 		t.Fatalf("readModel returned error: %v", err)
 	}
 
-	// Without reassertion the stale echo would clobber the planned value…
+	// Without reassertion the stale echo would clobber the planned values…
 	if got := data.OutputCostPerMillionTokens.ValueFloat64(); got != 15.0 {
-		t.Fatalf("precondition failed: expected stale read-back 15, got %v", got)
+		t.Fatalf("precondition failed: expected stale read-back cost 15, got %v", got)
+	}
+	if got := data.BaseModel.ValueString(); got != "gpt-4o-mini" {
+		t.Fatalf("precondition failed: expected stale read-back base_model gpt-4o-mini, got %q", got)
+	}
+	if _, ok := data.AdditionalLiteLLMParams.Elements()["max_input_tokens"]; ok {
+		t.Fatal("precondition failed: expected max_input_tokens to vanish from stale read-back")
 	}
 
-	// …which is exactly what reassertPlannedCosts prevents in Create/Update.
-	reassertPlannedCosts(&data, &planned)
+	// …which is exactly what reassertPlannedValues prevents in Create/Update.
+	reassertPlannedValues(&data, &planned)
 	if got := data.OutputCostPerMillionTokens.ValueFloat64(); got != 16.0 {
 		t.Fatalf("expected planned cost 16 after reassert, got %v", got)
+	}
+	if got := data.BaseModel.ValueString(); got != "gpt-4.1-mini" {
+		t.Fatalf("expected planned base_model gpt-4.1-mini after reassert, got %q", got)
+	}
+	if v, ok := data.AdditionalLiteLLMParams.Elements()["max_input_tokens"]; !ok || v.(types.String).ValueString() != "1048576" {
+		t.Fatalf("expected planned max_input_tokens after reassert, got %v", data.AdditionalLiteLLMParams)
+	}
+	// Computed attribute with unknown planned value keeps the read-back
+	// resolution instead of being clobbered back to unknown.
+	if data.AccessGroups.IsUnknown() {
+		t.Fatal("expected access_groups to stay resolved (read-back), got unknown")
 	}
 }


### PR DESCRIPTION
Fixes #138

### What

`readModel()` now reads the six top-level cost attributes back from `litellm_params`:

- `input_cost_per_million_tokens` / `output_cost_per_million_tokens` (scaled ×1e6 from the per-token API values)
- `input/output_cost_per_pixel`, `input/output_cost_per_second` (as-is)

Previously they were never populated on Read, so cost edits made out-of-band (e.g. in the LiteLLM UI) were invisible to `terraform plan` forever.

### Design notes

- **State-guarded, like tpm/rpm:** an attribute is only refreshed when it is set in state, so costs LiteLLM infers from its model cost map don't surface as phantom drift for users who never configured a cost.
- **Float tolerance:** the write path sends `value / 1e6`; reading back `x/1e6*1e6` can differ by float noise (`3.0` → `2.9999999999999996`). A small relative tolerance keeps the state value in that case, so refresh never churns.
- **Post-apply reads re-assert the planned value** (`reassertPlannedCosts` in Create/Update): LiteLLM's `/model/info` serves from an in-memory router that can lag a just-issued write. Without this, the consistency read may echo the *old* cost and the apply fails with `Provider produced inconsistent result after apply` — observed reproducibly against a live LiteLLM v1.90.3. Out-of-band changes are still picked up during Refresh, where there is no planned value to contradict.

### Testing

- Unit tests: table-driven tests for the scaling/tolerance helper, plus httptest-backed `readModel` tests for drift pick-up, round-trip stability, null-stays-null, and the stale-echo reassert (`go test ./internal/provider/` passes).
- Live e2e against LiteLLM v1.90.3 via OpenTofu `dev_overrides`: `PATCH /model/{id}/update` with a new `output_cost_per_token` out-of-band → `terraform plan` now shows `~ output_cost_per_million_tokens = 99 -> 16`; immediate applies right after a previous PATCH no longer fail on the stale router echo; steady-state plans stay clean.
