### PR TITLE
fix(model): keep known state for access_groups and additional_litellm_params in plans

### DIFF
--- a/internal/provider/resource_model.go
+++ b/internal/provider/resource_model.go
@@ -15,6 +15,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -228,12 +230,18 @@ func (r *ModelResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 				Optional:    true,
 				Computed:    true,
 				ElementType: types.StringType,
+				PlanModifiers: []planmodifier.List{
+					listplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"additional_litellm_params": schema.MapAttribute{
 				Description: "Additional parameters to pass to litellm_params.",
 				Optional:    true,
 				Computed:    true,
 				ElementType: types.StringType,
+				PlanModifiers: []planmodifier.Map{
+					mapplanmodifier.UseStateForUnknown(),
+				},
 			},
 		},
 	}


### PR DESCRIPTION
Fixes #139

### What

Adds `UseStateForUnknown` plan modifiers to two `litellm_model` attributes that are `Optional + Computed` but had no modifier, so every update plan showed them as `(known after apply)` even when untouched:

- `access_groups` → `listplanmodifier.UseStateForUnknown()`
- `additional_litellm_params` → `mapplanmodifier.UseStateForUnknown()`

This matches what `id` and `mode` already do.

### Why it's safe

`readModel()` already preserves the prior state value when the API omits these fields, so the state value is the correct prediction for an attribute the plan doesn't change.

### Testing

- `go test ./internal/provider/` passes.
- Live e2e against LiteLLM v1.90.3 via OpenTofu `dev_overrides`: before — changing a single cost attribute also printed `access_groups = [] -> (known after apply)` and `additional_litellm_params -> (known after apply)`; after — the plan shows only the changed attribute (`~ output_cost_per_million_tokens = 15 -> 16`, everything else "unchanged attributes hidden"), and a follow-up plan is clean.
