### PR TITLE
feat(model): add additional_model_info for arbitrary model_info fields

### DIFF
--- a/docs/resources/model.md
+++ b/docs/resources/model.md
@@ -264,6 +264,26 @@ The following arguments are supported:
   }
   ```
 
+* `additional_model_info` - (Optional) map(string). A map of arbitrary additional fields that will be merged into the `model_info` object sent to the LiteLLM API. The main use case is declaring capability flags (`supports_vision`, `supports_function_calling`, `supports_reasoning`, `supports_response_schema`, …) for models that are missing from LiteLLM's model cost map, so that `/model/info` and `/v1/models` advertise the model's capabilities to clients.
+
+  * Values follow the same string-to-native conversion rules as `additional_litellm_params` (booleans, integers, floats, JSON).
+  * Only keys configured here are managed. LiteLLM merges metadata derived from its model cost map (`max_tokens`, `supports_*`, `litellm_provider`, …) into `/model/info` responses; those derived fields are ignored on read so they never appear as drift, and they are not captured on import.
+  * **Limitation: keys cannot be deleted via update.** Same PATCH-merge behavior as `additional_litellm_params` — to fully remove a key, recreate the resource with `terraform apply -replace`.
+
+  ```hcl
+  resource "litellm_model" "kimi_k3" {
+    model_name          = "kimi-k3"
+    custom_llm_provider = "openrouter"
+    base_model          = "moonshotai/kimi-k3"
+    mode                = "chat"
+
+    additional_model_info = {
+      "supports_vision"           = "true"  # becomes boolean true
+      "supports_function_calling" = "true"
+    }
+  }
+  ```
+
 ### AWS-specific Configuration
 
 * `aws_access_key_id` - (Optional) string (Sensitive). AWS access key ID for AWS-based models.

--- a/internal/provider/resource_model.go
+++ b/internal/provider/resource_model.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -69,6 +70,7 @@ type ModelResourceModel struct {
 	VertexCredentials              types.String  `tfsdk:"vertex_credentials"`
 	AccessGroups                   types.List    `tfsdk:"access_groups"`
 	AdditionalLiteLLMParams        types.Map     `tfsdk:"additional_litellm_params"`
+	AdditionalModelInfo            types.Map     `tfsdk:"additional_model_info"`
 }
 
 func (r *ModelResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -235,6 +237,19 @@ func (r *ModelResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 				Computed:    true,
 				ElementType: types.StringType,
 			},
+			"additional_model_info": schema.MapAttribute{
+				Description: "Additional fields to store in model_info, e.g. capability flags " +
+					"(supports_vision, supports_function_calling, supports_reasoning, …) for models " +
+					"missing from LiteLLM's model cost map. Values are strings and are converted to " +
+					"native JSON types (int, float, bool, JSON) for the API. Only keys configured " +
+					"here are managed; fields LiteLLM derives from its model cost map are left alone.",
+				Optional:    true,
+				Computed:    true,
+				ElementType: types.StringType,
+				PlanModifiers: []planmodifier.Map{
+					mapplanmodifier.UseStateForUnknown(),
+				},
+			},
 		},
 	}
 }
@@ -264,9 +279,11 @@ func (r *ModelResource) Create(ctx context.Context, req resource.CreateRequest, 
 		return
 	}
 
-	// Normalise numeric strings in additional_litellm_params so that the
-	// planned value uses the same canonical form as the read-back value.
+	// Normalise numeric strings in additional_litellm_params and
+	// additional_model_info so that the planned value uses the same
+	// canonical form as the read-back value.
 	data.AdditionalLiteLLMParams = normalizeAdditionalParams(ctx, data.AdditionalLiteLLMParams)
+	data.AdditionalModelInfo = normalizeAdditionalParams(ctx, data.AdditionalModelInfo)
 
 	modelID := uuid.New().String()
 
@@ -315,9 +332,11 @@ func (r *ModelResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		return
 	}
 
-	// Normalise numeric strings in additional_litellm_params so that the
-	// planned value uses the same canonical form as the read-back value.
+	// Normalise numeric strings in additional_litellm_params and
+	// additional_model_info so that the planned value uses the same
+	// canonical form as the read-back value.
 	data.AdditionalLiteLLMParams = normalizeAdditionalParams(ctx, data.AdditionalLiteLLMParams)
+	data.AdditionalModelInfo = normalizeAdditionalParams(ctx, data.AdditionalModelInfo)
 
 	var state ModelResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
@@ -495,6 +514,16 @@ func (r *ModelResource) createOrUpdateModel(ctx context.Context, data *ModelReso
 		}
 	}
 
+	// Add additional_model_info to the request. Like additional_litellm_params,
+	// values are strings in Terraform but converted to native types for the API.
+	if !data.AdditionalModelInfo.IsNull() && !data.AdditionalModelInfo.IsUnknown() {
+		elements := make(map[string]string)
+		data.AdditionalModelInfo.ElementsAs(ctx, &elements, false)
+		for key, value := range elements {
+			modelInfo[key] = convertStringValue(value)
+		}
+	}
+
 	modelReq := map[string]interface{}{
 		"model_name":     data.ModelName.ValueString(),
 		"litellm_params": litellmParams,
@@ -642,28 +671,8 @@ func (r *ModelResource) readModel(ctx context.Context, data *ModelResourceModel)
 				}
 			}
 
-			switch v := rawValue.(type) {
-			case string:
-				// Normalize numeric strings to decimal notation so that
-				// "1.75e-07" (from API) matches "0.000000175" (from config).
-				if f, err := strconv.ParseFloat(v, 64); err == nil {
-					additionalParams[key] = types.StringValue(strconv.FormatFloat(f, 'f', -1, 64))
-				} else {
-					additionalParams[key] = types.StringValue(v)
-				}
-			case bool:
-				additionalParams[key] = types.StringValue(strconv.FormatBool(v))
-			case float64:
-				additionalParams[key] = types.StringValue(strconv.FormatFloat(v, 'f', -1, 64))
-			case int:
-				additionalParams[key] = types.StringValue(strconv.Itoa(v))
-			case int64:
-				additionalParams[key] = types.StringValue(strconv.FormatInt(v, 10))
-			default:
-				// Arrays, objects, and other complex types — serialize back to JSON string.
-				if jsonBytes, err := json.Marshal(v); err == nil {
-					additionalParams[key] = types.StringValue(string(jsonBytes))
-				}
+			if v, ok := stringifyAPIValue(rawValue); ok {
+				additionalParams[key] = v
 			}
 		}
 
@@ -721,6 +730,31 @@ func (r *ModelResource) readModel(ctx context.Context, data *ModelResourceModel)
 		data.AccessGroups, _ = types.ListValue(types.StringType, []attr.Value{})
 	}
 
+	// Read back additional_model_info. Only keys configured in state are
+	// consulted: /model/info merges metadata derived from LiteLLM's model
+	// cost map (max_tokens, supports_*, deprecation_date, …) into model_info,
+	// so echoing unknown keys — or slurping them all on import — would
+	// capture values the user never set and create permanent drift.
+	if !data.AdditionalModelInfo.IsNull() && !data.AdditionalModelInfo.IsUnknown() {
+		infoValues := make(map[string]attr.Value)
+		if hasModelInfo {
+			for key := range data.AdditionalModelInfo.Elements() {
+				rawValue, exists := modelInfo[key]
+				if !exists {
+					continue
+				}
+				if v, ok := stringifyAPIValue(rawValue); ok {
+					infoValues[key] = v
+				}
+			}
+		}
+		data.AdditionalModelInfo, _ = types.MapValue(types.StringType, infoValues)
+	} else {
+		// Resolve unknown/null to an empty map so the Computed attribute is
+		// known after apply.
+		data.AdditionalModelInfo, _ = types.MapValue(types.StringType, map[string]attr.Value{})
+	}
+
 	// Ensure mode is never Unknown after a Read. Terraform requires all
 	// Computed attributes to resolve to a known (or null) value after apply.
 	// Wildcard routes (e.g. openai/*) may not have a mode set in the API
@@ -733,6 +767,35 @@ func (r *ModelResource) readModel(ctx context.Context, data *ModelResourceModel)
 	return nil
 }
 
+// stringifyAPIValue converts a raw JSON value returned by the API into the
+// canonical string representation used by string-map attributes
+// (additional_litellm_params, additional_model_info). Numeric strings are
+// normalized to decimal notation so that "1.75e-07" (from API) matches
+// "0.000000175" (from config).
+func stringifyAPIValue(rawValue interface{}) (attr.Value, bool) {
+	switch v := rawValue.(type) {
+	case string:
+		if f, err := strconv.ParseFloat(v, 64); err == nil {
+			return types.StringValue(strconv.FormatFloat(f, 'f', -1, 64)), true
+		}
+		return types.StringValue(v), true
+	case bool:
+		return types.StringValue(strconv.FormatBool(v)), true
+	case float64:
+		return types.StringValue(strconv.FormatFloat(v, 'f', -1, 64)), true
+	case int:
+		return types.StringValue(strconv.Itoa(v)), true
+	case int64:
+		return types.StringValue(strconv.FormatInt(v, 10)), true
+	default:
+		// Arrays, objects, and other complex types — serialize back to JSON string.
+		if jsonBytes, err := json.Marshal(v); err == nil {
+			return types.StringValue(string(jsonBytes)), true
+		}
+		return nil, false
+	}
+}
+
 func finalizeModelComputedDefaults(data *ModelResourceModel) {
 	if data.Mode.IsUnknown() {
 		data.Mode = types.StringNull()
@@ -742,6 +805,9 @@ func finalizeModelComputedDefaults(data *ModelResourceModel) {
 	}
 	if data.AdditionalLiteLLMParams.IsUnknown() {
 		data.AdditionalLiteLLMParams, _ = types.MapValue(types.StringType, map[string]attr.Value{})
+	}
+	if data.AdditionalModelInfo.IsUnknown() {
+		data.AdditionalModelInfo, _ = types.MapValue(types.StringType, map[string]attr.Value{})
 	}
 }
 
@@ -909,6 +975,19 @@ func (r *ModelResource) patchModel(ctx context.Context, data *ModelResourceModel
 		data.AccessGroups.ElementsAs(ctx, &accessGroups, false)
 		if len(accessGroups) > 0 {
 			modelInfo["access_groups"] = accessGroups
+		}
+	}
+
+	// Add additional_model_info to the request. Like additional_litellm_params,
+	// values are strings in Terraform but converted to native types for the API.
+	// NOTE: LiteLLM PATCH API merges model_info, it does not replace it, so
+	// keys removed from config are not removed from the API (same as
+	// additional_litellm_params — recreate the model to fully drop a key).
+	if !data.AdditionalModelInfo.IsNull() && !data.AdditionalModelInfo.IsUnknown() {
+		elements := make(map[string]string)
+		data.AdditionalModelInfo.ElementsAs(ctx, &elements, false)
+		for key, value := range elements {
+			modelInfo[key] = convertStringValue(value)
 		}
 	}
 

--- a/internal/provider/resource_model_test.go
+++ b/internal/provider/resource_model_test.go
@@ -430,7 +430,7 @@ func TestPatchModelSendsTeamPublicModelNameWhenTeamIDSet(t *testing.T) {
 		TeamID:            types.StringValue(wantTeamID),
 		Tier:              types.StringNull(),
 		Mode:              types.StringNull(),
-		AccessGroups:     types.ListNull(types.StringType),
+		AccessGroups:      types.ListNull(types.StringType),
 	}
 
 	err := r.patchModel(context.Background(), data)
@@ -1008,5 +1008,237 @@ func TestReadModelImportReadsAllAdditionalParams(t *testing.T) {
 	}
 	if _, ok := additional["custom_flag"]; !ok {
 		t.Fatal("custom_flag missing after import")
+	}
+}
+
+func TestCreateModelSendsAdditionalModelInfo(t *testing.T) {
+	t.Parallel()
+
+	var capturedBody map[string]interface{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" {
+			_ = json.NewDecoder(r.Body).Decode(&capturedBody)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok"})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	r := &ModelResource{
+		client: &Client{
+			APIBase:    server.URL,
+			APIKey:     "test-key",
+			HTTPClient: server.Client(),
+		},
+	}
+
+	additionalInfo, _ := types.MapValue(types.StringType, map[string]attr.Value{
+		"supports_vision":           types.StringValue("true"),
+		"supports_function_calling": types.StringValue("true"),
+		"max_input_tokens":          types.StringValue("128000"),
+	})
+
+	data := &ModelResourceModel{
+		ModelName:           types.StringValue("kimi-k3"),
+		CustomLLMProvider:   types.StringValue("openrouter"),
+		BaseModel:           types.StringValue("moonshotai/kimi-k3"),
+		AdditionalModelInfo: additionalInfo,
+	}
+
+	if err := r.createOrUpdateModel(context.Background(), data, "test-id", false); err != nil {
+		t.Fatalf("createOrUpdateModel returned error: %v", err)
+	}
+
+	modelInfo, ok := capturedBody["model_info"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("model_info missing in request body: %v", capturedBody)
+	}
+
+	if got := modelInfo["supports_vision"]; got != true {
+		t.Fatalf("expected supports_vision=true (bool), got %v (%T)", got, got)
+	}
+	if got := modelInfo["supports_function_calling"]; got != true {
+		t.Fatalf("expected supports_function_calling=true (bool), got %v (%T)", got, got)
+	}
+	// convertStringValue turns "128000" into an integer.
+	if got := modelInfo["max_input_tokens"]; got != float64(128000) {
+		t.Fatalf("expected max_input_tokens=128000, got %v (%T)", got, got)
+	}
+	// Fixed fields must still be present.
+	if got := modelInfo["base_model"]; got != "moonshotai/kimi-k3" {
+		t.Fatalf("expected base_model to be preserved, got %v", got)
+	}
+}
+
+func TestPatchModelSendsAdditionalModelInfo(t *testing.T) {
+	t.Parallel()
+
+	var capturedBody map[string]interface{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "PATCH" {
+			_ = json.NewDecoder(r.Body).Decode(&capturedBody)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok"})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	r := &ModelResource{
+		client: &Client{
+			APIBase:    server.URL,
+			APIKey:     "test-key",
+			HTTPClient: server.Client(),
+		},
+	}
+
+	additionalInfo, _ := types.MapValue(types.StringType, map[string]attr.Value{
+		"supports_reasoning": types.StringValue("true"),
+	})
+
+	data := &ModelResourceModel{
+		ID:                  types.StringValue("model-info-patch"),
+		ModelName:           types.StringValue("kimi-k3"),
+		CustomLLMProvider:   types.StringValue("openrouter"),
+		BaseModel:           types.StringValue("moonshotai/kimi-k3"),
+		AdditionalModelInfo: additionalInfo,
+	}
+
+	if err := r.patchModel(context.Background(), data); err != nil {
+		t.Fatalf("patchModel returned error: %v", err)
+	}
+
+	modelInfo, ok := capturedBody["model_info"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("model_info missing in request body: %v", capturedBody)
+	}
+	if got := modelInfo["supports_reasoning"]; got != true {
+		t.Fatalf("expected supports_reasoning=true (bool), got %v (%T)", got, got)
+	}
+}
+
+func TestReadModelExtractsAdditionalModelInfoOnlyForConfiguredKeys(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": []interface{}{
+				map[string]interface{}{
+					"model_name": "kimi-k3",
+					"litellm_params": map[string]interface{}{
+						"custom_llm_provider": "openrouter",
+						"model":               "openrouter/moonshotai/kimi-k3",
+					},
+					"model_info": map[string]interface{}{
+						"base_model":      "moonshotai/kimi-k3",
+						"supports_vision": true,
+						// Metadata merged from LiteLLM's model cost map — the
+						// user never configured these and they must NOT be
+						// read into additional_model_info.
+						"max_tokens":              8192.0,
+						"supports_prompt_caching": false,
+						"litellm_provider":        "openrouter",
+						"input_cost_per_token":    2.5e-07,
+					},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	r := &ModelResource{
+		client: &Client{
+			APIBase:    server.URL,
+			APIKey:     "test-key",
+			HTTPClient: server.Client(),
+		},
+	}
+
+	priorInfo, _ := types.MapValue(types.StringType, map[string]attr.Value{
+		"supports_vision": types.StringValue("true"),
+	})
+
+	data := ModelResourceModel{
+		ID:                      types.StringValue("model-info-read"),
+		AccessGroups:            types.ListUnknown(types.StringType),
+		AdditionalLiteLLMParams: types.MapUnknown(types.StringType),
+		AdditionalModelInfo:     priorInfo,
+	}
+
+	if err := r.readModel(context.Background(), &data); err != nil {
+		t.Fatalf("readModel returned error: %v", err)
+	}
+
+	info := map[string]string{}
+	if diags := data.AdditionalModelInfo.ElementsAs(context.Background(), &info, false); diags.HasError() {
+		t.Fatalf("failed to decode additional_model_info: %v", diags)
+	}
+
+	if got := info["supports_vision"]; got != "true" {
+		t.Fatalf("expected supports_vision=true, got %q", got)
+	}
+	if len(info) != 1 {
+		t.Fatalf("expected only configured keys to be read back, got %v", info)
+	}
+}
+
+func TestReadModelResolvesUnknownAdditionalModelInfo(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": []interface{}{
+				map[string]interface{}{
+					"model_name": "gpt-4o-mini",
+					"litellm_params": map[string]interface{}{
+						"custom_llm_provider": "openai",
+						"model":               "openai/gpt-4o-mini",
+					},
+					"model_info": map[string]interface{}{
+						"base_model": "gpt-4o-mini",
+						// Cost-map metadata that must not be captured.
+						"max_tokens":      16384.0,
+						"supports_vision": true,
+					},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	r := &ModelResource{
+		client: &Client{
+			APIBase:    server.URL,
+			APIKey:     "test-key",
+			HTTPClient: server.Client(),
+		},
+	}
+
+	// Simulate Create (or Import) where additional_model_info was not configured.
+	data := ModelResourceModel{
+		ID:                      types.StringValue("model-info-unknown"),
+		AccessGroups:            types.ListUnknown(types.StringType),
+		AdditionalLiteLLMParams: types.MapUnknown(types.StringType),
+		AdditionalModelInfo:     types.MapUnknown(types.StringType),
+	}
+
+	if err := r.readModel(context.Background(), &data); err != nil {
+		t.Fatalf("readModel returned error: %v", err)
+	}
+
+	if data.AdditionalModelInfo.IsUnknown() {
+		t.Fatal("additional_model_info must be known after read")
+	}
+	if got := len(data.AdditionalModelInfo.Elements()); got != 0 {
+		t.Fatalf("expected empty additional_model_info, got %d elements: %v", got, data.AdditionalModelInfo)
 	}
 }


### PR DESCRIPTION
Fixes #140

### What

Adds an `additional_model_info` map attribute to `litellm_model`, mirroring `additional_litellm_params`, so arbitrary `model_info` fields can be managed — primarily LiteLLM capability flags for models missing from the model cost map:

```hcl
resource "litellm_model" "kimi_k3" {
  model_name          = "kimi-k3"
  custom_llm_provider = "openrouter"
  base_model          = "moonshotai/kimi-k3"
  mode                = "chat"

  additional_model_info = {
    supports_vision           = "true"
    supports_function_calling = "true"
  }
}
```

Without this, `/model/info` and `/v1/models` advertise `supports_* = null` for such models, and clients that gate features on capability metadata (image-upload buttons, tool UIs) never offer them even though the deployment handles the requests fine.

### Design notes

- **Write:** values are converted string → native JSON types with the existing `convertStringValue()` rules and merged into `model_info` in both `createOrUpdateModel()` and `patchModel()`.
- **Read: only keys present in state are consulted.** `/model/info` merges cost-map-derived metadata (`max_tokens`, `supports_*`, `litellm_provider`, …) into `model_info`; echoing unknown keys — or slurping them all on import — would capture values the user never configured and create permanent drift. Consequently, on import the attribute starts empty and converges on the first apply (documented).
- The read-back value conversion switch is extracted into a shared `stringifyAPIValue()` helper used by both map attributes; numeric-string normalization behavior is unchanged.
- Same PATCH-merge limitation as `additional_litellm_params` (keys can't be deleted via update) — documented in `docs/resources/model.md`.

### Testing

- Unit tests mirroring the `additional_litellm_params` suite: create/patch request bodies carry converted values, read-back extracts only configured keys (cost-map metadata in the response is ignored), unknown resolves to an empty known map (`go test ./internal/provider/` passes).
- Live e2e against LiteLLM v1.90.3 via OpenTofu `dev_overrides`: flags land in `model_info`, `GET /model/info` reports `supports_vision: true`, follow-up plans are clean (no drift from cost-map-merged fields), import → plan → apply converges.
- `docs/resources/model.md` updated.
