### PR TITLE
Feature: key level fallbacks

### DIFF
--- a/docs/data-sources/key.md
+++ b/docs/data-sources/key.md
@@ -41,6 +41,8 @@ output "key_info" {
 * `metadata` - Map of metadata for the key.
 * `tags` - List of tags for the key.
 * `blocked` - Whether the key is blocked.
+* `router_settings_fallbacks` - Per-model fallback chain. Keys are primary model names; values are ordered lists of fallback model names.
+* `router_settings_context_window_fallbacks` - Per-model context window fallback chain.
 
 ## Notes
 

--- a/docs/resources/key.md
+++ b/docs/resources/key.md
@@ -89,21 +89,19 @@ resource "litellm_key" "service_account" {
 resource "litellm_key" "service" {
   key_alias = "key-abc"
   team_id   = "team-abc"
-  models    = ["model-a", "model-b", "model-c"]
+  models    = ["model-a", "model-b", "model-c", "model-d"]
 
   router_settings_fallbacks = {
-    "model-a" = ["model-b", "model-c"]
-    "model-b" = ["model-c"]
+    "model-a" = ["model-c", "model-d"]
+    "model-b" = ["model-c", "model-d"]
   }
 
   router_settings_context_window_fallbacks = {
-    "model-a" = ["model-b", "model-c"]
-    "model-b" = ["model-c"]
+    "model-a" = ["model-c", "model-d"]
+    "model-b" = ["model-c", "model-d"]
   }
 }
 ```
-
-Every model listed as a fallback must also appear in `models`.
 
 ### Key with Complex Metadata (Logging Configuration)
 
@@ -196,7 +194,7 @@ The following arguments are supported:
 
 * `blocked` - (Optional) Whether this key is blocked.
 
-* `router_settings_fallbacks` - (Optional) Per-model fallback chain. Keys are primary model names; values are ordered lists of fallback model names. Every model listed as a fallback must also be present in `models`.
+* `router_settings_fallbacks` - (Optional) Per-model fallback chain. Keys are primary model names; values are ordered lists of fallback model names. Model names are plain strings and do not need to be declared as separate `litellm_model` resources.
 
 * `router_settings_context_window_fallbacks` - (Optional) Per-model context window fallback chain. Same format as `router_settings_fallbacks`; applied when the primary model's context window is exceeded.
 

--- a/docs/resources/key.md
+++ b/docs/resources/key.md
@@ -83,6 +83,28 @@ resource "litellm_key" "service_account" {
 }
 ```
 
+### Key with Fallback Chain
+
+```hcl
+resource "litellm_key" "service" {
+  key_alias = "key-abc"
+  team_id   = "team-abc"
+  models    = ["model-a", "model-b", "model-c"]
+
+  router_settings_fallbacks = {
+    "model-a" = ["model-b", "model-c"]
+    "model-b" = ["model-c"]
+  }
+
+  router_settings_context_window_fallbacks = {
+    "model-a" = ["model-b", "model-c"]
+    "model-b" = ["model-c"]
+  }
+}
+```
+
+Every model listed as a fallback must also appear in `models`.
+
 ### Key with Complex Metadata (Logging Configuration)
 
 ```hcl
@@ -173,6 +195,10 @@ The following arguments are supported:
 * `tags` - (Optional) List of tags. **Note:** Requires LiteLLM Enterprise license.
 
 * `blocked` - (Optional) Whether this key is blocked.
+
+* `router_settings_fallbacks` - (Optional) Per-model fallback chain. Keys are primary model names; values are ordered lists of fallback model names. Every model listed as a fallback must also be present in `models`.
+
+* `router_settings_context_window_fallbacks` - (Optional) Per-model context window fallback chain. Same format as `router_settings_fallbacks`; applied when the primary model's context window is exceeded.
 
 ## Attribute Reference
 

--- a/internal/provider/datasource_key.go
+++ b/internal/provider/datasource_key.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -161,13 +162,25 @@ func (d *KeyDataSource) Read(ctx context.Context, req datasource.ReadRequest, re
 		return
 	}
 
+	if err := d.readKeyDataSource(ctx, &data); err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read key: %s", err))
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// readKeyDataSource fetches /key/info for data.Key and maps the response onto data.
+func (d *KeyDataSource) readKeyDataSource(ctx context.Context, data *KeyDataSourceModel) error {
 	keyValue := data.Key.ValueString()
-	endpoint := fmt.Sprintf("/key/info?key=%s", keyValue)
+	// url.QueryEscape ensures special characters in the key (e.g. '#') are
+	// percent-encoded and not interpreted as a URL fragment, which would
+	// silently truncate the key value before it reaches the server.
+	endpoint := fmt.Sprintf("/key/info?key=%s", url.QueryEscape(keyValue))
 
 	var result map[string]interface{}
 	if err := d.client.DoRequestWithResponse(ctx, "GET", endpoint, nil, &result); err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read key: %s", err))
-		return
+		return err
 	}
 
 	// The /key/info endpoint may return key data nested inside "info"
@@ -277,5 +290,5 @@ func (d *KeyDataSource) Read(ctx context.Context, req datasource.ReadRequest, re
 	data.RouterSettingsFallbacks = readFallbacksField(routerSettings, "fallbacks", types.MapNull(listElemType), listElemType)
 	data.RouterSettingsContextWindowFallbacks = readFallbacksField(routerSettings, "context_window_fallbacks", types.MapNull(listElemType), listElemType)
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	return nil
 }

--- a/internal/provider/datasource_key.go
+++ b/internal/provider/datasource_key.go
@@ -21,23 +21,25 @@ type KeyDataSource struct {
 }
 
 type KeyDataSourceModel struct {
-	ID                  types.String  `tfsdk:"id"`
-	Key                 types.String  `tfsdk:"key"`
-	KeyAlias            types.String  `tfsdk:"key_alias"`
-	Models              types.List    `tfsdk:"models"`
-	MaxBudget           types.Float64 `tfsdk:"max_budget"`
-	Spend               types.Float64 `tfsdk:"spend"`
-	UserID              types.String  `tfsdk:"user_id"`
-	TeamID              types.String  `tfsdk:"team_id"`
-	ProjectID           types.String  `tfsdk:"project_id"`
-	MaxParallelRequests types.Int64   `tfsdk:"max_parallel_requests"`
-	TPMLimit            types.Int64   `tfsdk:"tpm_limit"`
-	RPMLimit            types.Int64   `tfsdk:"rpm_limit"`
-	BudgetDuration      types.String  `tfsdk:"budget_duration"`
-	SoftBudget          types.Float64 `tfsdk:"soft_budget"`
-	Metadata            types.Map     `tfsdk:"metadata"`
-	Tags                types.List    `tfsdk:"tags"`
-	Blocked             types.Bool    `tfsdk:"blocked"`
+	ID                                   types.String  `tfsdk:"id"`
+	Key                                  types.String  `tfsdk:"key"`
+	KeyAlias                             types.String  `tfsdk:"key_alias"`
+	Models                               types.List    `tfsdk:"models"`
+	MaxBudget                            types.Float64 `tfsdk:"max_budget"`
+	Spend                                types.Float64 `tfsdk:"spend"`
+	UserID                               types.String  `tfsdk:"user_id"`
+	TeamID                               types.String  `tfsdk:"team_id"`
+	ProjectID                            types.String  `tfsdk:"project_id"`
+	MaxParallelRequests                  types.Int64   `tfsdk:"max_parallel_requests"`
+	TPMLimit                             types.Int64   `tfsdk:"tpm_limit"`
+	RPMLimit                             types.Int64   `tfsdk:"rpm_limit"`
+	BudgetDuration                       types.String  `tfsdk:"budget_duration"`
+	SoftBudget                           types.Float64 `tfsdk:"soft_budget"`
+	Metadata                             types.Map     `tfsdk:"metadata"`
+	Tags                                 types.List    `tfsdk:"tags"`
+	Blocked                              types.Bool    `tfsdk:"blocked"`
+	RouterSettingsFallbacks              types.Map     `tfsdk:"router_settings_fallbacks"`
+	RouterSettingsContextWindowFallbacks types.Map     `tfsdk:"router_settings_context_window_fallbacks"`
 }
 
 func (d *KeyDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -119,6 +121,16 @@ func (d *KeyDataSource) Schema(ctx context.Context, req datasource.SchemaRequest
 			"blocked": schema.BoolAttribute{
 				Description: "Whether the key is blocked.",
 				Computed:    true,
+			},
+			"router_settings_fallbacks": schema.MapAttribute{
+				Description: "Per-model fallback chain.",
+				Computed:    true,
+				ElementType: types.ListType{ElemType: types.StringType},
+			},
+			"router_settings_context_window_fallbacks": schema.MapAttribute{
+				Description: "Per-model context window fallback chain.",
+				Computed:    true,
+				ElementType: types.ListType{ElemType: types.StringType},
 			},
 		},
 	}
@@ -259,6 +271,11 @@ func (d *KeyDataSource) Read(ctx context.Context, req datasource.ReadRequest, re
 	} else {
 		data.Metadata, _ = types.MapValue(types.StringType, map[string]attr.Value{})
 	}
+
+	listElemType := types.ListType{ElemType: types.StringType}
+	routerSettings, _ := info["router_settings"].(map[string]interface{})
+	data.RouterSettingsFallbacks = readFallbacksField(routerSettings, "fallbacks", types.MapNull(listElemType), listElemType)
+	data.RouterSettingsContextWindowFallbacks = readFallbacksField(routerSettings, "context_window_fallbacks", types.MapNull(listElemType), listElemType)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/provider/datasource_key_test.go
+++ b/internal/provider/datasource_key_test.go
@@ -1,0 +1,242 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// keyInfoServer returns a test server that answers /key/info with the given info payload.
+func keyInfoServer(t *testing.T, keyValue string, info map[string]interface{}) *httptest.Server {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"key":  keyValue,
+			"info": info,
+		})
+	}))
+	t.Cleanup(server.Close)
+
+	return server
+}
+
+func newKeyDataSource(server *httptest.Server) *KeyDataSource {
+	return &KeyDataSource{
+		client: &Client{
+			APIBase:    server.URL,
+			APIKey:     "test-key",
+			HTTPClient: server.Client(),
+		},
+	}
+}
+
+// fallbackChain returns the fallback models configured for primary in m.
+func fallbackChain(t *testing.T, m types.Map, primary string) []string {
+	t.Helper()
+
+	if m.IsNull() || m.IsUnknown() {
+		t.Fatalf("expected known, non-null map, got %v", m)
+	}
+
+	lv, ok := m.Elements()[primary]
+	if !ok {
+		t.Fatalf("expected primary model %q in map, got %v", primary, m.Elements())
+	}
+
+	list, ok := lv.(types.List)
+	if !ok {
+		t.Fatalf("expected types.List for primary model, got %T", lv)
+	}
+
+	var fallbacks []string
+	list.ElementsAs(context.Background(), &fallbacks, false)
+	return fallbacks
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestKeyDataSourceReadReadsRouterSettingsFallbacks(t *testing.T) {
+	t.Parallel()
+
+	server := keyInfoServer(t, "sk-ds-fallbacks", map[string]interface{}{
+		"token": "sk-ds-fallbacks",
+		"router_settings": map[string]interface{}{
+			"fallbacks": []interface{}{
+				map[string]interface{}{
+					"gpt-4o": []interface{}{"gpt-4o-mini", "gpt-3.5-turbo"},
+				},
+			},
+		},
+	})
+
+	data := KeyDataSourceModel{Key: types.StringValue("sk-ds-fallbacks")}
+
+	if err := newKeyDataSource(server).readKeyDataSource(context.Background(), &data); err != nil {
+		t.Fatalf("readKeyDataSource returned error: %v", err)
+	}
+
+	if got := len(data.RouterSettingsFallbacks.Elements()); got != 1 {
+		t.Fatalf("expected 1 primary model, got %d", got)
+	}
+	if got := fallbackChain(t, data.RouterSettingsFallbacks, "gpt-4o"); !equalStrings(got, []string{"gpt-4o-mini", "gpt-3.5-turbo"}) {
+		t.Errorf("unexpected fallback values: %v", got)
+	}
+
+	// context_window_fallbacks was absent from the response and must stay null.
+	if !data.RouterSettingsContextWindowFallbacks.IsNull() {
+		t.Error("router_settings_context_window_fallbacks should be null when absent from the response")
+	}
+}
+
+func TestKeyDataSourceReadReadsContextWindowFallbacks(t *testing.T) {
+	t.Parallel()
+
+	server := keyInfoServer(t, "sk-ds-cw-fallbacks", map[string]interface{}{
+		"token": "sk-ds-cw-fallbacks",
+		"router_settings": map[string]interface{}{
+			"context_window_fallbacks": []interface{}{
+				map[string]interface{}{
+					"claude-sonnet-4.6": []interface{}{"claude-opus-4.8"},
+				},
+			},
+		},
+	})
+
+	data := KeyDataSourceModel{Key: types.StringValue("sk-ds-cw-fallbacks")}
+
+	if err := newKeyDataSource(server).readKeyDataSource(context.Background(), &data); err != nil {
+		t.Fatalf("readKeyDataSource returned error: %v", err)
+	}
+
+	if got := fallbackChain(t, data.RouterSettingsContextWindowFallbacks, "claude-sonnet-4.6"); !equalStrings(got, []string{"claude-opus-4.8"}) {
+		t.Errorf("unexpected context window fallback values: %v", got)
+	}
+
+	if !data.RouterSettingsFallbacks.IsNull() {
+		t.Error("router_settings_fallbacks should be null when absent from the response")
+	}
+}
+
+func TestKeyDataSourceReadBothFallbackTypes(t *testing.T) {
+	t.Parallel()
+
+	server := keyInfoServer(t, "sk-ds-both-fallbacks", map[string]interface{}{
+		"token": "sk-ds-both-fallbacks",
+		"router_settings": map[string]interface{}{
+			"fallbacks": []interface{}{
+				map[string]interface{}{
+					"gpt-4o": []interface{}{"gpt-4o-mini"},
+				},
+			},
+			"context_window_fallbacks": []interface{}{
+				map[string]interface{}{
+					"gpt-4o": []interface{}{"gpt-3.5-turbo", "gpt-4o-mini"},
+				},
+			},
+		},
+	})
+
+	data := KeyDataSourceModel{Key: types.StringValue("sk-ds-both-fallbacks")}
+
+	if err := newKeyDataSource(server).readKeyDataSource(context.Background(), &data); err != nil {
+		t.Fatalf("readKeyDataSource returned error: %v", err)
+	}
+
+	if got := fallbackChain(t, data.RouterSettingsFallbacks, "gpt-4o"); !equalStrings(got, []string{"gpt-4o-mini"}) {
+		t.Errorf("unexpected fallback values: %v", got)
+	}
+	if got := fallbackChain(t, data.RouterSettingsContextWindowFallbacks, "gpt-4o"); !equalStrings(got, []string{"gpt-3.5-turbo", "gpt-4o-mini"}) {
+		t.Errorf("unexpected context window fallback values: %v", got)
+	}
+}
+
+func TestKeyDataSourceReadFallbacksNullWhenAbsent(t *testing.T) {
+	t.Parallel()
+
+	server := keyInfoServer(t, "sk-ds-no-fallbacks", map[string]interface{}{
+		"token": "sk-ds-no-fallbacks",
+	})
+
+	data := KeyDataSourceModel{Key: types.StringValue("sk-ds-no-fallbacks")}
+
+	if err := newKeyDataSource(server).readKeyDataSource(context.Background(), &data); err != nil {
+		t.Fatalf("readKeyDataSource returned error: %v", err)
+	}
+
+	// Unlike the resource, the data source has no prior state to preserve, so
+	// missing fallbacks stay null rather than collapsing to an empty map.
+	if !data.RouterSettingsFallbacks.IsNull() {
+		t.Errorf("router_settings_fallbacks should be null, got %v", data.RouterSettingsFallbacks)
+	}
+	if !data.RouterSettingsContextWindowFallbacks.IsNull() {
+		t.Errorf("router_settings_context_window_fallbacks should be null, got %v", data.RouterSettingsContextWindowFallbacks)
+	}
+}
+
+func TestKeyDataSourceReadFallbacksNullWhenEmpty(t *testing.T) {
+	t.Parallel()
+
+	server := keyInfoServer(t, "sk-ds-empty-fallbacks", map[string]interface{}{
+		"token": "sk-ds-empty-fallbacks",
+		"router_settings": map[string]interface{}{
+			"fallbacks":                []interface{}{},
+			"context_window_fallbacks": []interface{}{},
+		},
+	})
+
+	data := KeyDataSourceModel{Key: types.StringValue("sk-ds-empty-fallbacks")}
+
+	if err := newKeyDataSource(server).readKeyDataSource(context.Background(), &data); err != nil {
+		t.Fatalf("readKeyDataSource returned error: %v", err)
+	}
+
+	if !data.RouterSettingsFallbacks.IsNull() {
+		t.Errorf("router_settings_fallbacks should be null for an empty list, got %v", data.RouterSettingsFallbacks)
+	}
+	if !data.RouterSettingsContextWindowFallbacks.IsNull() {
+		t.Errorf("router_settings_context_window_fallbacks should be null for an empty list, got %v", data.RouterSettingsContextWindowFallbacks)
+	}
+}
+
+func TestKeyDataSourceReadURLEncodesSpecialChars(t *testing.T) {
+	t.Parallel()
+
+	const keyWithSpecialChars = "sk-ds-key#with?special&chars"
+
+	var gotKey string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotKey = r.URL.Query().Get("key")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"key":  keyWithSpecialChars,
+			"info": map[string]interface{}{"token": keyWithSpecialChars},
+		})
+	}))
+	defer server.Close()
+
+	data := KeyDataSourceModel{Key: types.StringValue(keyWithSpecialChars)}
+
+	if err := newKeyDataSource(server).readKeyDataSource(context.Background(), &data); err != nil {
+		t.Fatalf("readKeyDataSource returned error: %v", err)
+	}
+
+	if gotKey != keyWithSpecialChars {
+		t.Errorf("expected server to receive key %q, got %q", keyWithSpecialChars, gotKey)
+	}
+}

--- a/internal/provider/resource_key.go
+++ b/internal/provider/resource_key.go
@@ -72,6 +72,7 @@ type KeyResourceModel struct {
 	EnforcedParams           types.List    `tfsdk:"enforced_params"`
 	Tags                     types.List    `tfsdk:"tags"`
 	Blocked                  types.Bool    `tfsdk:"blocked"`
+	RouterSettingsFallbacks  types.Map     `tfsdk:"router_settings_fallbacks"`
 }
 
 func (r *KeyResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -266,6 +267,12 @@ func (r *KeyResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 				Description: "Whether the key is blocked.",
 				Optional:    true,
 				Computed:    true,
+			},
+			"router_settings_fallbacks": schema.MapAttribute{
+				Description: "Per-model fallback chain. Keys are primary model names; values are ordered lists of fallback model names. Configures router_settings.fallbacks on the key — only upstream failures (Azure/Bedrock 429s, 5xx, timeouts) trigger the fallback chain; proxy-level quota limits do not.",
+				Optional:    true,
+				Computed:    true,
+				ElementType: types.ListType{ElemType: types.StringType},
 			},
 		},
 	}
@@ -666,6 +673,26 @@ func (r *KeyResource) buildKeyRequest(ctx context.Context, data *KeyResourceMode
 		}
 	}
 
+	// router_settings.fallbacks: [{"primary_model": ["fallback1", ...]}]
+	if !data.RouterSettingsFallbacks.IsNull() && !data.RouterSettingsFallbacks.IsUnknown() {
+		elems := data.RouterSettingsFallbacks.Elements()
+		if len(elems) > 0 {
+			fallbacksList := make([]map[string]interface{}, 0, len(elems))
+			for primary, v := range elems {
+				var fallbacks []string
+				if lv, ok := v.(types.List); ok {
+					lv.ElementsAs(ctx, &fallbacks, false)
+				}
+				fallbacksList = append(fallbacksList, map[string]interface{}{
+					primary: fallbacks,
+				})
+			}
+			keyReq["router_settings"] = map[string]interface{}{
+				"fallbacks": fallbacksList,
+			}
+		}
+	}
+
 	// Handle service account
 	if !data.ServiceAccountID.IsNull() && !data.ServiceAccountID.IsUnknown() && data.ServiceAccountID.ValueString() != "" {
 		saID := data.ServiceAccountID.ValueString()
@@ -1025,6 +1052,41 @@ func (r *KeyResource) readKey(ctx context.Context, data *KeyResourceModel) error
 		data.ModelTPMLimit, _ = types.MapValue(types.Int64Type, tpmMap)
 	} else if data.ModelTPMLimit.IsUnknown() {
 		data.ModelTPMLimit, _ = types.MapValue(types.Int64Type, map[string]attr.Value{})
+	}
+
+	// Handle router_settings.fallbacks — the field LiteLLM's router actually reads
+	// (distinct from the top-level "fallbacks" field which is UI-metadata only).
+	listElemType := types.ListType{ElemType: types.StringType}
+	if routerSettings, ok := info["router_settings"].(map[string]interface{}); ok {
+		if fallbacksRaw, ok := routerSettings["fallbacks"].([]interface{}); ok && len(fallbacksRaw) > 0 {
+			fallbackMap := make(map[string]attr.Value)
+			for _, entry := range fallbacksRaw {
+				if entryMap, ok := entry.(map[string]interface{}); ok {
+					for primary, fbIface := range entryMap {
+						var vals []attr.Value
+						if fbSlice, ok := fbIface.([]interface{}); ok {
+							for _, f := range fbSlice {
+								if s, ok := f.(string); ok {
+									vals = append(vals, types.StringValue(s))
+								}
+							}
+						}
+						lv, _ := types.ListValue(types.StringType, vals)
+						fallbackMap[primary] = lv
+					}
+				}
+			}
+			data.RouterSettingsFallbacks, _ = types.MapValue(listElemType, fallbackMap)
+		} else if data.RouterSettingsFallbacks.IsUnknown() {
+			data.RouterSettingsFallbacks = types.MapNull(listElemType)
+		} else if !data.RouterSettingsFallbacks.IsNull() {
+			data.RouterSettingsFallbacks, _ = types.MapValue(listElemType, map[string]attr.Value{})
+		}
+	} else if data.RouterSettingsFallbacks.IsUnknown() {
+		data.RouterSettingsFallbacks = types.MapNull(listElemType)
+	} else if !data.RouterSettingsFallbacks.IsNull() {
+		// router_settings absent from API but user had configured fallbacks — clear to empty
+		data.RouterSettingsFallbacks, _ = types.MapValue(listElemType, map[string]attr.Value{})
 	}
 
 	return nil

--- a/internal/provider/resource_key.go
+++ b/internal/provider/resource_key.go
@@ -38,41 +38,42 @@ type KeyResource struct {
 }
 
 type KeyResourceModel struct {
-	ID                       types.String  `tfsdk:"id"`
-	Key                      types.String  `tfsdk:"key"`
-	Models                   types.List    `tfsdk:"models"`
-	AllowedRoutes            types.List    `tfsdk:"allowed_routes"`
-	AllowedPassthroughRoutes types.List    `tfsdk:"allowed_passthrough_routes"`
-	MaxBudget                types.Float64 `tfsdk:"max_budget"`
-	UserID                   types.String  `tfsdk:"user_id"`
-	TeamID                   types.String  `tfsdk:"team_id"`
-	OrganizationID           types.String  `tfsdk:"organization_id"`
-	ProjectID                types.String  `tfsdk:"project_id"`
-	BudgetID                 types.String  `tfsdk:"budget_id"`
-	ServiceAccountID         types.String  `tfsdk:"service_account_id"`
-	MaxParallelRequests      types.Int64   `tfsdk:"max_parallel_requests"`
-	Metadata                 types.Map     `tfsdk:"metadata"`
-	TPMLimit                 types.Int64   `tfsdk:"tpm_limit"`
-	RPMLimit                 types.Int64   `tfsdk:"rpm_limit"`
-	TPMLimitType             types.String  `tfsdk:"tpm_limit_type"`
-	RPMLimitType             types.String  `tfsdk:"rpm_limit_type"`
-	BudgetDuration           types.String  `tfsdk:"budget_duration"`
-	AllowedCacheControls     types.List    `tfsdk:"allowed_cache_controls"`
-	SoftBudget               types.Float64 `tfsdk:"soft_budget"`
-	KeyAlias                 types.String  `tfsdk:"key_alias"`
-	Duration                 types.String  `tfsdk:"duration"`
-	Aliases                  types.Map     `tfsdk:"aliases"`
-	Config                   types.Map     `tfsdk:"config"`
-	Permissions              types.Map     `tfsdk:"permissions"`
-	ModelMaxBudget           types.Map     `tfsdk:"model_max_budget"`
-	ModelRPMLimit            types.Map     `tfsdk:"model_rpm_limit"`
-	ModelTPMLimit            types.Map     `tfsdk:"model_tpm_limit"`
-	Guardrails               types.List    `tfsdk:"guardrails"`
-	Prompts                  types.List    `tfsdk:"prompts"`
-	EnforcedParams           types.List    `tfsdk:"enforced_params"`
-	Tags                     types.List    `tfsdk:"tags"`
-	Blocked                  types.Bool    `tfsdk:"blocked"`
-	RouterSettingsFallbacks  types.Map     `tfsdk:"router_settings_fallbacks"`
+	ID                                   types.String  `tfsdk:"id"`
+	Key                                  types.String  `tfsdk:"key"`
+	Models                               types.List    `tfsdk:"models"`
+	AllowedRoutes                        types.List    `tfsdk:"allowed_routes"`
+	AllowedPassthroughRoutes             types.List    `tfsdk:"allowed_passthrough_routes"`
+	MaxBudget                            types.Float64 `tfsdk:"max_budget"`
+	UserID                               types.String  `tfsdk:"user_id"`
+	TeamID                               types.String  `tfsdk:"team_id"`
+	OrganizationID                       types.String  `tfsdk:"organization_id"`
+	ProjectID                            types.String  `tfsdk:"project_id"`
+	BudgetID                             types.String  `tfsdk:"budget_id"`
+	ServiceAccountID                     types.String  `tfsdk:"service_account_id"`
+	MaxParallelRequests                  types.Int64   `tfsdk:"max_parallel_requests"`
+	Metadata                             types.Map     `tfsdk:"metadata"`
+	TPMLimit                             types.Int64   `tfsdk:"tpm_limit"`
+	RPMLimit                             types.Int64   `tfsdk:"rpm_limit"`
+	TPMLimitType                         types.String  `tfsdk:"tpm_limit_type"`
+	RPMLimitType                         types.String  `tfsdk:"rpm_limit_type"`
+	BudgetDuration                       types.String  `tfsdk:"budget_duration"`
+	AllowedCacheControls                 types.List    `tfsdk:"allowed_cache_controls"`
+	SoftBudget                           types.Float64 `tfsdk:"soft_budget"`
+	KeyAlias                             types.String  `tfsdk:"key_alias"`
+	Duration                             types.String  `tfsdk:"duration"`
+	Aliases                              types.Map     `tfsdk:"aliases"`
+	Config                               types.Map     `tfsdk:"config"`
+	Permissions                          types.Map     `tfsdk:"permissions"`
+	ModelMaxBudget                       types.Map     `tfsdk:"model_max_budget"`
+	ModelRPMLimit                        types.Map     `tfsdk:"model_rpm_limit"`
+	ModelTPMLimit                        types.Map     `tfsdk:"model_tpm_limit"`
+	Guardrails                           types.List    `tfsdk:"guardrails"`
+	Prompts                              types.List    `tfsdk:"prompts"`
+	EnforcedParams                       types.List    `tfsdk:"enforced_params"`
+	Tags                                 types.List    `tfsdk:"tags"`
+	Blocked                              types.Bool    `tfsdk:"blocked"`
+	RouterSettingsFallbacks              types.Map     `tfsdk:"router_settings_fallbacks"`
+	RouterSettingsContextWindowFallbacks types.Map     `tfsdk:"router_settings_context_window_fallbacks"`
 }
 
 func (r *KeyResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -269,7 +270,13 @@ func (r *KeyResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 				Computed:    true,
 			},
 			"router_settings_fallbacks": schema.MapAttribute{
-				Description: "Per-model fallback chain. Keys are primary model names; values are ordered lists of fallback model names. Configures router_settings.fallbacks on the key — only upstream failures (Azure/Bedrock 429s, 5xx, timeouts) trigger the fallback chain; proxy-level quota limits do not.",
+				Description: "Per-model fallback chain. Keys are primary model names; values are ordered lists of fallback model names.",
+				Optional:    true,
+				Computed:    true,
+				ElementType: types.ListType{ElemType: types.StringType},
+			},
+			"router_settings_context_window_fallbacks": schema.MapAttribute{
+				Description: "Per-model context window fallback chain. Keys are primary model names; values are ordered lists of fallback model names used when the primary model's context window is exceeded.",
 				Optional:    true,
 				Computed:    true,
 				ElementType: types.ListType{ElemType: types.StringType},
@@ -482,6 +489,64 @@ func (r *KeyResource) UpgradeState(ctx context.Context) map[int64]resource.State
 	}
 }
 
+// buildFallbacksPayload converts a map(list(string)) attribute into the
+// [{"primary": ["fallback1", ...]}] slice expected by router_settings.
+func buildFallbacksPayload(ctx context.Context, m types.Map) []map[string]interface{} {
+	if m.IsNull() || m.IsUnknown() {
+		return nil
+	}
+	elems := m.Elements()
+	if len(elems) == 0 {
+		return nil
+	}
+	out := make([]map[string]interface{}, 0, len(elems))
+	for primary, v := range elems {
+		var fallbacks []string
+		if lv, ok := v.(types.List); ok {
+			lv.ElementsAs(ctx, &fallbacks, false)
+		}
+		out = append(out, map[string]interface{}{primary: fallbacks})
+	}
+	return out
+}
+
+// readFallbacksField parses a router_settings sub-key (e.g. "fallbacks",
+// "context_window_fallbacks") from the API response and returns the updated
+// attribute value, preserving null/unknown semantics.
+func readFallbacksField(routerSettings map[string]interface{}, key string, current types.Map, elemType types.ListType) types.Map {
+	if routerSettings != nil {
+		if raw, ok := routerSettings[key].([]interface{}); ok && len(raw) > 0 {
+			fallbackMap := make(map[string]attr.Value)
+			for _, entry := range raw {
+				if entryMap, ok := entry.(map[string]interface{}); ok {
+					for primary, fbIface := range entryMap {
+						var vals []attr.Value
+						if fbSlice, ok := fbIface.([]interface{}); ok {
+							for _, f := range fbSlice {
+								if s, ok := f.(string); ok {
+									vals = append(vals, types.StringValue(s))
+								}
+							}
+						}
+						lv, _ := types.ListValue(types.StringType, vals)
+						fallbackMap[primary] = lv
+					}
+				}
+			}
+			m, _ := types.MapValue(elemType, fallbackMap)
+			return m
+		}
+	}
+	if current.IsUnknown() {
+		return types.MapNull(elemType)
+	}
+	if !current.IsNull() {
+		m, _ := types.MapValue(elemType, map[string]attr.Value{})
+		return m
+	}
+	return current
+}
+
 func (r *KeyResource) buildKeyRequest(ctx context.Context, data *KeyResourceModel) map[string]interface{} {
 	keyReq := make(map[string]interface{})
 
@@ -673,24 +738,16 @@ func (r *KeyResource) buildKeyRequest(ctx context.Context, data *KeyResourceMode
 		}
 	}
 
-	// router_settings.fallbacks: [{"primary_model": ["fallback1", ...]}]
-	if !data.RouterSettingsFallbacks.IsNull() && !data.RouterSettingsFallbacks.IsUnknown() {
-		elems := data.RouterSettingsFallbacks.Elements()
-		if len(elems) > 0 {
-			fallbacksList := make([]map[string]interface{}, 0, len(elems))
-			for primary, v := range elems {
-				var fallbacks []string
-				if lv, ok := v.(types.List); ok {
-					lv.ElementsAs(ctx, &fallbacks, false)
-				}
-				fallbacksList = append(fallbacksList, map[string]interface{}{
-					primary: fallbacks,
-				})
-			}
-			keyReq["router_settings"] = map[string]interface{}{
-				"fallbacks": fallbacksList,
-			}
-		}
+	// router_settings: fallbacks and context_window_fallbacks
+	routerSettings := map[string]interface{}{}
+	if fb := buildFallbacksPayload(ctx, data.RouterSettingsFallbacks); fb != nil {
+		routerSettings["fallbacks"] = fb
+	}
+	if cwfb := buildFallbacksPayload(ctx, data.RouterSettingsContextWindowFallbacks); cwfb != nil {
+		routerSettings["context_window_fallbacks"] = cwfb
+	}
+	if len(routerSettings) > 0 {
+		keyReq["router_settings"] = routerSettings
 	}
 
 	// Handle service account
@@ -1054,40 +1111,10 @@ func (r *KeyResource) readKey(ctx context.Context, data *KeyResourceModel) error
 		data.ModelTPMLimit, _ = types.MapValue(types.Int64Type, map[string]attr.Value{})
 	}
 
-	// Handle router_settings.fallbacks — the field LiteLLM's router actually reads
-	// (distinct from the top-level "fallbacks" field which is UI-metadata only).
 	listElemType := types.ListType{ElemType: types.StringType}
-	if routerSettings, ok := info["router_settings"].(map[string]interface{}); ok {
-		if fallbacksRaw, ok := routerSettings["fallbacks"].([]interface{}); ok && len(fallbacksRaw) > 0 {
-			fallbackMap := make(map[string]attr.Value)
-			for _, entry := range fallbacksRaw {
-				if entryMap, ok := entry.(map[string]interface{}); ok {
-					for primary, fbIface := range entryMap {
-						var vals []attr.Value
-						if fbSlice, ok := fbIface.([]interface{}); ok {
-							for _, f := range fbSlice {
-								if s, ok := f.(string); ok {
-									vals = append(vals, types.StringValue(s))
-								}
-							}
-						}
-						lv, _ := types.ListValue(types.StringType, vals)
-						fallbackMap[primary] = lv
-					}
-				}
-			}
-			data.RouterSettingsFallbacks, _ = types.MapValue(listElemType, fallbackMap)
-		} else if data.RouterSettingsFallbacks.IsUnknown() {
-			data.RouterSettingsFallbacks = types.MapNull(listElemType)
-		} else if !data.RouterSettingsFallbacks.IsNull() {
-			data.RouterSettingsFallbacks, _ = types.MapValue(listElemType, map[string]attr.Value{})
-		}
-	} else if data.RouterSettingsFallbacks.IsUnknown() {
-		data.RouterSettingsFallbacks = types.MapNull(listElemType)
-	} else if !data.RouterSettingsFallbacks.IsNull() {
-		// router_settings absent from API but user had configured fallbacks — clear to empty
-		data.RouterSettingsFallbacks, _ = types.MapValue(listElemType, map[string]attr.Value{})
-	}
+	routerSettings, _ := info["router_settings"].(map[string]interface{})
+	data.RouterSettingsFallbacks = readFallbacksField(routerSettings, "fallbacks", data.RouterSettingsFallbacks, listElemType)
+	data.RouterSettingsContextWindowFallbacks = readFallbacksField(routerSettings, "context_window_fallbacks", data.RouterSettingsContextWindowFallbacks, listElemType)
 
 	return nil
 }

--- a/internal/provider/resource_key.go
+++ b/internal/provider/resource_key.go
@@ -491,23 +491,26 @@ func (r *KeyResource) UpgradeState(ctx context.Context) map[int64]resource.State
 
 // buildFallbacksPayload converts a map(list(string)) attribute into the
 // [{"primary": ["fallback1", ...]}] slice expected by router_settings.
-func buildFallbacksPayload(ctx context.Context, m types.Map) []map[string]interface{} {
-	if m.IsNull() || m.IsUnknown() {
-		return nil
+// Returns (payload, true) when the field should be included in the request
+// (including an empty slice to explicitly clear existing fallbacks), and
+// (nil, false) only when the value is unknown (not yet resolved).
+func buildFallbacksPayload(ctx context.Context, m types.Map) ([]map[string]interface{}, bool) {
+	if m.IsUnknown() {
+		return nil, false
 	}
-	elems := m.Elements()
-	if len(elems) == 0 {
-		return nil
+	if m.IsNull() || len(m.Elements()) == 0 {
+		// Explicitly send [] so the API clears any previously configured fallbacks.
+		return []map[string]interface{}{}, true
 	}
-	out := make([]map[string]interface{}, 0, len(elems))
-	for primary, v := range elems {
+	out := make([]map[string]interface{}, 0, len(m.Elements()))
+	for primary, v := range m.Elements() {
 		var fallbacks []string
 		if lv, ok := v.(types.List); ok {
 			lv.ElementsAs(ctx, &fallbacks, false)
 		}
 		out = append(out, map[string]interface{}{primary: fallbacks})
 	}
-	return out
+	return out, true
 }
 
 // readFallbacksField parses a router_settings sub-key (e.g. "fallbacks",
@@ -740,10 +743,10 @@ func (r *KeyResource) buildKeyRequest(ctx context.Context, data *KeyResourceMode
 
 	// router_settings: fallbacks and context_window_fallbacks
 	routerSettings := map[string]interface{}{}
-	if fb := buildFallbacksPayload(ctx, data.RouterSettingsFallbacks); fb != nil {
+	if fb, ok := buildFallbacksPayload(ctx, data.RouterSettingsFallbacks); ok {
 		routerSettings["fallbacks"] = fb
 	}
-	if cwfb := buildFallbacksPayload(ctx, data.RouterSettingsContextWindowFallbacks); cwfb != nil {
+	if cwfb, ok := buildFallbacksPayload(ctx, data.RouterSettingsContextWindowFallbacks); ok {
 		routerSettings["context_window_fallbacks"] = cwfb
 	}
 	if len(routerSettings) > 0 {

--- a/internal/provider/resource_key_test.go
+++ b/internal/provider/resource_key_test.go
@@ -133,25 +133,26 @@ func TestReadKeyDoesNotSetAPIInjectedBudgetDurationWhenUnconfigured(t *testing.T
 	}
 
 	data := KeyResourceModel{
-		ID:                       types.StringValue(hashKeyForID("sk-budget-duration-default")),
-		Key:                      types.StringValue("sk-budget-duration-default"),
-		BudgetDuration:           types.StringNull(),
-		Models:                   types.ListNull(types.StringType),
-		AllowedRoutes:            types.ListNull(types.StringType),
-		AllowedPassthroughRoutes: types.ListNull(types.StringType),
-		AllowedCacheControls:     types.ListNull(types.StringType),
-		Guardrails:               types.ListNull(types.StringType),
-		Prompts:                  types.ListNull(types.StringType),
-		EnforcedParams:           types.ListNull(types.StringType),
-		Tags:                     types.ListNull(types.StringType),
-		Metadata:                 types.MapNull(types.StringType),
-		Aliases:                  types.MapNull(types.StringType),
-		Config:                   types.MapNull(types.StringType),
-		Permissions:              types.MapNull(types.StringType),
-		ModelMaxBudget:           types.MapNull(types.Float64Type),
-		ModelRPMLimit:            types.MapNull(types.Int64Type),
-		ModelTPMLimit:            types.MapNull(types.Int64Type),
-		RouterSettingsFallbacks:  types.MapNull(types.ListType{ElemType: types.StringType}),
+		ID:                                   types.StringValue(hashKeyForID("sk-budget-duration-default")),
+		Key:                                  types.StringValue("sk-budget-duration-default"),
+		BudgetDuration:                       types.StringNull(),
+		Models:                               types.ListNull(types.StringType),
+		AllowedRoutes:                        types.ListNull(types.StringType),
+		AllowedPassthroughRoutes:             types.ListNull(types.StringType),
+		AllowedCacheControls:                 types.ListNull(types.StringType),
+		Guardrails:                           types.ListNull(types.StringType),
+		Prompts:                              types.ListNull(types.StringType),
+		EnforcedParams:                       types.ListNull(types.StringType),
+		Tags:                                 types.ListNull(types.StringType),
+		Metadata:                             types.MapNull(types.StringType),
+		Aliases:                              types.MapNull(types.StringType),
+		Config:                               types.MapNull(types.StringType),
+		Permissions:                          types.MapNull(types.StringType),
+		ModelMaxBudget:                       types.MapNull(types.Float64Type),
+		ModelRPMLimit:                        types.MapNull(types.Int64Type),
+		ModelTPMLimit:                        types.MapNull(types.Int64Type),
+		RouterSettingsFallbacks:              types.MapNull(types.ListType{ElemType: types.StringType}),
+		RouterSettingsContextWindowFallbacks: types.MapNull(types.ListType{ElemType: types.StringType}),
 	}
 
 	if err := r.readKey(context.Background(), &data); err != nil {
@@ -187,25 +188,26 @@ func TestReadKeyDoesNotSetAPIInjectedDefaultUserIDWhenUnconfigured(t *testing.T)
 	}
 
 	data := KeyResourceModel{
-		ID:                       types.StringValue(hashKeyForID("sk-default-user-key")),
-		Key:                      types.StringValue("sk-default-user-key"),
-		UserID:                   types.StringNull(),
-		Models:                   types.ListNull(types.StringType),
-		AllowedRoutes:            types.ListNull(types.StringType),
-		AllowedPassthroughRoutes: types.ListNull(types.StringType),
-		AllowedCacheControls:     types.ListNull(types.StringType),
-		Guardrails:               types.ListNull(types.StringType),
-		Prompts:                  types.ListNull(types.StringType),
-		EnforcedParams:           types.ListNull(types.StringType),
-		Tags:                     types.ListNull(types.StringType),
-		Metadata:                 types.MapNull(types.StringType),
-		Aliases:                  types.MapNull(types.StringType),
-		Config:                   types.MapNull(types.StringType),
-		Permissions:              types.MapNull(types.StringType),
-		ModelMaxBudget:           types.MapNull(types.Float64Type),
-		ModelRPMLimit:            types.MapNull(types.Int64Type),
-		ModelTPMLimit:            types.MapNull(types.Int64Type),
-		RouterSettingsFallbacks:  types.MapNull(types.ListType{ElemType: types.StringType}),
+		ID:                                   types.StringValue(hashKeyForID("sk-default-user-key")),
+		Key:                                  types.StringValue("sk-default-user-key"),
+		UserID:                               types.StringNull(),
+		Models:                               types.ListNull(types.StringType),
+		AllowedRoutes:                        types.ListNull(types.StringType),
+		AllowedPassthroughRoutes:             types.ListNull(types.StringType),
+		AllowedCacheControls:                 types.ListNull(types.StringType),
+		Guardrails:                           types.ListNull(types.StringType),
+		Prompts:                              types.ListNull(types.StringType),
+		EnforcedParams:                       types.ListNull(types.StringType),
+		Tags:                                 types.ListNull(types.StringType),
+		Metadata:                             types.MapNull(types.StringType),
+		Aliases:                              types.MapNull(types.StringType),
+		Config:                               types.MapNull(types.StringType),
+		Permissions:                          types.MapNull(types.StringType),
+		ModelMaxBudget:                       types.MapNull(types.Float64Type),
+		ModelRPMLimit:                        types.MapNull(types.Int64Type),
+		ModelTPMLimit:                        types.MapNull(types.Int64Type),
+		RouterSettingsFallbacks:              types.MapNull(types.ListType{ElemType: types.StringType}),
+		RouterSettingsContextWindowFallbacks: types.MapNull(types.ListType{ElemType: types.StringType}),
 	}
 
 	if err := r.readKey(context.Background(), &data); err != nil {
@@ -241,24 +243,25 @@ func TestReadKeyReadsProjectID(t *testing.T) {
 	}
 
 	data := KeyResourceModel{
-		ID:                       types.StringValue(hashKeyForID("sk-project-key")),
-		Key:                      types.StringValue("sk-project-key"),
-		Models:                   types.ListNull(types.StringType),
-		AllowedRoutes:            types.ListNull(types.StringType),
-		AllowedPassthroughRoutes: types.ListNull(types.StringType),
-		AllowedCacheControls:     types.ListNull(types.StringType),
-		Guardrails:               types.ListNull(types.StringType),
-		Prompts:                  types.ListNull(types.StringType),
-		EnforcedParams:           types.ListNull(types.StringType),
-		Tags:                     types.ListNull(types.StringType),
-		Metadata:                 types.MapNull(types.StringType),
-		Aliases:                  types.MapNull(types.StringType),
-		Config:                   types.MapNull(types.StringType),
-		Permissions:              types.MapNull(types.StringType),
-		ModelMaxBudget:           types.MapNull(types.Float64Type),
-		ModelRPMLimit:            types.MapNull(types.Int64Type),
-		ModelTPMLimit:            types.MapNull(types.Int64Type),
-		RouterSettingsFallbacks:  types.MapNull(types.ListType{ElemType: types.StringType}),
+		ID:                                   types.StringValue(hashKeyForID("sk-project-key")),
+		Key:                                  types.StringValue("sk-project-key"),
+		Models:                               types.ListNull(types.StringType),
+		AllowedRoutes:                        types.ListNull(types.StringType),
+		AllowedPassthroughRoutes:             types.ListNull(types.StringType),
+		AllowedCacheControls:                 types.ListNull(types.StringType),
+		Guardrails:                           types.ListNull(types.StringType),
+		Prompts:                              types.ListNull(types.StringType),
+		EnforcedParams:                       types.ListNull(types.StringType),
+		Tags:                                 types.ListNull(types.StringType),
+		Metadata:                             types.MapNull(types.StringType),
+		Aliases:                              types.MapNull(types.StringType),
+		Config:                               types.MapNull(types.StringType),
+		Permissions:                          types.MapNull(types.StringType),
+		ModelMaxBudget:                       types.MapNull(types.Float64Type),
+		ModelRPMLimit:                        types.MapNull(types.Int64Type),
+		ModelTPMLimit:                        types.MapNull(types.Int64Type),
+		RouterSettingsFallbacks:              types.MapNull(types.ListType{ElemType: types.StringType}),
+		RouterSettingsContextWindowFallbacks: types.MapNull(types.ListType{ElemType: types.StringType}),
 	}
 
 	if err := r.readKey(context.Background(), &data); err != nil {
@@ -521,24 +524,25 @@ func TestReadKeyResolvesUnknownOptionalComputedCollections(t *testing.T) {
 	}
 
 	data := KeyResourceModel{
-		ID:                       types.StringValue("key-123"),
-		Key:                      types.StringValue("key-123"),
-		Models:                   types.ListUnknown(types.StringType),
-		AllowedRoutes:            types.ListUnknown(types.StringType),
-		AllowedPassthroughRoutes: types.ListUnknown(types.StringType),
-		AllowedCacheControls:     types.ListUnknown(types.StringType),
-		Guardrails:               types.ListUnknown(types.StringType),
-		Prompts:                  types.ListUnknown(types.StringType),
-		EnforcedParams:           types.ListUnknown(types.StringType),
-		Tags:                     types.ListUnknown(types.StringType),
-		Metadata:                 types.MapUnknown(types.StringType),
-		Aliases:                  types.MapUnknown(types.StringType),
-		Config:                   types.MapUnknown(types.StringType),
-		Permissions:              types.MapUnknown(types.StringType),
-		ModelMaxBudget:           types.MapUnknown(types.Float64Type),
-		ModelRPMLimit:            types.MapUnknown(types.Int64Type),
-		ModelTPMLimit:            types.MapUnknown(types.Int64Type),
-		RouterSettingsFallbacks:  types.MapUnknown(types.ListType{ElemType: types.StringType}),
+		ID:                                   types.StringValue("key-123"),
+		Key:                                  types.StringValue("key-123"),
+		Models:                               types.ListUnknown(types.StringType),
+		AllowedRoutes:                        types.ListUnknown(types.StringType),
+		AllowedPassthroughRoutes:             types.ListUnknown(types.StringType),
+		AllowedCacheControls:                 types.ListUnknown(types.StringType),
+		Guardrails:                           types.ListUnknown(types.StringType),
+		Prompts:                              types.ListUnknown(types.StringType),
+		EnforcedParams:                       types.ListUnknown(types.StringType),
+		Tags:                                 types.ListUnknown(types.StringType),
+		Metadata:                             types.MapUnknown(types.StringType),
+		Aliases:                              types.MapUnknown(types.StringType),
+		Config:                               types.MapUnknown(types.StringType),
+		Permissions:                          types.MapUnknown(types.StringType),
+		ModelMaxBudget:                       types.MapUnknown(types.Float64Type),
+		ModelRPMLimit:                        types.MapUnknown(types.Int64Type),
+		ModelTPMLimit:                        types.MapUnknown(types.Int64Type),
+		RouterSettingsFallbacks:              types.MapUnknown(types.ListType{ElemType: types.StringType}),
+		RouterSettingsContextWindowFallbacks: types.MapUnknown(types.ListType{ElemType: types.StringType}),
 	}
 
 	if err := r.readKey(context.Background(), &data); err != nil {
@@ -641,24 +645,25 @@ func TestReadKeyWithNestedInfoResponse(t *testing.T) {
 	// In real usage, Create sets the hashed ID before calling readKey.
 	// Simulate that here: Key is known, ID is already hashed.
 	data := KeyResourceModel{
-		ID:                       types.StringValue(hashKeyForID("sk-test-key-123")),
-		Key:                      types.StringValue("sk-test-key-123"),
-		Models:                   types.ListUnknown(types.StringType),
-		AllowedRoutes:            types.ListUnknown(types.StringType),
-		AllowedPassthroughRoutes: types.ListUnknown(types.StringType),
-		AllowedCacheControls:     types.ListUnknown(types.StringType),
-		Guardrails:               types.ListUnknown(types.StringType),
-		Prompts:                  types.ListUnknown(types.StringType),
-		EnforcedParams:           types.ListUnknown(types.StringType),
-		Tags:                     types.ListUnknown(types.StringType),
-		Metadata:                 types.MapUnknown(types.StringType),
-		Aliases:                  types.MapUnknown(types.StringType),
-		Config:                   types.MapUnknown(types.StringType),
-		Permissions:              types.MapUnknown(types.StringType),
-		ModelMaxBudget:           types.MapUnknown(types.Float64Type),
-		ModelRPMLimit:            types.MapUnknown(types.Int64Type),
-		ModelTPMLimit:            types.MapUnknown(types.Int64Type),
-		RouterSettingsFallbacks:  types.MapUnknown(types.ListType{ElemType: types.StringType}),
+		ID:                                   types.StringValue(hashKeyForID("sk-test-key-123")),
+		Key:                                  types.StringValue("sk-test-key-123"),
+		Models:                               types.ListUnknown(types.StringType),
+		AllowedRoutes:                        types.ListUnknown(types.StringType),
+		AllowedPassthroughRoutes:             types.ListUnknown(types.StringType),
+		AllowedCacheControls:                 types.ListUnknown(types.StringType),
+		Guardrails:                           types.ListUnknown(types.StringType),
+		Prompts:                              types.ListUnknown(types.StringType),
+		EnforcedParams:                       types.ListUnknown(types.StringType),
+		Tags:                                 types.ListUnknown(types.StringType),
+		Metadata:                             types.MapUnknown(types.StringType),
+		Aliases:                              types.MapUnknown(types.StringType),
+		Config:                               types.MapUnknown(types.StringType),
+		Permissions:                          types.MapUnknown(types.StringType),
+		ModelMaxBudget:                       types.MapUnknown(types.Float64Type),
+		ModelRPMLimit:                        types.MapUnknown(types.Int64Type),
+		ModelTPMLimit:                        types.MapUnknown(types.Int64Type),
+		RouterSettingsFallbacks:              types.MapUnknown(types.ListType{ElemType: types.StringType}),
+		RouterSettingsContextWindowFallbacks: types.MapUnknown(types.ListType{ElemType: types.StringType}),
 	}
 
 	if err := r.readKey(context.Background(), &data); err != nil {
@@ -1231,23 +1236,24 @@ func TestReadKeyURLEncodesSpecialChars(t *testing.T) {
 	}
 
 	data := &KeyResourceModel{
-		Key:                      types.StringValue(keyWithSpecialChars),
-		Models:                   types.ListNull(types.StringType),
-		AllowedRoutes:            types.ListNull(types.StringType),
-		AllowedPassthroughRoutes: types.ListNull(types.StringType),
-		AllowedCacheControls:     types.ListNull(types.StringType),
-		Guardrails:               types.ListNull(types.StringType),
-		Prompts:                  types.ListNull(types.StringType),
-		EnforcedParams:           types.ListNull(types.StringType),
-		Tags:                     types.ListNull(types.StringType),
-		Metadata:                 types.MapNull(types.StringType),
-		Aliases:                  types.MapNull(types.StringType),
-		Config:                   types.MapNull(types.StringType),
-		Permissions:              types.MapNull(types.StringType),
-		ModelMaxBudget:           types.MapNull(types.Float64Type),
-		ModelRPMLimit:            types.MapNull(types.Int64Type),
-		ModelTPMLimit:            types.MapNull(types.Int64Type),
-		RouterSettingsFallbacks:  types.MapNull(types.ListType{ElemType: types.StringType}),
+		Key:                                  types.StringValue(keyWithSpecialChars),
+		Models:                               types.ListNull(types.StringType),
+		AllowedRoutes:                        types.ListNull(types.StringType),
+		AllowedPassthroughRoutes:             types.ListNull(types.StringType),
+		AllowedCacheControls:                 types.ListNull(types.StringType),
+		Guardrails:                           types.ListNull(types.StringType),
+		Prompts:                              types.ListNull(types.StringType),
+		EnforcedParams:                       types.ListNull(types.StringType),
+		Tags:                                 types.ListNull(types.StringType),
+		Metadata:                             types.MapNull(types.StringType),
+		Aliases:                              types.MapNull(types.StringType),
+		Config:                               types.MapNull(types.StringType),
+		Permissions:                          types.MapNull(types.StringType),
+		ModelMaxBudget:                       types.MapNull(types.Float64Type),
+		ModelRPMLimit:                        types.MapNull(types.Int64Type),
+		ModelTPMLimit:                        types.MapNull(types.Int64Type),
+		RouterSettingsFallbacks:              types.MapNull(types.ListType{ElemType: types.StringType}),
+		RouterSettingsContextWindowFallbacks: types.MapNull(types.ListType{ElemType: types.StringType}),
 	}
 
 	if err := r.readKey(context.Background(), data); err != nil {
@@ -1308,22 +1314,23 @@ func TestReadKeyPreservesUserProvidedKey(t *testing.T) {
 		ID:  types.StringValue(hashKeyForID(rawKey)),
 		Key: types.StringValue(rawKey), // user-provided, already known
 		// Initialise collection fields to avoid nil panics in readKey.
-		Models:                   types.ListNull(types.StringType),
-		AllowedRoutes:            types.ListNull(types.StringType),
-		AllowedPassthroughRoutes: types.ListNull(types.StringType),
-		AllowedCacheControls:     types.ListNull(types.StringType),
-		Guardrails:               types.ListNull(types.StringType),
-		Prompts:                  types.ListNull(types.StringType),
-		EnforcedParams:           types.ListNull(types.StringType),
-		Tags:                     types.ListNull(types.StringType),
-		Metadata:                 types.MapNull(types.StringType),
-		Aliases:                  types.MapNull(types.StringType),
-		Config:                   types.MapNull(types.StringType),
-		Permissions:              types.MapNull(types.StringType),
-		ModelMaxBudget:           types.MapNull(types.Float64Type),
-		ModelRPMLimit:            types.MapNull(types.Int64Type),
-		ModelTPMLimit:            types.MapNull(types.Int64Type),
-		RouterSettingsFallbacks:  types.MapNull(types.ListType{ElemType: types.StringType}),
+		Models:                               types.ListNull(types.StringType),
+		AllowedRoutes:                        types.ListNull(types.StringType),
+		AllowedPassthroughRoutes:             types.ListNull(types.StringType),
+		AllowedCacheControls:                 types.ListNull(types.StringType),
+		Guardrails:                           types.ListNull(types.StringType),
+		Prompts:                              types.ListNull(types.StringType),
+		EnforcedParams:                       types.ListNull(types.StringType),
+		Tags:                                 types.ListNull(types.StringType),
+		Metadata:                             types.MapNull(types.StringType),
+		Aliases:                              types.MapNull(types.StringType),
+		Config:                               types.MapNull(types.StringType),
+		Permissions:                          types.MapNull(types.StringType),
+		ModelMaxBudget:                       types.MapNull(types.Float64Type),
+		ModelRPMLimit:                        types.MapNull(types.Int64Type),
+		ModelTPMLimit:                        types.MapNull(types.Int64Type),
+		RouterSettingsFallbacks:              types.MapNull(types.ListType{ElemType: types.StringType}),
+		RouterSettingsContextWindowFallbacks: types.MapNull(types.ListType{ElemType: types.StringType}),
 	}
 
 	if err := r.readKey(context.Background(), &data); err != nil {
@@ -1389,24 +1396,25 @@ func TestReadKeyPopulatesUnknownKey(t *testing.T) {
 	// This test confirms that when the key in state matches the API
 	// response, it stays unchanged (no-op case).
 	data := KeyResourceModel{
-		ID:                       types.StringValue(hashKeyForID(apiReturnedKey)),
-		Key:                      types.StringValue(apiReturnedKey),
-		Models:                   types.ListNull(types.StringType),
-		AllowedRoutes:            types.ListNull(types.StringType),
-		AllowedPassthroughRoutes: types.ListNull(types.StringType),
-		AllowedCacheControls:     types.ListNull(types.StringType),
-		Guardrails:               types.ListNull(types.StringType),
-		Prompts:                  types.ListNull(types.StringType),
-		EnforcedParams:           types.ListNull(types.StringType),
-		Tags:                     types.ListNull(types.StringType),
-		Metadata:                 types.MapNull(types.StringType),
-		Aliases:                  types.MapNull(types.StringType),
-		Config:                   types.MapNull(types.StringType),
-		Permissions:              types.MapNull(types.StringType),
-		ModelMaxBudget:           types.MapNull(types.Float64Type),
-		ModelRPMLimit:            types.MapNull(types.Int64Type),
-		ModelTPMLimit:            types.MapNull(types.Int64Type),
-		RouterSettingsFallbacks:  types.MapNull(types.ListType{ElemType: types.StringType}),
+		ID:                                   types.StringValue(hashKeyForID(apiReturnedKey)),
+		Key:                                  types.StringValue(apiReturnedKey),
+		Models:                               types.ListNull(types.StringType),
+		AllowedRoutes:                        types.ListNull(types.StringType),
+		AllowedPassthroughRoutes:             types.ListNull(types.StringType),
+		AllowedCacheControls:                 types.ListNull(types.StringType),
+		Guardrails:                           types.ListNull(types.StringType),
+		Prompts:                              types.ListNull(types.StringType),
+		EnforcedParams:                       types.ListNull(types.StringType),
+		Tags:                                 types.ListNull(types.StringType),
+		Metadata:                             types.MapNull(types.StringType),
+		Aliases:                              types.MapNull(types.StringType),
+		Config:                               types.MapNull(types.StringType),
+		Permissions:                          types.MapNull(types.StringType),
+		ModelMaxBudget:                       types.MapNull(types.Float64Type),
+		ModelRPMLimit:                        types.MapNull(types.Int64Type),
+		ModelTPMLimit:                        types.MapNull(types.Int64Type),
+		RouterSettingsFallbacks:              types.MapNull(types.ListType{ElemType: types.StringType}),
+		RouterSettingsContextWindowFallbacks: types.MapNull(types.ListType{ElemType: types.StringType}),
 	}
 
 	if err := r.readKey(context.Background(), &data); err != nil {
@@ -1465,13 +1473,14 @@ func TestBuildKeyRequestOmitsRouterSettingsFallbacksWhenNull(t *testing.T) {
 
 	r := &KeyResource{}
 	data := &KeyResourceModel{
-		RouterSettingsFallbacks: types.MapNull(types.ListType{ElemType: types.StringType}),
+		RouterSettingsFallbacks:              types.MapNull(types.ListType{ElemType: types.StringType}),
+		RouterSettingsContextWindowFallbacks: types.MapNull(types.ListType{ElemType: types.StringType}),
 	}
 
 	req := r.buildKeyRequest(context.Background(), data)
 
 	if _, ok := req["router_settings"]; ok {
-		t.Error("router_settings must not appear in request when router_settings_fallbacks is null")
+		t.Error("router_settings must not appear in request when both fallback fields are null")
 	}
 }
 
@@ -1611,5 +1620,141 @@ func TestReadKeyRouterSettingsFallbacksUnknownResolvesToNull(t *testing.T) {
 	}
 	if !data.RouterSettingsFallbacks.IsNull() {
 		t.Error("router_settings_fallbacks should be null when API returns no router_settings and field was Unknown")
+	}
+}
+
+func TestBuildKeyRequestIncludesContextWindowFallbacks(t *testing.T) {
+	t.Parallel()
+
+	r := &KeyResource{}
+
+	cwfb, _ := types.ListValue(types.StringType, []attr.Value{types.StringValue("claude-haiku-4.5")})
+	cwfbMap, _ := types.MapValue(
+		types.ListType{ElemType: types.StringType},
+		map[string]attr.Value{"claude-sonnet-4.6": cwfb},
+	)
+
+	data := &KeyResourceModel{
+		RouterSettingsContextWindowFallbacks: cwfbMap,
+	}
+
+	req := r.buildKeyRequest(context.Background(), data)
+
+	rs, ok := req["router_settings"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected router_settings in request, got %T", req["router_settings"])
+	}
+	if _, ok := rs["fallbacks"]; ok {
+		t.Error("fallbacks must not appear when only context_window_fallbacks is set")
+	}
+	cwfbList, ok := rs["context_window_fallbacks"].([]map[string]interface{})
+	if !ok {
+		t.Fatalf("expected context_window_fallbacks to be []map[string]interface{}, got %T", rs["context_window_fallbacks"])
+	}
+	if len(cwfbList) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(cwfbList))
+	}
+	fallbacks, ok := cwfbList[0]["claude-sonnet-4.6"].([]string)
+	if !ok {
+		t.Fatalf("expected []string for primary model, got %T", cwfbList[0]["claude-sonnet-4.6"])
+	}
+	if len(fallbacks) != 1 || fallbacks[0] != "claude-haiku-4.5" {
+		t.Errorf("unexpected fallbacks: %v", fallbacks)
+	}
+}
+
+func TestBuildKeyRequestBothFallbackTypes(t *testing.T) {
+	t.Parallel()
+
+	r := &KeyResource{}
+
+	fb, _ := types.ListValue(types.StringType, []attr.Value{types.StringValue("claude-haiku-4.5")})
+	fbMap, _ := types.MapValue(types.ListType{ElemType: types.StringType}, map[string]attr.Value{"claude-sonnet-4.6": fb})
+
+	cwfb, _ := types.ListValue(types.StringType, []attr.Value{types.StringValue("claude-haiku-4.5")})
+	cwfbMap, _ := types.MapValue(types.ListType{ElemType: types.StringType}, map[string]attr.Value{"claude-sonnet-4.6": cwfb})
+
+	data := &KeyResourceModel{
+		RouterSettingsFallbacks:              fbMap,
+		RouterSettingsContextWindowFallbacks: cwfbMap,
+	}
+
+	req := r.buildKeyRequest(context.Background(), data)
+
+	rs, ok := req["router_settings"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected router_settings, got %T", req["router_settings"])
+	}
+	if _, ok := rs["fallbacks"]; !ok {
+		t.Error("fallbacks missing from router_settings")
+	}
+	if _, ok := rs["context_window_fallbacks"]; !ok {
+		t.Error("context_window_fallbacks missing from router_settings")
+	}
+}
+
+func TestReadKeyReadsContextWindowFallbacks(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"key": "sk-cwfb-key",
+			"info": map[string]interface{}{
+				"token": "sk-cwfb-key",
+				"router_settings": map[string]interface{}{
+					"context_window_fallbacks": []interface{}{
+						map[string]interface{}{
+							"claude-sonnet-4.6": []interface{}{"claude-haiku-4.5"},
+						},
+					},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	rc := &KeyResource{
+		client: &Client{
+			APIBase:    server.URL,
+			APIKey:     "test-key",
+			HTTPClient: server.Client(),
+		},
+	}
+
+	cwfb, _ := types.ListValue(types.StringType, []attr.Value{types.StringValue("claude-haiku-4.5")})
+	configured, _ := types.MapValue(types.ListType{ElemType: types.StringType}, map[string]attr.Value{"claude-sonnet-4.6": cwfb})
+
+	data := KeyResourceModel{
+		ID:                                   types.StringValue(hashKeyForID("sk-cwfb-key")),
+		Key:                                  types.StringValue("sk-cwfb-key"),
+		RouterSettingsFallbacks:              types.MapNull(types.ListType{ElemType: types.StringType}),
+		RouterSettingsContextWindowFallbacks: configured,
+	}
+
+	if err := rc.readKey(context.Background(), &data); err != nil {
+		t.Fatalf("readKey returned error: %v", err)
+	}
+
+	if data.RouterSettingsContextWindowFallbacks.IsNull() || data.RouterSettingsContextWindowFallbacks.IsUnknown() {
+		t.Fatal("router_settings_context_window_fallbacks should be known and non-null")
+	}
+	elems := data.RouterSettingsContextWindowFallbacks.Elements()
+	if len(elems) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(elems))
+	}
+	lv, ok := elems["claude-sonnet-4.6"].(types.List)
+	if !ok {
+		t.Fatalf("expected types.List, got %T", elems["claude-sonnet-4.6"])
+	}
+	var fallbacks []string
+	lv.ElementsAs(context.Background(), &fallbacks, false)
+	if len(fallbacks) != 1 || fallbacks[0] != "claude-haiku-4.5" {
+		t.Errorf("unexpected fallbacks: %v", fallbacks)
+	}
+
+	// fallbacks field was null and API didn't return it — should stay null
+	if !data.RouterSettingsFallbacks.IsNull() {
+		t.Error("router_settings_fallbacks should remain null when absent from API response")
 	}
 }

--- a/internal/provider/resource_key_test.go
+++ b/internal/provider/resource_key_test.go
@@ -151,6 +151,7 @@ func TestReadKeyDoesNotSetAPIInjectedBudgetDurationWhenUnconfigured(t *testing.T
 		ModelMaxBudget:           types.MapNull(types.Float64Type),
 		ModelRPMLimit:            types.MapNull(types.Int64Type),
 		ModelTPMLimit:            types.MapNull(types.Int64Type),
+		RouterSettingsFallbacks:  types.MapNull(types.ListType{ElemType: types.StringType}),
 	}
 
 	if err := r.readKey(context.Background(), &data); err != nil {
@@ -204,6 +205,7 @@ func TestReadKeyDoesNotSetAPIInjectedDefaultUserIDWhenUnconfigured(t *testing.T)
 		ModelMaxBudget:           types.MapNull(types.Float64Type),
 		ModelRPMLimit:            types.MapNull(types.Int64Type),
 		ModelTPMLimit:            types.MapNull(types.Int64Type),
+		RouterSettingsFallbacks:  types.MapNull(types.ListType{ElemType: types.StringType}),
 	}
 
 	if err := r.readKey(context.Background(), &data); err != nil {
@@ -256,6 +258,7 @@ func TestReadKeyReadsProjectID(t *testing.T) {
 		ModelMaxBudget:           types.MapNull(types.Float64Type),
 		ModelRPMLimit:            types.MapNull(types.Int64Type),
 		ModelTPMLimit:            types.MapNull(types.Int64Type),
+		RouterSettingsFallbacks:  types.MapNull(types.ListType{ElemType: types.StringType}),
 	}
 
 	if err := r.readKey(context.Background(), &data); err != nil {
@@ -535,6 +538,7 @@ func TestReadKeyResolvesUnknownOptionalComputedCollections(t *testing.T) {
 		ModelMaxBudget:           types.MapUnknown(types.Float64Type),
 		ModelRPMLimit:            types.MapUnknown(types.Int64Type),
 		ModelTPMLimit:            types.MapUnknown(types.Int64Type),
+		RouterSettingsFallbacks:  types.MapUnknown(types.ListType{ElemType: types.StringType}),
 	}
 
 	if err := r.readKey(context.Background(), &data); err != nil {
@@ -654,6 +658,7 @@ func TestReadKeyWithNestedInfoResponse(t *testing.T) {
 		ModelMaxBudget:           types.MapUnknown(types.Float64Type),
 		ModelRPMLimit:            types.MapUnknown(types.Int64Type),
 		ModelTPMLimit:            types.MapUnknown(types.Int64Type),
+		RouterSettingsFallbacks:  types.MapUnknown(types.ListType{ElemType: types.StringType}),
 	}
 
 	if err := r.readKey(context.Background(), &data); err != nil {
@@ -1242,6 +1247,7 @@ func TestReadKeyURLEncodesSpecialChars(t *testing.T) {
 		ModelMaxBudget:           types.MapNull(types.Float64Type),
 		ModelRPMLimit:            types.MapNull(types.Int64Type),
 		ModelTPMLimit:            types.MapNull(types.Int64Type),
+		RouterSettingsFallbacks:  types.MapNull(types.ListType{ElemType: types.StringType}),
 	}
 
 	if err := r.readKey(context.Background(), data); err != nil {
@@ -1317,6 +1323,7 @@ func TestReadKeyPreservesUserProvidedKey(t *testing.T) {
 		ModelMaxBudget:           types.MapNull(types.Float64Type),
 		ModelRPMLimit:            types.MapNull(types.Int64Type),
 		ModelTPMLimit:            types.MapNull(types.Int64Type),
+		RouterSettingsFallbacks:  types.MapNull(types.ListType{ElemType: types.StringType}),
 	}
 
 	if err := r.readKey(context.Background(), &data); err != nil {
@@ -1399,6 +1406,7 @@ func TestReadKeyPopulatesUnknownKey(t *testing.T) {
 		ModelMaxBudget:           types.MapNull(types.Float64Type),
 		ModelRPMLimit:            types.MapNull(types.Int64Type),
 		ModelTPMLimit:            types.MapNull(types.Int64Type),
+		RouterSettingsFallbacks:  types.MapNull(types.ListType{ElemType: types.StringType}),
 	}
 
 	if err := r.readKey(context.Background(), &data); err != nil {
@@ -1407,5 +1415,201 @@ func TestReadKeyPopulatesUnknownKey(t *testing.T) {
 
 	if data.Key.ValueString() != apiReturnedKey {
 		t.Errorf("key should remain %q, got %q", apiReturnedKey, data.Key.ValueString())
+	}
+}
+
+func TestBuildKeyRequestIncludesRouterSettingsFallbacks(t *testing.T) {
+	t.Parallel()
+
+	r := &KeyResource{}
+
+	fb1, _ := types.ListValue(types.StringType, []attr.Value{
+		types.StringValue("claude-haiku-4.5"),
+		types.StringValue("claude-opus-4.8"),
+	})
+	fallbacksMap, _ := types.MapValue(
+		types.ListType{ElemType: types.StringType},
+		map[string]attr.Value{"claude-sonnet-4.6": fb1},
+	)
+
+	data := &KeyResourceModel{
+		RouterSettingsFallbacks: fallbacksMap,
+	}
+
+	req := r.buildKeyRequest(context.Background(), data)
+
+	rs, ok := req["router_settings"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected router_settings in request, got %T", req["router_settings"])
+	}
+
+	fbList, ok := rs["fallbacks"].([]map[string]interface{})
+	if !ok {
+		t.Fatalf("expected router_settings.fallbacks to be []map[string]interface{}, got %T", rs["fallbacks"])
+	}
+	if len(fbList) != 1 {
+		t.Fatalf("expected 1 fallback entry, got %d", len(fbList))
+	}
+
+	fallbacks, ok := fbList[0]["claude-sonnet-4.6"].([]string)
+	if !ok {
+		t.Fatalf("expected []string for primary model fallbacks, got %T", fbList[0]["claude-sonnet-4.6"])
+	}
+	if len(fallbacks) != 2 || fallbacks[0] != "claude-haiku-4.5" || fallbacks[1] != "claude-opus-4.8" {
+		t.Errorf("unexpected fallbacks: %v", fallbacks)
+	}
+}
+
+func TestBuildKeyRequestOmitsRouterSettingsFallbacksWhenNull(t *testing.T) {
+	t.Parallel()
+
+	r := &KeyResource{}
+	data := &KeyResourceModel{
+		RouterSettingsFallbacks: types.MapNull(types.ListType{ElemType: types.StringType}),
+	}
+
+	req := r.buildKeyRequest(context.Background(), data)
+
+	if _, ok := req["router_settings"]; ok {
+		t.Error("router_settings must not appear in request when router_settings_fallbacks is null")
+	}
+}
+
+func TestReadKeyReadsRouterSettingsFallbacks(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"key": "sk-fallback-key",
+			"info": map[string]interface{}{
+				"token": "sk-fallback-key",
+				"router_settings": map[string]interface{}{
+					"fallbacks": []interface{}{
+						map[string]interface{}{
+							"claude-sonnet-4.6": []interface{}{"claude-haiku-4.5", "claude-opus-4.8"},
+						},
+					},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	rc := &KeyResource{
+		client: &Client{
+			APIBase:    server.URL,
+			APIKey:     "test-key",
+			HTTPClient: server.Client(),
+		},
+	}
+
+	fb1, _ := types.ListValue(types.StringType, []attr.Value{types.StringValue("claude-haiku-4.5")})
+	configured, _ := types.MapValue(
+		types.ListType{ElemType: types.StringType},
+		map[string]attr.Value{"claude-sonnet-4.6": fb1},
+	)
+
+	data := KeyResourceModel{
+		ID:                      types.StringValue(hashKeyForID("sk-fallback-key")),
+		Key:                     types.StringValue("sk-fallback-key"),
+		RouterSettingsFallbacks: configured,
+	}
+
+	if err := rc.readKey(context.Background(), &data); err != nil {
+		t.Fatalf("readKey returned error: %v", err)
+	}
+
+	if data.RouterSettingsFallbacks.IsNull() || data.RouterSettingsFallbacks.IsUnknown() {
+		t.Fatal("router_settings_fallbacks should be known and non-null after read")
+	}
+
+	elems := data.RouterSettingsFallbacks.Elements()
+	if len(elems) != 1 {
+		t.Fatalf("expected 1 primary model, got %d", len(elems))
+	}
+
+	lv, ok := elems["claude-sonnet-4.6"].(types.List)
+	if !ok {
+		t.Fatalf("expected types.List for primary model, got %T", elems["claude-sonnet-4.6"])
+	}
+
+	var fallbacks []string
+	lv.ElementsAs(context.Background(), &fallbacks, false)
+	if len(fallbacks) != 2 || fallbacks[0] != "claude-haiku-4.5" || fallbacks[1] != "claude-opus-4.8" {
+		t.Errorf("unexpected fallback values: %v", fallbacks)
+	}
+}
+
+func TestReadKeyRouterSettingsFallbacksNullWhenAbsent(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"key":  "sk-no-fallbacks",
+			"info": map[string]interface{}{"token": "sk-no-fallbacks"},
+		})
+	}))
+	defer server.Close()
+
+	rc := &KeyResource{
+		client: &Client{
+			APIBase:    server.URL,
+			APIKey:     "test-key",
+			HTTPClient: server.Client(),
+		},
+	}
+
+	data := KeyResourceModel{
+		ID:                      types.StringValue(hashKeyForID("sk-no-fallbacks")),
+		Key:                     types.StringValue("sk-no-fallbacks"),
+		RouterSettingsFallbacks: types.MapNull(types.ListType{ElemType: types.StringType}),
+	}
+
+	if err := rc.readKey(context.Background(), &data); err != nil {
+		t.Fatalf("readKey returned error: %v", err)
+	}
+
+	if !data.RouterSettingsFallbacks.IsNull() {
+		t.Error("router_settings_fallbacks should remain null when API returns no router_settings")
+	}
+}
+
+func TestReadKeyRouterSettingsFallbacksUnknownResolvesToNull(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"key":  "sk-unknown-fallbacks",
+			"info": map[string]interface{}{"token": "sk-unknown-fallbacks"},
+		})
+	}))
+	defer server.Close()
+
+	rc := &KeyResource{
+		client: &Client{
+			APIBase:    server.URL,
+			APIKey:     "test-key",
+			HTTPClient: server.Client(),
+		},
+	}
+
+	data := KeyResourceModel{
+		ID:                      types.StringValue(hashKeyForID("sk-unknown-fallbacks")),
+		Key:                     types.StringValue("sk-unknown-fallbacks"),
+		RouterSettingsFallbacks: types.MapUnknown(types.ListType{ElemType: types.StringType}),
+	}
+
+	if err := rc.readKey(context.Background(), &data); err != nil {
+		t.Fatalf("readKey returned error: %v", err)
+	}
+
+	if data.RouterSettingsFallbacks.IsUnknown() {
+		t.Fatal("router_settings_fallbacks must not remain Unknown after readKey")
+	}
+	if !data.RouterSettingsFallbacks.IsNull() {
+		t.Error("router_settings_fallbacks should be null when API returns no router_settings and field was Unknown")
 	}
 }

--- a/internal/provider/resource_key_test.go
+++ b/internal/provider/resource_key_test.go
@@ -1468,9 +1468,11 @@ func TestBuildKeyRequestIncludesRouterSettingsFallbacks(t *testing.T) {
 	}
 }
 
-func TestBuildKeyRequestOmitsRouterSettingsFallbacksWhenNull(t *testing.T) {
+func TestBuildKeyRequestClearsRouterSettingsFallbacksWhenNull(t *testing.T) {
 	t.Parallel()
 
+	// Null means the user removed the attribute — the provider must send empty
+	// lists so LiteLLM clears any previously configured fallbacks.
 	r := &KeyResource{}
 	data := &KeyResourceModel{
 		RouterSettingsFallbacks:              types.MapNull(types.ListType{ElemType: types.StringType}),
@@ -1479,8 +1481,23 @@ func TestBuildKeyRequestOmitsRouterSettingsFallbacksWhenNull(t *testing.T) {
 
 	req := r.buildKeyRequest(context.Background(), data)
 
-	if _, ok := req["router_settings"]; ok {
-		t.Error("router_settings must not appear in request when both fallback fields are null")
+	rs, ok := req["router_settings"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected router_settings in request to clear fallbacks, got %T", req["router_settings"])
+	}
+	fb, ok := rs["fallbacks"].([]map[string]interface{})
+	if !ok {
+		t.Fatalf("expected fallbacks to be []map[string]interface{}, got %T", rs["fallbacks"])
+	}
+	if len(fb) != 0 {
+		t.Errorf("expected empty fallbacks list, got %v", fb)
+	}
+	cwfb, ok := rs["context_window_fallbacks"].([]map[string]interface{})
+	if !ok {
+		t.Fatalf("expected context_window_fallbacks to be []map[string]interface{}, got %T", rs["context_window_fallbacks"])
+	}
+	if len(cwfb) != 0 {
+		t.Errorf("expected empty context_window_fallbacks list, got %v", cwfb)
 	}
 }
 
@@ -1644,8 +1661,14 @@ func TestBuildKeyRequestIncludesContextWindowFallbacks(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected router_settings in request, got %T", req["router_settings"])
 	}
-	if _, ok := rs["fallbacks"]; ok {
-		t.Error("fallbacks must not appear when only context_window_fallbacks is set")
+	// When RouterSettingsFallbacks is unset (zero value = null), the provider
+	// sends fallbacks: [] to clear any previously configured fallbacks.
+	fb, ok := rs["fallbacks"].([]map[string]interface{})
+	if !ok {
+		t.Fatalf("expected fallbacks to be []map[string]interface{}, got %T", rs["fallbacks"])
+	}
+	if len(fb) != 0 {
+		t.Errorf("expected empty fallbacks list, got %v", fb)
 	}
 	cwfbList, ok := rs["context_window_fallbacks"].([]map[string]interface{})
 	if !ok {

--- a/internal_testing/README.md
+++ b/internal_testing/README.md
@@ -81,6 +81,7 @@ internal_testing/
     key_minimal.tf
     key_full.tf
     key_service_account.tf
+    key_fallbacks_full.tf
     key_block_minimal.tf       # blocks the minimal key (destructive)
     team_minimal.tf
     team_full.tf
@@ -117,6 +118,7 @@ internal_testing/
   datasources/                 # one file per data source
     model.tf
     key.tf
+    key_fallbacks.tf           # reads back resources/key_fallbacks_full.tf
     team.tf
     organization.tf
     user.tf

--- a/internal_testing/datasources/key.tf
+++ b/internal_testing/datasources/key.tf
@@ -32,3 +32,11 @@ output "ds_key_tags" {
 output "ds_key_metadata" {
   value = data.litellm_key.lookup.metadata
 }
+
+output "ds_key_router_settings_fallbacks" {
+  value = data.litellm_key.lookup.router_settings_fallbacks
+}
+
+output "ds_key_router_settings_context_window_fallbacks" {
+  value = data.litellm_key.lookup.router_settings_context_window_fallbacks
+}

--- a/internal_testing/datasources/key_fallbacks.tf
+++ b/internal_testing/datasources/key_fallbacks.tf
@@ -1,0 +1,15 @@
+# data.litellm_key - Fallbacks
+# Reads back the key created by resources/key_fallbacks_full.tf, so the outputs below
+# assert the resource -> API -> data source round trip for both fallback maps.
+
+data "litellm_key" "fallbacks" {
+  key = litellm_key.with_fallbacks.key
+}
+
+output "ds_key_fallbacks_router_settings_fallbacks" {
+  value = data.litellm_key.fallbacks.router_settings_fallbacks
+}
+
+output "ds_key_fallbacks_router_settings_context_window_fallbacks" {
+  value = data.litellm_key.fallbacks.router_settings_context_window_fallbacks
+}

--- a/internal_testing/resources/key_fallbacks_full.tf
+++ b/internal_testing/resources/key_fallbacks_full.tf
@@ -1,0 +1,33 @@
+# litellm_key - Fallbacks
+# Tests both router_settings_fallbacks and router_settings_context_window_fallbacks.
+# Model names are plain strings — no litellm_model resources required.
+
+resource "litellm_key" "with_fallbacks" {
+  key_alias = "test-key-fallbacks"
+  models    = ["gpt-4o", "gpt-4o-mini", "gpt-3.5-turbo", "claude-3-5-sonnet-20241022", "claude-3-haiku-20240307"]
+
+  router_settings_fallbacks = {
+    "gpt-4o" = ["gpt-4o-mini", "gpt-3.5-turbo"]
+  }
+
+  router_settings_context_window_fallbacks = {
+    "gpt-4o" = ["gpt-4o-mini", "gpt-3.5-turbo"]
+  }
+}
+
+output "key_fallbacks_id" {
+  value = litellm_key.with_fallbacks.id
+}
+
+output "key_fallbacks_router_settings_fallbacks" {
+  value = litellm_key.with_fallbacks.router_settings_fallbacks
+}
+
+output "key_fallbacks_router_settings_context_window_fallbacks" {
+  value = litellm_key.with_fallbacks.router_settings_context_window_fallbacks
+}
+
+output "key_fallbacks_key" {
+  value     = litellm_key.with_fallbacks.key
+  sensitive = true
+}


### PR DESCRIPTION
### Problem

LiteLLM supports per-key router fallbacks — when a model fails, the router can retry with a fallback model. When a model's context window is exceeded, it can fall back to a model with a larger context. Neither of these could be configured via Terraform.

### Summary

Adds router_settings_fallbacks and router_settings_context_window_fallbacks to the litellm_key resource. Both are map(list(string)): each key is a primary model name, each value is an ordered list of fallbacks. Multiple primary models and multiple fallbacks per model are supported. Model names are plain strings — no litellm_model resources required.
Removing either attribute from config sends an explicit empty list to the API, correctly clearing previously configured fallbacks rather than leaving them as orphaned state.

### Verified                                                                                                                                                                           
                                                                                                                                                                                     
  Against the bundled internal_testing docker compose LiteLLM:                                                                                                                       
                                                                                                                                                                                     
  - Create: API returns the correct router_settings structure with multiple fallbacks per primary model and multiple primary models per key.
```python
"router_settings": {
      "fallbacks": [
        {
          "gpt-4o": [
            "gpt-4o-mini",
            "gpt-3.5-turbo"
          ]
        },
        {
          "gpt-4o-mini": [
            "gpt-3.5-turbo"
          ]
        }
      ],
      "context_window_fallbacks": [
        {
          "claude-3-5-sonnet-20241022": [
            "gpt-4o-mini",
            "gpt-3.5-turbo"
          ]
        },
        {
          "claude-3-haiku-20240307": [
            "gpt-4o-mini",
            "gpt-3.5-turbo"
          ]
        },
        {
          "gpt-4o": [
            "gpt-4o-mini",
            "gpt-3.5-turbo"
          ]
        }
      ]
    }
``` 
  - Delete: removing the attributes sends fallbacks: [] / context_window_fallbacks: []; API confirms both are cleared.
  
```python
"router_settings": {
      "fallbacks": [],
      "context_window_fallbacks": []
    },
``` 