### PR TITLE
fix(fallback): retry transient data source reads

### DIFF
--- a/internal/provider/datasource_fallback.go
+++ b/internal/provider/datasource_fallback.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -85,19 +86,32 @@ func (d *FallbackDataSource) Read(ctx context.Context, req datasource.ReadReques
 		fallbackType = "general"
 	}
 
-	endpoint := fmt.Sprintf("/fallback/%s?fallback_type=%s",
-		url.PathEscape(data.Model.ValueString()),
-		url.QueryEscape(fallbackType))
-
-	var result map[string]interface{}
-	if err := d.client.DoRequestWithResponse(ctx, "GET", endpoint, nil, &result); err != nil {
+	data.FallbackType = types.StringValue(fallbackType)
+	if err := d.readFallbackWithRetry(ctx, &data, fallbackReadMaxAttempts, fallbackReadInitialDelay, fallbackReadMaxDelay); err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read fallback for model '%s': %s", data.Model.ValueString(), err))
 		return
 	}
 
-	data.ID = types.StringValue(data.Model.ValueString() + ":" + fallbackType)
-	data.FallbackType = types.StringValue(fallbackType)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
 
+func (d *FallbackDataSource) readFallbackWithRetry(ctx context.Context, data *FallbackDataSourceModel, maxAttempts int, initialDelay, maxDelay time.Duration) error {
+	return retryFallbackRead(ctx, maxAttempts, initialDelay, maxDelay, func() error {
+		return d.readFallback(ctx, data)
+	})
+}
+
+func (d *FallbackDataSource) readFallback(ctx context.Context, data *FallbackDataSourceModel) error {
+	endpoint := fmt.Sprintf("/fallback/%s?fallback_type=%s",
+		url.PathEscape(data.Model.ValueString()),
+		url.QueryEscape(data.FallbackType.ValueString()))
+
+	var result map[string]interface{}
+	if err := d.client.DoRequestWithResponse(ctx, "GET", endpoint, nil, &result); err != nil {
+		return err
+	}
+
+	data.ID = types.StringValue(data.Model.ValueString() + ":" + data.FallbackType.ValueString())
 	if fallbackModels, ok := result["fallback_models"].([]interface{}); ok {
 		list := make([]attr.Value, 0, len(fallbackModels))
 		for _, m := range fallbackModels {
@@ -110,5 +124,5 @@ func (d *FallbackDataSource) Read(ctx context.Context, req datasource.ReadReques
 		data.FallbackModels, _ = types.ListValue(types.StringType, []attr.Value{})
 	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	return nil
 }

--- a/internal/provider/datasource_fallback_test.go
+++ b/internal/provider/datasource_fallback_test.go
@@ -1,0 +1,127 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestFallbackDataSourceReadRetriesNotFoundAndPopulatesState(t *testing.T) {
+	t.Parallel()
+
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("fallback_type"); got != "general" {
+			t.Errorf("fallback_type query = %q, want general", got)
+		}
+
+		if attempts.Add(1) < 3 {
+			http.Error(w, `{"detail":{"error":"fallback not found"}}`, http.StatusNotFound)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"fallback_type":   "general",
+			"fallback_models": []string{"secondary-a", "secondary-b"},
+		})
+	}))
+	defer server.Close()
+
+	d := &FallbackDataSource{
+		client: &Client{
+			APIBase:    server.URL,
+			APIKey:     "test-key",
+			HTTPClient: server.Client(),
+		},
+	}
+	data := &FallbackDataSourceModel{
+		Model:        types.StringValue("primary"),
+		FallbackType: types.StringValue("general"),
+	}
+
+	if err := d.readFallbackWithRetry(context.Background(), data, 5, 0, 0); err != nil {
+		t.Fatalf("readFallbackWithRetry returned error: %v", err)
+	}
+	if got := attempts.Load(); got != 3 {
+		t.Fatalf("attempts = %d, want 3", got)
+	}
+	if got := data.ID.ValueString(); got != "primary:general" {
+		t.Errorf("id = %q, want primary:general", got)
+	}
+	if got := data.FallbackType.ValueString(); got != "general" {
+		t.Errorf("fallback_type = %q, want general", got)
+	}
+
+	var models []string
+	if diags := data.FallbackModels.ElementsAs(context.Background(), &models, false); diags.HasError() {
+		t.Fatalf("decode fallback_models: %v", diags)
+	}
+	if len(models) != 2 || models[0] != "secondary-a" || models[1] != "secondary-b" {
+		t.Errorf("fallback_models = %v, want [secondary-a secondary-b]", models)
+	}
+}
+
+func TestRetryFallbackReadStopsAtAttemptLimit(t *testing.T) {
+	t.Parallel()
+
+	var attempts int
+	expected := errors.New("404 fallback not found")
+	err := retryFallbackRead(context.Background(), 3, 0, 0, func() error {
+		attempts++
+		return expected
+	})
+
+	if !errors.Is(err, expected) {
+		t.Fatalf("error = %v, want %v", err, expected)
+	}
+	if attempts != 3 {
+		t.Errorf("attempts = %d, want 3", attempts)
+	}
+}
+
+func TestRetryFallbackReadDoesNotRetryOtherErrors(t *testing.T) {
+	t.Parallel()
+
+	var attempts int
+	expected := errors.New("API request failed with status 500")
+	err := retryFallbackRead(context.Background(), 5, 0, 0, func() error {
+		attempts++
+		return expected
+	})
+
+	if !errors.Is(err, expected) {
+		t.Fatalf("error = %v, want %v", err, expected)
+	}
+	if attempts != 1 {
+		t.Errorf("attempts = %d, want 1", attempts)
+	}
+}
+
+func TestRetryFallbackReadHonorsCancellationDuringBackoff(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var attempts int
+	err := retryFallbackRead(ctx, 5, time.Hour, time.Hour, func() error {
+		attempts++
+		cancel()
+		return errors.New("404 fallback not found")
+	})
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+	if attempts != 1 {
+		t.Errorf("attempts = %d, want 1", attempts)
+	}
+}

--- a/internal/provider/resource_fallback.go
+++ b/internal/provider/resource_fallback.go
@@ -19,6 +19,12 @@ import (
 var _ resource.Resource = &FallbackResource{}
 var _ resource.ResourceWithImportState = &FallbackResource{}
 
+const (
+	fallbackReadMaxAttempts  = 5
+	fallbackReadInitialDelay = time.Second
+	fallbackReadMaxDelay     = 10 * time.Second
+)
+
 func NewFallbackResource() resource.Resource {
 	return &FallbackResource{}
 }
@@ -104,7 +110,7 @@ func (r *FallbackResource) Create(ctx context.Context, req resource.CreateReques
 
 	data.ID = types.StringValue(data.Model.ValueString() + ":" + data.FallbackType.ValueString())
 
-	if err := r.readFallbackWithRetry(ctx, &data, 5); err != nil {
+	if err := r.readFallbackWithRetry(ctx, &data, fallbackReadMaxAttempts); err != nil {
 		resp.Diagnostics.AddWarning("Read Error", fmt.Sprintf("Fallback created but failed to read back: %s", err))
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -117,7 +123,7 @@ func (r *FallbackResource) Read(ctx context.Context, req resource.ReadRequest, r
 		return
 	}
 
-	if err := r.readFallbackWithRetry(ctx, &data, 5); err != nil {
+	if err := r.readFallbackWithRetry(ctx, &data, fallbackReadMaxAttempts); err != nil {
 		if IsNotFoundError(err) {
 			resp.State.RemoveResource(ctx)
 			return
@@ -141,7 +147,7 @@ func (r *FallbackResource) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 
-	if err := r.readFallbackWithRetry(ctx, &data, 5); err != nil {
+	if err := r.readFallbackWithRetry(ctx, &data, fallbackReadMaxAttempts); err != nil {
 		resp.Diagnostics.AddWarning("Read Error", fmt.Sprintf("Fallback updated but failed to read back: %s", err))
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -237,23 +243,47 @@ func shouldRetryFallbackWriteError(err error) bool {
 		strings.Contains(errStr, "not found in router")
 }
 
-func (r *FallbackResource) readFallbackWithRetry(ctx context.Context, data *FallbackResourceModel, maxRetries int) error {
-	var err error
-	delay := 1 * time.Second
-	maxDelay := 10 * time.Second
+func (r *FallbackResource) readFallbackWithRetry(ctx context.Context, data *FallbackResourceModel, maxAttempts int) error {
+	return retryFallbackRead(ctx, maxAttempts, fallbackReadInitialDelay, fallbackReadMaxDelay, func() error {
+		return r.readFallback(ctx, data)
+	})
+}
 
-	for i := 0; i < maxRetries; i++ {
-		err = r.readFallback(ctx, data)
-		if err == nil {
-			return nil
+// retryFallbackRead retries only not-found responses because LiteLLM fallback
+// updates can take time to propagate between proxy workers. The delay is
+// configurable so tests can exercise retry behavior without sleeping.
+func retryFallbackRead(ctx context.Context, maxAttempts int, initialDelay, maxDelay time.Duration, read func() error) error {
+	if maxAttempts < 1 {
+		return fmt.Errorf("fallback read requires at least one attempt")
+	}
+
+	delay := initialDelay
+	var err error
+
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
 		}
 
-		if !IsNotFoundError(err) {
+		err = read()
+		if err == nil || !IsNotFoundError(err) {
 			return err
 		}
+		if attempt == maxAttempts-1 {
+			break
+		}
 
-		if i < maxRetries-1 {
-			time.Sleep(delay)
+		if delay > 0 {
+			timer := time.NewTimer(delay)
+			select {
+			case <-timer.C:
+			case <-ctx.Done():
+				timer.Stop()
+				return ctx.Err()
+			}
+		}
+
+		if delay < maxDelay {
 			delay *= 2
 			if delay > maxDelay {
 				delay = maxDelay


### PR DESCRIPTION
## Summary

- add bounded retry handling to `data.litellm_fallback` for transient 404s after fallback writes
- share one fallback-read retry primitive with the resource implementation
- make retry backoff context-cancellable
- keep production behavior at five attempts with exponential backoff
- add deterministic zero-delay tests for recovery, exhaustion, non-retryable errors, cancellation, and decoded state

Fixes #153.

## Validation

- `gofmt`
- `go vet ./...`
- `go test ./...`
- live dev targeted fallback: create models/fallback → immediate data-source read → clean plan → destroy
- full live dev E2E: 23/23 resource folders passed apply → no-drift plan → destroy
