### PR TITLE
chore: ignore local environment credential files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,5 +78,10 @@ go.work
 # Log files
 *.log
 
-# Environment files
+# Local environment and credential files
 .env
+.env.*
+*.env
+*.env.*
+!.env.example
+!*.env.example


### PR DESCRIPTION
Adds repository-level ignore rules for local `.env` and `*.env` credential files while allowing sanitized `.env.example` templates. Verified that no env files were historically tracked and that current dev credential values are absent from all reachable Git blobs.