### PR TITLE
fix(model): preserve additional params omitted by API

### DIFF
--- a/internal/provider/resource_model.go
+++ b/internal/provider/resource_model.go
@@ -667,6 +667,25 @@ func (r *ModelResource) readModel(ctx context.Context, data *ModelResourceModel)
 			}
 		}
 
+		// Carry forward keys the user configured in additional_litellm_params
+		// that the API does not echo back in litellm_params (e.g. tags,
+		// max_retries, timeout, stream_timeout). Without this, those keys are
+		// dropped on read-back and Terraform fails the post-apply consistency
+		// check with "element <key> has vanished" ("Provider produced
+		// inconsistent result after apply"). We only do this during normal
+		// Read (filterByState), preserving the value from prior state; on
+		// Import we intentionally reflect the full API state instead.
+		if filterByState {
+			priorParams := data.AdditionalLiteLLMParams.Elements()
+			for k := range stateKeys {
+				if _, present := additionalParams[k]; !present {
+					if prior, ok := priorParams[k]; ok {
+						additionalParams[k] = prior
+					}
+				}
+			}
+		}
+
 		// Set additional_litellm_params from API response to detect drift
 		// for keys that the user configured.
 		data.AdditionalLiteLLMParams, _ = types.MapValue(types.StringType, additionalParams)

--- a/internal/provider/resource_model_test.go
+++ b/internal/provider/resource_model_test.go
@@ -430,7 +430,7 @@ func TestPatchModelSendsTeamPublicModelNameWhenTeamIDSet(t *testing.T) {
 		TeamID:            types.StringValue(wantTeamID),
 		Tier:              types.StringNull(),
 		Mode:              types.StringNull(),
-		AccessGroups:     types.ListNull(types.StringType),
+		AccessGroups:      types.ListNull(types.StringType),
 	}
 
 	err := r.patchModel(context.Background(), data)
@@ -510,6 +510,66 @@ func TestReadModelExtractsAdditionalLiteLLMParams(t *testing.T) {
 	}
 	if got := additional["max_retries"]; got != "3" {
 		t.Fatalf("expected max_retries=3, got %q", got)
+	}
+}
+
+func TestReadModelCarriesForwardConfiguredParamsOmittedByAPI(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": []interface{}{
+				map[string]interface{}{
+					"model_name": "gpt-4o-mini",
+					"litellm_params": map[string]interface{}{
+						"custom_llm_provider": "openai",
+						"model":               "openai/gpt-4o-mini",
+					},
+					"model_info": map[string]interface{}{"base_model": "gpt-4o-mini"},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	r := &ModelResource{client: &Client{
+		APIBase:    server.URL,
+		APIKey:     "test-key",
+		HTTPClient: server.Client(),
+	}}
+	prior, _ := types.MapValue(types.StringType, map[string]attr.Value{
+		"tags":           types.StringValue(`["production"]`),
+		"max_retries":    types.StringValue("3"),
+		"timeout":        types.StringValue("30"),
+		"stream_timeout": types.StringValue("60"),
+	})
+	data := ModelResourceModel{
+		ID:                      types.StringValue("model-123"),
+		AdditionalLiteLLMParams: prior,
+	}
+
+	if err := r.readModel(context.Background(), &data); err != nil {
+		t.Fatalf("readModel returned error: %v", err)
+	}
+
+	var got map[string]string
+	if diags := data.AdditionalLiteLLMParams.ElementsAs(context.Background(), &got, false); diags.HasError() {
+		t.Fatalf("decode additional_litellm_params: %v", diags)
+	}
+	want := map[string]string{
+		"tags":           `["production"]`,
+		"max_retries":    "3",
+		"timeout":        "30",
+		"stream_timeout": "60",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("additional_litellm_params = %v, want %v", got, want)
+	}
+	for key, value := range want {
+		if got[key] != value {
+			t.Errorf("additional_litellm_params[%q] = %q, want %q", key, got[key], value)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- carry forward configured `additional_litellm_params` keys when LiteLLM omits them from `/model/info`
- preserve import behavior and API-returned values when present
- add regression coverage for omitted `tags`, `max_retries`, `timeout`, and `stream_timeout`

Fixes #120.

The implementation commit is preserved from @ripiomatiascalvo's PR #121 (`a02ba35e`). This integration branch adds maintainer regression coverage and validates it against the current `issues` branch.

## Validation

- `gofmt`
- `go vet ./...`
- `go test ./...`
- live dev LiteLLM v1.98.0 configured-parameter apply → no-drift plan → destroy
- full live dev E2E: 23/23 resource folders passed apply → no-drift plan → destroy
- staged diff scanned against local dev credential values; no secrets present
