### PR TITLE
fix(model): preserve semantically equal JSON params

### DIFF
--- a/internal/provider/resource_model.go
+++ b/internal/provider/resource_model.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -617,7 +618,9 @@ func (r *ModelResource) readModel(ctx context.Context, data *ModelResourceModel)
 		// the imported resource captures the full API state.
 		filterByState := !data.AdditionalLiteLLMParams.IsNull() && !data.AdditionalLiteLLMParams.IsUnknown()
 		stateKeys := make(map[string]struct{})
+		priorStrings := make(map[string]string)
 		if filterByState {
+			data.AdditionalLiteLLMParams.ElementsAs(ctx, &priorStrings, false)
 			for k := range data.AdditionalLiteLLMParams.Elements() {
 				stateKeys[k] = struct{}{}
 			}
@@ -662,7 +665,17 @@ func (r *ModelResource) readModel(ctx context.Context, data *ModelResourceModel)
 			default:
 				// Arrays, objects, and other complex types — serialize back to JSON string.
 				if jsonBytes, err := json.Marshal(v); err == nil {
-					additionalParams[key] = types.StringValue(string(jsonBytes))
+					// If the prior config/state value is JSON that is semantically
+					// equal to the API-returned value, preserve the prior string.
+					// json.Marshal emits compact, key-sorted JSON, so a config
+					// value like {"inputs": "{prompt}"} would otherwise round-trip
+					// to {"inputs":"{prompt}"} and fail the post-apply consistency
+					// check purely on formatting.
+					if prior, ok := priorStrings[key]; ok && jsonSemanticallyEqual(prior, string(jsonBytes)) {
+						additionalParams[key] = types.StringValue(prior)
+					} else {
+						additionalParams[key] = types.StringValue(string(jsonBytes))
+					}
 				}
 			}
 		}
@@ -955,6 +968,22 @@ func normalizeNumericString(s string) string {
 		return strconv.FormatFloat(f, 'f', -1, 64)
 	}
 	return s
+}
+
+// jsonSemanticallyEqual reports whether two strings are both valid JSON that
+// decode to the same value, ignoring formatting differences (whitespace, key
+// ordering). Used on read-back so a JSON-valued additional_litellm_params
+// entry that only differs from the provider's compact re-marshal by formatting
+// is not treated as drift.
+func jsonSemanticallyEqual(a, b string) bool {
+	var av, bv interface{}
+	if err := json.Unmarshal([]byte(a), &av); err != nil {
+		return false
+	}
+	if err := json.Unmarshal([]byte(b), &bv); err != nil {
+		return false
+	}
+	return reflect.DeepEqual(av, bv)
 }
 
 // normalizeAdditionalParams returns a new MapValue where every numeric string

--- a/internal/provider/resource_model_test.go
+++ b/internal/provider/resource_model_test.go
@@ -205,6 +205,32 @@ func TestConvertStringValue(t *testing.T) {
 	}
 }
 
+func TestJSONSemanticallyEqual(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		a    string
+		b    string
+		want bool
+	}{
+		{"whitespace after colon", `{"inputs": "{prompt}"}`, `{"inputs":"{prompt}"}`, true},
+		{"key ordering", `{"a":1,"b":2}`, `{"b":2,"a":1}`, true},
+		{"identical", `{"inputs":"{prompt}"}`, `{"inputs":"{prompt}"}`, true},
+		{"arrays equal", `["a", "b"]`, `["a","b"]`, true},
+		{"different values", `{"inputs":"{prompt}"}`, `{"inputs":"{other}"}`, false},
+		{"different keys", `{"a":1}`, `{"b":1}`, false},
+		{"a not json", `not json {`, `{"a":1}`, false},
+		{"b not json", `{"a":1}`, `not json {`, false},
+	}
+
+	for _, tt := range tests {
+		if got := jsonSemanticallyEqual(tt.a, tt.b); got != tt.want {
+			t.Errorf("%s: jsonSemanticallyEqual(%q, %q) = %v, want %v", tt.name, tt.a, tt.b, got, tt.want)
+		}
+	}
+}
+
 func TestCreateModelSendsAdditionalLiteLLMParams(t *testing.T) {
 	t.Parallel()
 

--- a/internal/provider/resource_model_test.go
+++ b/internal/provider/resource_model_test.go
@@ -231,6 +231,64 @@ func TestJSONSemanticallyEqual(t *testing.T) {
 	}
 }
 
+func TestReadModelPreservesSemanticallyEqualJSONFormatting(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": []interface{}{
+				map[string]interface{}{
+					"model_name": "gpt-4o-mini",
+					"litellm_params": map[string]interface{}{
+						"custom_llm_provider": "openai",
+						"model":               "openai/gpt-4o-mini",
+						"input_schema":        map[string]interface{}{"inputs": "{prompt}"},
+						"ordering":            map[string]interface{}{"a": 1.0, "b": 2.0},
+						"stop_sequences":      []interface{}{"</end>", "STOP"},
+					},
+					"model_info": map[string]interface{}{"base_model": "gpt-4o-mini"},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	r := &ModelResource{client: &Client{
+		APIBase:    server.URL,
+		APIKey:     "test-key",
+		HTTPClient: server.Client(),
+	}}
+	prior, _ := types.MapValue(types.StringType, map[string]attr.Value{
+		"input_schema":   types.StringValue(`{"inputs": "{prompt}"}`),
+		"ordering":       types.StringValue(`{"b": 2, "a": 1}`),
+		"stop_sequences": types.StringValue(`["</end>", "STOP"]`),
+	})
+	data := ModelResourceModel{
+		ID:                      types.StringValue("model-123"),
+		AdditionalLiteLLMParams: prior,
+	}
+
+	if err := r.readModel(context.Background(), &data); err != nil {
+		t.Fatalf("readModel returned error: %v", err)
+	}
+
+	var got map[string]string
+	if diags := data.AdditionalLiteLLMParams.ElementsAs(context.Background(), &got, false); diags.HasError() {
+		t.Fatalf("decode additional_litellm_params: %v", diags)
+	}
+	want := map[string]string{
+		"input_schema":   `{"inputs": "{prompt}"}`,
+		"ordering":       `{"b": 2, "a": 1}`,
+		"stop_sequences": `["</end>", "STOP"]`,
+	}
+	for key, value := range want {
+		if got[key] != value {
+			t.Errorf("additional_litellm_params[%q] = %q, want preserved %q", key, got[key], value)
+		}
+	}
+}
+
 func TestCreateModelSendsAdditionalLiteLLMParams(t *testing.T) {
 	t.Parallel()
 

--- a/internal_testing/resources/model_json_params.tf
+++ b/internal_testing/resources/model_json_params.tf
@@ -1,0 +1,34 @@
+# litellm_model - JSON-valued additional_litellm_params
+#
+# Regression fixture for: https://github.com/ncecere/terraform-provider-litellm/issues/126
+#
+# A JSON object/array value in additional_litellm_params must survive a
+# plan/apply round-trip even when the config's JSON formatting differs from
+# Go's compact, key-sorted json.Marshal output. Before the fix, apply failed:
+#
+#   Error: Provider produced inconsistent result after apply
+#   .additional_litellm_params["input_schema"]:
+#     was cty.StringVal("{\"inputs\": \"{prompt}\"}"),
+#     but now cty.StringVal("{\"inputs\":\"{prompt}\"}").
+#
+# The values below use non-canonical formatting on purpose: a space after the
+# colon, out-of-order keys, and an array — so `make smoke` catches a regression.
+
+resource "litellm_model" "json_params" {
+  model_name          = "test-model-json-params"
+  custom_llm_provider = "openai"
+  base_model          = "gpt-4o-mini"
+
+  additional_litellm_params = {
+    # space after colon (differs from compact marshal)
+    input_schema = "{\"inputs\": \"{prompt}\"}"
+    # keys deliberately out of alphabetical order
+    ordering = "{\"b\": 2, \"a\": 1}"
+    # a JSON array value
+    stop_sequences = "[\"</end>\", \"STOP\"]"
+  }
+}
+
+output "model_json_params_id" {
+  value = litellm_model.json_params.id
+}


### PR DESCRIPTION
## Summary

- preserve prior JSON strings in `additional_litellm_params` when API-returned JSON is semantically equal
- avoid post-apply inconsistency caused only by whitespace or object-key ordering
- add helper, read-path regression coverage, and a reusable smoke fixture

Fixes #126.

The implementation and smoke commits are preserved from @msabramo's PR #127 (`46e0bde0`, `92cf7dad`). The masking-specific commit from that PR is intentionally excluded here and will be integrated separately under #119.

## Validation

- `gofmt`
- `go vet ./...`
- `go test ./...`
- live dev LiteLLM v1.98.0 non-canonical JSON apply → no-drift plan → destroy
- full live dev E2E: 23/23 resource folders passed apply → no-drift plan → destroy
- staged and branch diffs scanned against local dev credential values; no secrets present
