### PR TITLE
fix(model): preserve masked additional parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **`litellm_model`**: Preserve configured `additional_litellm_params` values when LiteLLM masks direct secrets such as `azure_ad_token` or nested JSON secret values during read-back, while continuing to surface unmasked remote drift. ([#119](https://github.com/ncecere/terraform-provider-litellm/issues/119)) — thanks @msabramo
+
 ## [2.0.1] - 2026-06-12
 
 ### Fixed

--- a/internal/provider/resource_model.go
+++ b/internal/provider/resource_model.go
@@ -647,9 +647,15 @@ func (r *ModelResource) readModel(ctx context.Context, data *ModelResourceModel)
 
 			switch v := rawValue.(type) {
 			case string:
-				// Normalize numeric strings to decimal notation so that
-				// "1.75e-07" (from API) matches "0.000000175" (from config).
-				if f, err := strconv.ParseFloat(v, 64); err == nil {
+				// LiteLLM masks sensitive scalar values such as azure_ad_token
+				// before returning them. Preserve the configured value when the API
+				// clearly returned a masking marker instead of exposing the masked
+				// value to Terraform's post-apply consistency check.
+				if prior, hasPrior := priorStrings[key]; hasPrior && isMaskedAPIString(v) {
+					additionalParams[key] = types.StringValue(prior)
+				} else if f, err := strconv.ParseFloat(v, 64); err == nil {
+					// Normalize numeric strings to decimal notation so that
+					// "1.75e-07" (from API) matches "0.000000175" (from config).
 					additionalParams[key] = types.StringValue(strconv.FormatFloat(f, 'f', -1, 64))
 				} else {
 					additionalParams[key] = types.StringValue(v)
@@ -675,13 +681,10 @@ func (r *ModelResource) readModel(ctx context.Context, data *ModelResourceModel)
 					// post-apply consistency check purely on formatting.
 					case hasPrior && jsonSemanticallyEqual(prior, apiJSON):
 						additionalParams[key] = types.StringValue(prior)
-					// Also preserve it when the value has the same SHAPE but
-					// differing scalar leaves -- LiteLLM masks/encrypts secret
-					// values (e.g. an x-api-key inside extra_headers) on read, so
-					// the API value never matches what was sent. We can't
-					// distinguish masking from real drift, so we carry forward the
-					// prior value, mirroring how model_api_key/aws_* are handled.
-					case hasPrior && jsonSameShape(prior, apiJSON):
+					// Preserve same-shaped JSON only when the API value contains an
+					// explicit masking marker. Shape alone is insufficient because
+					// it would hide genuine out-of-band scalar drift.
+					case hasPrior && jsonSameShape(prior, apiJSON) && jsonContainsMaskedValue(apiJSON):
 						additionalParams[key] = types.StringValue(prior)
 					default:
 						additionalParams[key] = types.StringValue(apiJSON)
@@ -998,14 +1001,9 @@ func jsonSemanticallyEqual(a, b string) bool {
 
 // jsonSameShape reports whether two JSON strings have the same structure --
 // same object keys (recursively) and same array lengths -- ignoring differences
-// in scalar (string/number/bool) leaf values. It's used to detect the case
-// where LiteLLM returns a value whose secret leaves have been masked/encrypted
-// on read (e.g. an x-api-key inside extra_headers): the shape is identical but
-// a scalar differs. In that case we can't tell a masked value from a genuinely
-// changed one, so the caller preserves the prior state value rather than fail
-// the post-apply consistency check on what is almost always just masking.
-// (This mirrors how model_api_key and the aws_* secret fields are already
-// carried forward from state rather than trusted from the API response.)
+// in scalar (string/number/bool) leaf values. The read path combines this check
+// with jsonContainsMaskedValue before preserving prior state, so same-shaped
+// unmasked remote drift remains visible.
 func jsonSameShape(a, b string) bool {
 	var av, bv interface{}
 	if err := json.Unmarshal([]byte(a), &av); err != nil {
@@ -1057,6 +1055,39 @@ func isJSONContainer(v interface{}) bool {
 	default:
 		return false
 	}
+}
+
+func isMaskedAPIString(value string) bool {
+	upper := strings.ToUpper(value)
+	return strings.Contains(value, "****") || strings.Contains(upper, "REDACTED")
+}
+
+func jsonContainsMaskedValue(value string) bool {
+	var decoded interface{}
+	if err := json.Unmarshal([]byte(value), &decoded); err != nil {
+		return false
+	}
+	return containsMaskedValue(decoded)
+}
+
+func containsMaskedValue(value interface{}) bool {
+	switch typed := value.(type) {
+	case string:
+		return isMaskedAPIString(typed)
+	case map[string]interface{}:
+		for _, child := range typed {
+			if containsMaskedValue(child) {
+				return true
+			}
+		}
+	case []interface{}:
+		for _, child := range typed {
+			if containsMaskedValue(child) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // normalizeAdditionalParams returns a new MapValue where every numeric string

--- a/internal/provider/resource_model.go
+++ b/internal/provider/resource_model.go
@@ -665,16 +665,26 @@ func (r *ModelResource) readModel(ctx context.Context, data *ModelResourceModel)
 			default:
 				// Arrays, objects, and other complex types — serialize back to JSON string.
 				if jsonBytes, err := json.Marshal(v); err == nil {
-					// If the prior config/state value is JSON that is semantically
-					// equal to the API-returned value, preserve the prior string.
-					// json.Marshal emits compact, key-sorted JSON, so a config
-					// value like {"inputs": "{prompt}"} would otherwise round-trip
-					// to {"inputs":"{prompt}"} and fail the post-apply consistency
-					// check purely on formatting.
-					if prior, ok := priorStrings[key]; ok && jsonSemanticallyEqual(prior, string(jsonBytes)) {
+					apiJSON := string(jsonBytes)
+					prior, hasPrior := priorStrings[key]
+					switch {
+					// Preserve the prior string when it's semantically equal to
+					// the API value: json.Marshal emits compact, key-sorted JSON,
+					// so a config value like {"inputs": "{prompt}"} would
+					// otherwise round-trip to {"inputs":"{prompt}"} and fail the
+					// post-apply consistency check purely on formatting.
+					case hasPrior && jsonSemanticallyEqual(prior, apiJSON):
 						additionalParams[key] = types.StringValue(prior)
-					} else {
-						additionalParams[key] = types.StringValue(string(jsonBytes))
+					// Also preserve it when the value has the same SHAPE but
+					// differing scalar leaves -- LiteLLM masks/encrypts secret
+					// values (e.g. an x-api-key inside extra_headers) on read, so
+					// the API value never matches what was sent. We can't
+					// distinguish masking from real drift, so we carry forward the
+					// prior value, mirroring how model_api_key/aws_* are handled.
+					case hasPrior && jsonSameShape(prior, apiJSON):
+						additionalParams[key] = types.StringValue(prior)
+					default:
+						additionalParams[key] = types.StringValue(apiJSON)
 					}
 				}
 			}
@@ -984,6 +994,69 @@ func jsonSemanticallyEqual(a, b string) bool {
 		return false
 	}
 	return reflect.DeepEqual(av, bv)
+}
+
+// jsonSameShape reports whether two JSON strings have the same structure --
+// same object keys (recursively) and same array lengths -- ignoring differences
+// in scalar (string/number/bool) leaf values. It's used to detect the case
+// where LiteLLM returns a value whose secret leaves have been masked/encrypted
+// on read (e.g. an x-api-key inside extra_headers): the shape is identical but
+// a scalar differs. In that case we can't tell a masked value from a genuinely
+// changed one, so the caller preserves the prior state value rather than fail
+// the post-apply consistency check on what is almost always just masking.
+// (This mirrors how model_api_key and the aws_* secret fields are already
+// carried forward from state rather than trusted from the API response.)
+func jsonSameShape(a, b string) bool {
+	var av, bv interface{}
+	if err := json.Unmarshal([]byte(a), &av); err != nil {
+		return false
+	}
+	if err := json.Unmarshal([]byte(b), &bv); err != nil {
+		return false
+	}
+	return sameShape(av, bv)
+}
+
+func sameShape(a, b interface{}) bool {
+	switch at := a.(type) {
+	case map[string]interface{}:
+		bt, ok := b.(map[string]interface{})
+		if !ok || len(at) != len(bt) {
+			return false
+		}
+		for k, av := range at {
+			bv, present := bt[k]
+			if !present || !sameShape(av, bv) {
+				return false
+			}
+		}
+		return true
+	case []interface{}:
+		bt, ok := b.([]interface{})
+		if !ok || len(at) != len(bt) {
+			return false
+		}
+		for i := range at {
+			if !sameShape(at[i], bt[i]) {
+				return false
+			}
+		}
+		return true
+	default:
+		// Scalars (string, float64, bool, nil): shape matches if both are
+		// scalars of a compatible kind. Differing scalar VALUES are treated as
+		// the same shape -- that's the masking case we want to tolerate.
+		return !isJSONContainer(b)
+	}
+}
+
+func isJSONContainer(v interface{}) bool {
+	switch v.(type) {
+	case map[string]interface{}, []interface{}:
+		return true
+	default:
+		return false
+	}
 }
 
 // normalizeAdditionalParams returns a new MapValue where every numeric string

--- a/internal/provider/resource_model_test.go
+++ b/internal/provider/resource_model_test.go
@@ -261,6 +261,28 @@ func TestJSONSameShape(t *testing.T) {
 	}
 }
 
+func TestJSONContainsMaskedValue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{"masked nested secret", `{"headers":{"x-api-key":"sk****99"}}`, true},
+		{"redacted marker", `{"token":"***REDACTED***"}`, true},
+		{"unmasked scalar drift", `{"headers":{"x-api-key":"changed-value"}}`, false},
+		{"asterisks below mask threshold", `{"value":"a***b"}`, false},
+		{"invalid JSON", `not json`, false},
+	}
+
+	for _, test := range tests {
+		if got := jsonContainsMaskedValue(test.value); got != test.want {
+			t.Errorf("%s: jsonContainsMaskedValue(%q) = %v, want %v", test.name, test.value, got, test.want)
+		}
+	}
+}
+
 func TestReadModelPreservesSemanticallyEqualJSONFormatting(t *testing.T) {
 	t.Parallel()
 
@@ -627,12 +649,10 @@ func TestReadModelExtractsAdditionalLiteLLMParams(t *testing.T) {
 	}
 }
 
-// TestReadModelPreservesMaskedExtraHeaders verifies that when LiteLLM returns
-// a JSON-valued additional_litellm_params entry (e.g. extra_headers) with a
-// secret leaf masked/encrypted, readModel preserves the prior state value
-// instead of the masked API value -- otherwise every apply fails the
-// post-apply consistency check ("inconsistent result after apply").
-func TestReadModelPreservesMaskedExtraHeaders(t *testing.T) {
+// TestReadModelPreservesMaskedAdditionalParams verifies both direct scalar
+// masking (the azure_ad_token case from #119) and a masked secret nested inside
+// a JSON-valued additional parameter.
+func TestReadModelPreservesMaskedAdditionalParams(t *testing.T) {
 	t.Parallel()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -644,8 +664,9 @@ func TestReadModelPreservesMaskedExtraHeaders(t *testing.T) {
 					"litellm_params": map[string]interface{}{
 						"custom_llm_provider": "openai",
 						"model":               "openai/checkpoint-3400",
+						"azure_ad_token":      "_oidc*****ange_",
 						"extra_headers": map[string]interface{}{
-							"x-api-key":  "sk-masked-9999999999",
+							"x-api-key":  "sk****99",
 							"X-Model-Id": "needs-attribution-classifier-xlab",
 						},
 					},
@@ -662,7 +683,8 @@ func TestReadModelPreservesMaskedExtraHeaders(t *testing.T) {
 
 	priorHeaders := `{"x-api-key":"realsecret","X-Model-Id":"needs-attribution-classifier-xlab"}`
 	priorParams, _ := types.MapValue(types.StringType, map[string]attr.Value{
-		"extra_headers": types.StringValue(priorHeaders),
+		"azure_ad_token": types.StringValue("real-oidc-token"),
+		"extra_headers":  types.StringValue(priorHeaders),
 	})
 	data := ModelResourceModel{
 		ID:                      types.StringValue("model-xlab"),
@@ -678,8 +700,56 @@ func TestReadModelPreservesMaskedExtraHeaders(t *testing.T) {
 	if diags := data.AdditionalLiteLLMParams.ElementsAs(context.Background(), &additional, false); diags.HasError() {
 		t.Fatalf("failed to decode additional_litellm_params: %v", diags)
 	}
+	if got := additional["azure_ad_token"]; got != "real-oidc-token" {
+		t.Errorf("expected azure_ad_token preserved from prior state, got %q", got)
+	}
 	if got := additional["extra_headers"]; got != priorHeaders {
-		t.Fatalf("expected extra_headers preserved from prior state %q, got %q", priorHeaders, got)
+		t.Errorf("expected extra_headers preserved from prior state %q, got %q", priorHeaders, got)
+	}
+}
+
+func TestReadModelDoesNotHideUnmaskedJSONDrift(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": []interface{}{
+				map[string]interface{}{
+					"model_name": "test-model",
+					"litellm_params": map[string]interface{}{
+						"custom_llm_provider": "openai",
+						"model":               "openai/test-model",
+						"extra_headers": map[string]interface{}{
+							"x-api-key": "changed-without-mask-marker",
+						},
+					},
+					"model_info": map[string]interface{}{"base_model": "test-model"},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	r := &ModelResource{client: &Client{APIBase: server.URL, APIKey: "test-key", HTTPClient: server.Client()}}
+	prior, _ := types.MapValue(types.StringType, map[string]attr.Value{
+		"extra_headers": types.StringValue(`{"x-api-key":"original"}`),
+	})
+	data := ModelResourceModel{
+		ID:                      types.StringValue("model-123"),
+		AdditionalLiteLLMParams: prior,
+	}
+
+	if err := r.readModel(context.Background(), &data); err != nil {
+		t.Fatalf("readModel returned error: %v", err)
+	}
+	var additional map[string]string
+	if diags := data.AdditionalLiteLLMParams.ElementsAs(context.Background(), &additional, false); diags.HasError() {
+		t.Fatalf("decode additional_litellm_params: %v", diags)
+	}
+	want := `{"x-api-key":"changed-without-mask-marker"}`
+	if got := additional["extra_headers"]; got != want {
+		t.Errorf("extra_headers = %q, want API drift %q", got, want)
 	}
 }
 

--- a/internal/provider/resource_model_test.go
+++ b/internal/provider/resource_model_test.go
@@ -231,6 +231,36 @@ func TestJSONSemanticallyEqual(t *testing.T) {
 	}
 }
 
+func TestJSONSameShape(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		a    string
+		b    string
+		want bool
+	}{
+		// Masking case: same keys, a scalar value differs (secret masked on read).
+		{"masked scalar value", `{"x-api-key":"realsecret","X-Model-Id":"m"}`, `{"x-api-key":"sk-masked-abc","X-Model-Id":"m"}`, true},
+		{"identical", `{"x-api-key":"a"}`, `{"x-api-key":"a"}`, true},
+		{"nested masked", `{"h":{"k":"real"}}`, `{"h":{"k":"masked"}}`, true},
+		{"array same len differing scalars", `["a","b"]`, `["x","y"]`, true},
+		// Not the same shape -- real structural drift, should NOT be tolerated.
+		{"extra key", `{"a":"1"}`, `{"a":"1","b":"2"}`, false},
+		{"missing key", `{"a":"1","b":"2"}`, `{"a":"1"}`, false},
+		{"renamed key", `{"a":"1"}`, `{"b":"1"}`, false},
+		{"array length differs", `["a"]`, `["a","b"]`, false},
+		{"scalar vs object", `{"a":"1"}`, `"1"`, false},
+		{"a not json", `not json`, `{"a":"1"}`, false},
+	}
+
+	for _, tt := range tests {
+		if got := jsonSameShape(tt.a, tt.b); got != tt.want {
+			t.Errorf("%s: jsonSameShape(%q, %q) = %v, want %v", tt.name, tt.a, tt.b, got, tt.want)
+		}
+	}
+}
+
 func TestReadModelPreservesSemanticallyEqualJSONFormatting(t *testing.T) {
 	t.Parallel()
 
@@ -594,6 +624,62 @@ func TestReadModelExtractsAdditionalLiteLLMParams(t *testing.T) {
 	}
 	if got := additional["max_retries"]; got != "3" {
 		t.Fatalf("expected max_retries=3, got %q", got)
+	}
+}
+
+// TestReadModelPreservesMaskedExtraHeaders verifies that when LiteLLM returns
+// a JSON-valued additional_litellm_params entry (e.g. extra_headers) with a
+// secret leaf masked/encrypted, readModel preserves the prior state value
+// instead of the masked API value -- otherwise every apply fails the
+// post-apply consistency check ("inconsistent result after apply").
+func TestReadModelPreservesMaskedExtraHeaders(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": []interface{}{
+				map[string]interface{}{
+					"model_name": "needs-attribution-classifier-xlab",
+					"litellm_params": map[string]interface{}{
+						"custom_llm_provider": "openai",
+						"model":               "openai/checkpoint-3400",
+						"extra_headers": map[string]interface{}{
+							"x-api-key":  "sk-masked-9999999999",
+							"X-Model-Id": "needs-attribution-classifier-xlab",
+						},
+					},
+					"model_info": map[string]interface{}{"base_model": "checkpoint-3400"},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	r := &ModelResource{
+		client: &Client{APIBase: server.URL, APIKey: "test-key", HTTPClient: server.Client()},
+	}
+
+	priorHeaders := `{"x-api-key":"realsecret","X-Model-Id":"needs-attribution-classifier-xlab"}`
+	priorParams, _ := types.MapValue(types.StringType, map[string]attr.Value{
+		"extra_headers": types.StringValue(priorHeaders),
+	})
+	data := ModelResourceModel{
+		ID:                      types.StringValue("model-xlab"),
+		AccessGroups:            types.ListUnknown(types.StringType),
+		AdditionalLiteLLMParams: priorParams,
+	}
+
+	if err := r.readModel(context.Background(), &data); err != nil {
+		t.Fatalf("readModel returned error: %v", err)
+	}
+
+	additional := map[string]string{}
+	if diags := data.AdditionalLiteLLMParams.ElementsAs(context.Background(), &additional, false); diags.HasError() {
+		t.Fatalf("failed to decode additional_litellm_params: %v", diags)
+	}
+	if got := additional["extra_headers"]; got != priorHeaders {
+		t.Fatalf("expected extra_headers preserved from prior state %q, got %q", priorHeaders, got)
 	}
 }
 


### PR DESCRIPTION
### Summary

Closes #119. `litellm_model` now preserves configured `additional_litellm_params` values when LiteLLM returns an explicit mask/redaction marker, covering both direct scalar secrets such as `azure_ad_token` and masked values nested in JSON such as `extra_headers`.

This builds on @msabramo's masking work from #127, while requiring an actual mask marker before using same-shape JSON preservation so unmasked remote scalar drift remains visible.

### Validation

Confirmed the exact scalar and nested masking behavior against LiteLLM v1.98.0 using fake test secrets: create succeeded, the API returned masked values, the subsequent Terraform plan was clean, and destroy succeeded. Focused regressions cover both masking paths and prove unmasked JSON drift is not hidden; `go vet ./...`, `go test ./...`, and the full 23-resource live dev lifecycle suite also pass with zero drift or failures.

### Diff size

**Docs** — 1 file · `+5 / -0`

Adds the fix to the Unreleased changelog.

**Implementation** — 1 file · `+116 / -12`

Adds recursive JSON shape/mask detection and scalar mask preservation in the model read path.

**Tests** — 1 file · `+156 / -0`

Covers helper behavior, direct and nested masking, semantic JSON preservation, and the unmasked-drift boundary.
