### PR TITLE
docs: backfill unreleased issue fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **`litellm_team`**: Keep API-injected `max_budget` and `budget_duration` defaults out of state when those attributes are unconfigured, preventing inconsistent results after create while preserving explicit clear-to-null behavior. ([#152](https://github.com/ncecere/terraform-provider-litellm/issues/152))
+- **`litellm_fallback` data source**: Retry transient not-found responses while LiteLLM propagates newly created fallback routes, matching the existing resource read behavior. ([#153](https://github.com/ncecere/terraform-provider-litellm/issues/153))
+- **`litellm_model`**: Preserve configured `additional_litellm_params` keys such as `tags`, `max_retries`, and `timeout` when LiteLLM omits them during read-back. ([#120](https://github.com/ncecere/terraform-provider-litellm/issues/120)) — thanks @ripiomatiascalvo
+- **`litellm_model`**: Preserve configured formatting for semantically equivalent JSON-valued `additional_litellm_params`, avoiding post-apply inconsistencies caused only by whitespace or key ordering. ([#126](https://github.com/ncecere/terraform-provider-litellm/issues/126)) — thanks @msabramo
 - **`litellm_model`**: Preserve configured `additional_litellm_params` values when LiteLLM masks direct secrets such as `azure_ad_token` or nested JSON secret values during read-back, while continuing to surface unmasked remote drift. ([#119](https://github.com/ncecere/terraform-provider-litellm/issues/119)) — thanks @msabramo
 
 ## [2.0.1] - 2026-06-12


### PR DESCRIPTION
### Summary

Backfills the Unreleased changelog with the already-merged fixes for #152, #153, #120, and #126. The #119 entry added in #159 remains in the same section so all issue work integrated for the next release is recorded together.

### Validation

Documentation-only change; verified the entries against the merged issue branches and contributor attribution.

### Diff size

**Docs** — 1 file · `+4 / -0`

Adds one concise Unreleased entry for each previously merged fix.

**Implementation** — 0 files · `+0 / -0`

Not applicable.

**Tests** — 0 files · `+0 / -0`

Not applicable.
