### PR TITLE
fix(model): replace when additional params are removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`litellm_model`**: Preserve configured `additional_litellm_params` keys such as `tags`, `max_retries`, and `timeout` when LiteLLM omits them during read-back. ([#120](https://github.com/ncecere/terraform-provider-litellm/issues/120)) — thanks @ripiomatiascalvo
 - **`litellm_model`**: Preserve configured formatting for semantically equivalent JSON-valued `additional_litellm_params`, avoiding post-apply inconsistencies caused only by whitespace or key ordering. ([#126](https://github.com/ncecere/terraform-provider-litellm/issues/126)) — thanks @msabramo
 - **`litellm_model`**: Preserve configured `additional_litellm_params` values when LiteLLM masks direct secrets such as `azure_ad_token` or nested JSON secret values during read-back, while continuing to surface unmasked remote drift. ([#119](https://github.com/ncecere/terraform-provider-litellm/issues/119)) — thanks @msabramo
+- **`litellm_model`**: Plan model replacement when configured `additional_litellm_params` keys are removed or cleared, ensuring LiteLLM actually drops the remote values instead of silently retaining them through merge-style updates. Imported or API-computed parameters remain adopted while the argument is omitted. ([#151](https://github.com/ncecere/terraform-provider-litellm/issues/151))
 
 ## [2.0.1] - 2026-06-12
 

--- a/docs/resources/model.md
+++ b/docs/resources/model.md
@@ -236,7 +236,9 @@ The following arguments are supported:
   * Non-string map values (if supplied) are passed through unchanged.
   * The provider merges these keys into the `litellm_params` payload sent to the API.
   * Note: the remote API may not echo back all custom parameters; this provider preserves `additional_litellm_params` in state when present in configuration.
-  * **Limitation: keys cannot be deleted via update.** The LiteLLM PATCH API (`/model/update`) merges `litellm_params` using `dict.update()` with `exclude_none=True`. This means adding or changing keys works, but removing a key from `additional_litellm_params` in your configuration will **not** remove it from the remote model — it will simply stop being sent. To fully remove a key, recreate the resource using `terraform apply -replace` or `terraform taint`.
+  * Adding keys or changing values uses an in-place model update.
+  * **Removing a key, clearing the map, or removing the argument replaces the model.** LiteLLM's update endpoints merge or retain some parameter classes instead of deleting them reliably. Terraform therefore plans replacement so the new model is created without the removed values rather than silently leaving stale remote configuration.
+  * Imported remote parameters are adopted when `additional_litellm_params` remains omitted. Set the map explicitly, including `{}` to clear all imported parameters, when Terraform should take ownership of that imported parameter set. The first explicit configuration records that ownership in state even when its values already match the imported values.
 
   **Special parameter: `additional_drop_params`**
   * When `additional_drop_params` is provided as a JSON array string, it specifies parameters to remove from the final `litellm_params` before sending to the API

--- a/internal/provider/resource_model.go
+++ b/internal/provider/resource_model.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -19,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -37,39 +39,40 @@ type ModelResource struct {
 
 // ModelResourceModel describes the resource data model.
 type ModelResourceModel struct {
-	ID                             types.String  `tfsdk:"id"`
-	ModelName                      types.String  `tfsdk:"model_name"`
-	CustomLLMProvider              types.String  `tfsdk:"custom_llm_provider"`
-	TPM                            types.Int64   `tfsdk:"tpm"`
-	RPM                            types.Int64   `tfsdk:"rpm"`
-	ReasoningEffort                types.String  `tfsdk:"reasoning_effort"`
-	ThinkingEnabled                types.Bool    `tfsdk:"thinking_enabled"`
-	ThinkingBudgetTokens           types.Int64   `tfsdk:"thinking_budget_tokens"`
-	MergeReasoningContentInChoices types.Bool    `tfsdk:"merge_reasoning_content_in_choices"`
-	ModelAPIKey                    types.String  `tfsdk:"model_api_key"`
-	ModelAPIBase                   types.String  `tfsdk:"model_api_base"`
-	APIVersion                     types.String  `tfsdk:"api_version"`
-	BaseModel                      types.String  `tfsdk:"base_model"`
-	Tier                           types.String  `tfsdk:"tier"`
-	TeamID                         types.String  `tfsdk:"team_id"`
-	Mode                           types.String  `tfsdk:"mode"`
-	LiteLLMCredentialName          types.String  `tfsdk:"litellm_credential_name"`
-	InputCostPerMillionTokens      types.Float64 `tfsdk:"input_cost_per_million_tokens"`
-	OutputCostPerMillionTokens     types.Float64 `tfsdk:"output_cost_per_million_tokens"`
-	InputCostPerPixel              types.Float64 `tfsdk:"input_cost_per_pixel"`
-	OutputCostPerPixel             types.Float64 `tfsdk:"output_cost_per_pixel"`
-	InputCostPerSecond             types.Float64 `tfsdk:"input_cost_per_second"`
-	OutputCostPerSecond            types.Float64 `tfsdk:"output_cost_per_second"`
-	AWSAccessKeyID                 types.String  `tfsdk:"aws_access_key_id"`
-	AWSSecretAccessKey             types.String  `tfsdk:"aws_secret_access_key"`
-	AWSRegionName                  types.String  `tfsdk:"aws_region_name"`
-	AWSSessionName                 types.String  `tfsdk:"aws_session_name"`
-	AWSRoleName                    types.String  `tfsdk:"aws_role_name"`
-	VertexProject                  types.String  `tfsdk:"vertex_project"`
-	VertexLocation                 types.String  `tfsdk:"vertex_location"`
-	VertexCredentials              types.String  `tfsdk:"vertex_credentials"`
-	AccessGroups                   types.List    `tfsdk:"access_groups"`
-	AdditionalLiteLLMParams        types.Map     `tfsdk:"additional_litellm_params"`
+	ID                                types.String  `tfsdk:"id"`
+	ModelName                         types.String  `tfsdk:"model_name"`
+	CustomLLMProvider                 types.String  `tfsdk:"custom_llm_provider"`
+	TPM                               types.Int64   `tfsdk:"tpm"`
+	RPM                               types.Int64   `tfsdk:"rpm"`
+	ReasoningEffort                   types.String  `tfsdk:"reasoning_effort"`
+	ThinkingEnabled                   types.Bool    `tfsdk:"thinking_enabled"`
+	ThinkingBudgetTokens              types.Int64   `tfsdk:"thinking_budget_tokens"`
+	MergeReasoningContentInChoices    types.Bool    `tfsdk:"merge_reasoning_content_in_choices"`
+	ModelAPIKey                       types.String  `tfsdk:"model_api_key"`
+	ModelAPIBase                      types.String  `tfsdk:"model_api_base"`
+	APIVersion                        types.String  `tfsdk:"api_version"`
+	BaseModel                         types.String  `tfsdk:"base_model"`
+	Tier                              types.String  `tfsdk:"tier"`
+	TeamID                            types.String  `tfsdk:"team_id"`
+	Mode                              types.String  `tfsdk:"mode"`
+	LiteLLMCredentialName             types.String  `tfsdk:"litellm_credential_name"`
+	InputCostPerMillionTokens         types.Float64 `tfsdk:"input_cost_per_million_tokens"`
+	OutputCostPerMillionTokens        types.Float64 `tfsdk:"output_cost_per_million_tokens"`
+	InputCostPerPixel                 types.Float64 `tfsdk:"input_cost_per_pixel"`
+	OutputCostPerPixel                types.Float64 `tfsdk:"output_cost_per_pixel"`
+	InputCostPerSecond                types.Float64 `tfsdk:"input_cost_per_second"`
+	OutputCostPerSecond               types.Float64 `tfsdk:"output_cost_per_second"`
+	AWSAccessKeyID                    types.String  `tfsdk:"aws_access_key_id"`
+	AWSSecretAccessKey                types.String  `tfsdk:"aws_secret_access_key"`
+	AWSRegionName                     types.String  `tfsdk:"aws_region_name"`
+	AWSSessionName                    types.String  `tfsdk:"aws_session_name"`
+	AWSRoleName                       types.String  `tfsdk:"aws_role_name"`
+	VertexProject                     types.String  `tfsdk:"vertex_project"`
+	VertexLocation                    types.String  `tfsdk:"vertex_location"`
+	VertexCredentials                 types.String  `tfsdk:"vertex_credentials"`
+	AccessGroups                      types.List    `tfsdk:"access_groups"`
+	AdditionalLiteLLMParams           types.Map     `tfsdk:"additional_litellm_params"`
+	AdditionalLiteLLMParamsConfigured types.Bool    `tfsdk:"additional_litellm_params_configured"`
 }
 
 func (r *ModelResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -231,10 +234,23 @@ func (r *ModelResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 				ElementType: types.StringType,
 			},
 			"additional_litellm_params": schema.MapAttribute{
-				Description: "Additional parameters to pass to litellm_params.",
+				Description: "Additional parameters to pass to litellm_params. Removing configured keys replaces the model so LiteLLM cannot silently retain them.",
 				Optional:    true,
 				Computed:    true,
 				ElementType: types.StringType,
+				Validators: []validator.Map{
+					mapvalidator.NoNullValues(),
+				},
+				PlanModifiers: []planmodifier.Map{
+					modelAdditionalParamsRemovalModifier{},
+				},
+			},
+			"additional_litellm_params_configured": schema.BoolAttribute{
+				Description: "Internal state marker indicating whether additional_litellm_params is explicitly managed by configuration.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.Bool{
+					modelAdditionalParamsOwnershipModifier{},
+				},
 			},
 		},
 	}
@@ -264,6 +280,16 @@ func (r *ModelResource) Create(ctx context.Context, req resource.CreateRequest, 
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	var configuredAdditionalParams types.Map
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("additional_litellm_params"), &configuredAdditionalParams)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if !configuredAdditionalParams.IsNull() && !configuredAdditionalParams.IsUnknown() {
+		data.AdditionalLiteLLMParams = configuredAdditionalParams
+	}
+	data.AdditionalLiteLLMParamsConfigured = types.BoolValue(!configuredAdditionalParams.IsNull() && !configuredAdditionalParams.IsUnknown())
 
 	// Normalise numeric strings in additional_litellm_params so that the
 	// planned value uses the same canonical form as the read-back value.
@@ -295,6 +321,13 @@ func (r *ModelResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		return
 	}
 
+	priorAdditionalParams := data.AdditionalLiteLLMParams
+	importedMarker, privateDiags := req.Private.GetKey(ctx, modelImportedPrivateKey)
+	resp.Diagnostics.Append(privateDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	err := r.readModelWithRetry(ctx, &data, 8)
 	if err != nil {
 		if IsNotFoundError(err) {
@@ -303,6 +336,14 @@ func (r *ModelResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		}
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read model: %s", err))
 		return
+	}
+
+	if data.AdditionalLiteLLMParamsConfigured.IsNull() || data.AdditionalLiteLLMParamsConfigured.IsUnknown() {
+		configured := len(inferLegacyConfiguredAdditionalParamKeys(priorAdditionalParams)) > 0
+		if string(importedMarker) == "true" {
+			configured = false
+		}
+		data.AdditionalLiteLLMParamsConfigured = types.BoolValue(configured)
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -315,6 +356,13 @@ func (r *ModelResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	var configuredAdditionalParams types.Map
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("additional_litellm_params"), &configuredAdditionalParams)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	data.AdditionalLiteLLMParamsConfigured = types.BoolValue(!configuredAdditionalParams.IsNull() && !configuredAdditionalParams.IsUnknown())
 
 	// Normalise numeric strings in additional_litellm_params so that the
 	// planned value uses the same canonical form as the read-back value.
@@ -360,6 +408,7 @@ func (r *ModelResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 
 func (r *ModelResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, modelImportedPrivateKey, []byte("true"))...)
 }
 
 func (r *ModelResource) createOrUpdateModel(ctx context.Context, data *ModelResourceModel, modelID string, isUpdate bool) error {

--- a/internal/provider/resource_model_plan_modifier.go
+++ b/internal/provider/resource_model_plan_modifier.go
@@ -1,0 +1,162 @@
+package provider
+
+import (
+	"context"
+	"sort"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+const modelImportedPrivateKey = "model_imported_v1"
+
+// LiteLLM v1.98.0 injects this complete set into litellm_params for models
+// created without additional_litellm_params. Older provider state has no
+// configured-key metadata, so the full key/value signature identifies an
+// adopted API-computed map. Checking both the complete set and values avoids
+// misclassifying an explicitly configured non-default value by key name alone.
+var legacyComputedAdditionalParamDefaults = map[string]string{
+	"allow_client_keepalive_override":    "false",
+	"merge_reasoning_content_in_choices": "false",
+	"use_in_pass_through":                "false",
+	"use_litellm_proxy":                  "false",
+	"use_xai_oauth":                      "false",
+}
+
+type modelAdditionalParamsRemovalModifier struct{}
+
+var _ planmodifier.Map = modelAdditionalParamsRemovalModifier{}
+
+func (modelAdditionalParamsRemovalModifier) Description(context.Context) string {
+	return "Replaces the model when configured additional LiteLLM parameter keys are removed."
+}
+
+func (m modelAdditionalParamsRemovalModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (modelAdditionalParamsRemovalModifier) PlanModifyMap(ctx context.Context, req planmodifier.MapRequest, resp *planmodifier.MapResponse) {
+	if req.State.Raw.IsNull() || req.ConfigValue.IsUnknown() || req.StateValue.IsNull() || req.StateValue.IsUnknown() {
+		return
+	}
+
+	var configuredState types.Bool
+	resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("additional_litellm_params_configured"), &configuredState)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	configured := !configuredState.IsNull() && !configuredState.IsUnknown() && configuredState.ValueBool()
+	if configuredState.IsNull() || configuredState.IsUnknown() {
+		configured = len(inferLegacyConfiguredAdditionalParamKeys(req.StateValue)) > 0
+	}
+
+	resp.PlanValue, resp.RequiresReplace = planAdditionalParamRemoval(
+		req.ConfigValue,
+		req.StateValue,
+		req.PlanValue,
+		configured,
+	)
+}
+
+func planAdditionalParamRemoval(config, state, proposedPlan types.Map, configured bool) (types.Map, bool) {
+	if config.IsUnknown() || state.IsNull() || state.IsUnknown() {
+		return proposedPlan, false
+	}
+
+	// Optional+Computed maps retain prior state when their configuration is
+	// removed. Override that proposed value only when state records that the
+	// map was explicitly configured. Imported and API-computed-only maps remain
+	// adopted when omitted.
+	if config.IsNull() {
+		if !configured {
+			return state, false
+		}
+		// Leave the replacement result unknown so Create adopts API-computed
+		// values exactly like an ordinary resource created with this argument
+		// omitted. The remote model is still recreated without configured keys.
+		return types.MapUnknown(types.StringType), true
+	}
+
+	// Once the map is explicitly configured, it describes the complete desired
+	// set. Any state key omitted from it is a removal and must replace the model;
+	// LiteLLM's update endpoints cannot reliably delete every parameter class.
+	configKeys := mapKeys(config)
+	for key := range state.Elements() {
+		if _, present := configKeys[key]; !present {
+			return proposedPlan, true
+		}
+	}
+
+	return proposedPlan, false
+}
+
+func configuredAdditionalParamKeys(value types.Map) []string {
+	if value.IsNull() || value.IsUnknown() {
+		return []string{}
+	}
+
+	keys := make([]string, 0, len(value.Elements()))
+	for key := range value.Elements() {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func inferLegacyConfiguredAdditionalParamKeys(value types.Map) []string {
+	elements := value.Elements()
+	matchesComputedSignature := len(elements) >= len(legacyComputedAdditionalParamDefaults)
+	for key, want := range legacyComputedAdditionalParamDefaults {
+		raw, present := elements[key]
+		stringValue, isString := raw.(types.String)
+		if !present || !isString || stringValue.IsNull() || stringValue.IsUnknown() || stringValue.ValueString() != want {
+			matchesComputedSignature = false
+			break
+		}
+	}
+	if matchesComputedSignature {
+		return []string{}
+	}
+	return configuredAdditionalParamKeys(value)
+}
+
+func mapKeys(value types.Map) map[string]struct{} {
+	keys := make(map[string]struct{}, len(value.Elements()))
+	for key := range value.Elements() {
+		keys[key] = struct{}{}
+	}
+	return keys
+}
+
+type modelAdditionalParamsOwnershipModifier struct{}
+
+var _ planmodifier.Bool = modelAdditionalParamsOwnershipModifier{}
+
+func (modelAdditionalParamsOwnershipModifier) Description(context.Context) string {
+	return "Records whether additional_litellm_params is explicitly configured."
+}
+
+func (m modelAdditionalParamsOwnershipModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (modelAdditionalParamsOwnershipModifier) PlanModifyBool(ctx context.Context, req planmodifier.BoolRequest, resp *planmodifier.BoolResponse) {
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+
+	var configuredMap types.Map
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("additional_litellm_params"), &configuredMap)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.PlanValue = planAdditionalParamsOwnership(configuredMap)
+}
+
+func planAdditionalParamsOwnership(config types.Map) types.Bool {
+	if config.IsUnknown() {
+		return types.BoolUnknown()
+	}
+	return types.BoolValue(!config.IsNull())
+}

--- a/internal/provider/resource_model_plan_modifier_test.go
+++ b/internal/provider/resource_model_plan_modifier_test.go
@@ -1,0 +1,273 @@
+package provider
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	resourceschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestPlanAdditionalParamRemoval(t *testing.T) {
+	t.Parallel()
+
+	state := testStringMap(map[string]string{
+		"cache_control_injection_points": `[{"location":"system"}]`,
+		"timeout":                        "60",
+	})
+	empty := testStringMap(map[string]string{})
+
+	tests := []struct {
+		name        string
+		config      types.Map
+		state       types.Map
+		proposed    types.Map
+		configured  bool
+		wantPlan    types.Map
+		wantReplace bool
+	}{
+		{
+			name:        "omitted configured map becomes empty replacement",
+			config:      types.MapNull(types.StringType),
+			state:       state,
+			proposed:    state,
+			configured:  true,
+			wantPlan:    types.MapUnknown(types.StringType),
+			wantReplace: true,
+		},
+		{
+			name:        "omitted computed map remains adopted",
+			config:      types.MapNull(types.StringType),
+			state:       state,
+			proposed:    types.MapUnknown(types.StringType),
+			configured:  false,
+			wantPlan:    state,
+			wantReplace: false,
+		},
+		{
+			name:        "adopted identical map has no key removal",
+			config:      state,
+			state:       state,
+			proposed:    state,
+			configured:  false,
+			wantPlan:    state,
+			wantReplace: false,
+		},
+		{
+			name:        "explicit empty map replaces imported values",
+			config:      empty,
+			state:       state,
+			proposed:    empty,
+			configured:  false,
+			wantPlan:    empty,
+			wantReplace: true,
+		},
+		{
+			name:   "individual key removal requires replacement",
+			config: testStringMap(map[string]string{"timeout": "60"}),
+			state:  state,
+			proposed: testStringMap(map[string]string{
+				"timeout": "60",
+			}),
+			configured:  true,
+			wantPlan:    testStringMap(map[string]string{"timeout": "60"}),
+			wantReplace: true,
+		},
+		{
+			name:   "value change remains in place",
+			config: testStringMap(map[string]string{"timeout": "120", "cache_control_injection_points": `[{"location":"system"}]`}),
+			state:  state,
+			proposed: testStringMap(map[string]string{
+				"timeout":                        "120",
+				"cache_control_injection_points": `[{"location":"system"}]`,
+			}),
+			configured: true,
+			wantPlan: testStringMap(map[string]string{
+				"timeout":                        "120",
+				"cache_control_injection_points": `[{"location":"system"}]`,
+			}),
+			wantReplace: false,
+		},
+		{
+			name:   "addition remains in place",
+			config: testStringMap(map[string]string{"timeout": "60", "tags": `["test"]`, "cache_control_injection_points": `[{"location":"system"}]`}),
+			state:  state,
+			proposed: testStringMap(map[string]string{
+				"timeout":                        "60",
+				"tags":                           `["test"]`,
+				"cache_control_injection_points": `[{"location":"system"}]`,
+			}),
+			configured: true,
+			wantPlan: testStringMap(map[string]string{
+				"timeout":                        "60",
+				"tags":                           `["test"]`,
+				"cache_control_injection_points": `[{"location":"system"}]`,
+			}),
+			wantReplace: false,
+		},
+		{
+			name:        "unknown configuration is preserved",
+			config:      types.MapUnknown(types.StringType),
+			state:       state,
+			proposed:    types.MapUnknown(types.StringType),
+			configured:  true,
+			wantPlan:    types.MapUnknown(types.StringType),
+			wantReplace: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			gotPlan, gotReplace := planAdditionalParamRemoval(test.config, test.state, test.proposed, test.configured)
+			if !gotPlan.Equal(test.wantPlan) {
+				t.Errorf("plan = %#v, want %#v", gotPlan, test.wantPlan)
+			}
+			if gotReplace != test.wantReplace {
+				t.Errorf("requires replacement = %v, want %v", gotReplace, test.wantReplace)
+			}
+		})
+	}
+}
+
+func TestInferLegacyConfiguredAdditionalParamKeys(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		state map[string]string
+		want  []string
+	}{
+		{
+			name: "complete API default signature is adopted",
+			state: map[string]string{
+				"allow_client_keepalive_override":    "false",
+				"cache_control_injection_points":     `[{"location":"system"}]`,
+				"merge_reasoning_content_in_choices": "false",
+				"timeout":                            "60",
+				"use_in_pass_through":                "false",
+				"use_litellm_proxy":                  "false",
+				"use_xai_oauth":                      "false",
+			},
+			want: []string{},
+		},
+		{
+			name: "incomplete default signature remains configured",
+			state: map[string]string{
+				"allow_client_keepalive_override":    "false",
+				"cache_control_injection_points":     `[{"location":"system"}]`,
+				"merge_reasoning_content_in_choices": "false",
+				"use_in_pass_through":                "false",
+				"use_litellm_proxy":                  "false",
+			},
+			want: []string{"allow_client_keepalive_override", "cache_control_injection_points", "merge_reasoning_content_in_choices", "use_in_pass_through", "use_litellm_proxy"},
+		},
+		{
+			name: "non-default value remains configured",
+			state: map[string]string{
+				"allow_client_keepalive_override":    "false",
+				"merge_reasoning_content_in_choices": "false",
+				"use_in_pass_through":                "false",
+				"use_litellm_proxy":                  "true",
+				"use_xai_oauth":                      "false",
+			},
+			want: []string{"allow_client_keepalive_override", "merge_reasoning_content_in_choices", "use_in_pass_through", "use_litellm_proxy", "use_xai_oauth"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got := inferLegacyConfiguredAdditionalParamKeys(testStringMap(test.state))
+			if !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("inferred configured keys = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestPlanAdditionalParamsOwnership(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		config types.Map
+		want   types.Bool
+	}{
+		{"omitted", types.MapNull(types.StringType), types.BoolValue(false)},
+		{"explicit empty", testStringMap(map[string]string{}), types.BoolValue(true)},
+		{"explicit values", testStringMap(map[string]string{"timeout": "60"}), types.BoolValue(true)},
+		{"unknown", types.MapUnknown(types.StringType), types.BoolUnknown()},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if got := planAdditionalParamsOwnership(test.config); !got.Equal(test.want) {
+				t.Fatalf("ownership plan = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestConfiguredAdditionalParamKeysSorted(t *testing.T) {
+	t.Parallel()
+
+	got := configuredAdditionalParamKeys(testStringMap(map[string]string{
+		"z": "1",
+		"a": "2",
+		"m": "3",
+	}))
+	want := []string{"a", "m", "z"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("configured keys = %v, want %v", got, want)
+	}
+}
+
+func TestModelAdditionalParamsRejectNullValues(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	var schemaResp resource.SchemaResponse
+	(&ModelResource{}).Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("schema diagnostics: %v", schemaResp.Diagnostics)
+	}
+	attribute, ok := schemaResp.Schema.Attributes["additional_litellm_params"].(resourceschema.MapAttribute)
+	if !ok {
+		t.Fatal("additional_litellm_params is not a map attribute")
+	}
+
+	tests := []struct {
+		name      string
+		value     attr.Value
+		wantError bool
+	}{
+		{"null element", types.StringNull(), true},
+		{"unknown element", types.StringUnknown(), false},
+		{"known element", types.StringValue("60"), false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var validationResp validator.MapResponse
+			request := validator.MapRequest{ConfigValue: types.MapValueMust(types.StringType, map[string]attr.Value{"timeout": test.value})}
+			for _, mapValidator := range attribute.Validators {
+				mapValidator.ValidateMap(ctx, request, &validationResp)
+			}
+			if got := validationResp.Diagnostics.HasError(); got != test.wantError {
+				t.Fatalf("validation error = %v, want %v: %v", got, test.wantError, validationResp.Diagnostics)
+			}
+		})
+	}
+}
+
+func testStringMap(values map[string]string) types.Map {
+	elements := make(map[string]attr.Value, len(values))
+	for key, value := range values {
+		elements[key] = types.StringValue(value)
+	}
+	return types.MapValueMust(types.StringType, elements)
+}


### PR DESCRIPTION
### Summary

Closes #151. Removing the entire `additional_litellm_params` argument, clearing it, or deleting individual keys now plans replacement of `litellm_model`, guaranteeing the recreated LiteLLM model does not retain stale parameters through merge-style update behavior.

A computed ownership marker distinguishes explicitly configured maps from API-computed or imported values. Omitted imported/computed maps remain adopted, while explicitly configuring the map records ownership even when the values already match. Legacy migration recognizes LiteLLM v1.98.0's complete five-key false-valued default signature so minimal and imported existing models are not replaced during upgrade.

### Validation

Focused coverage exercises whole-map and individual-key removal, ownership transitions, adoption, explicit imported-map clearing, null rejection, additions, value changes, unknown values, and legacy-state inference. Live LiteLLM v1.98.0 tests confirmed replacement changes the model ID, removes arbitrary and declared test parameters remotely, re-adopts API defaults, converges cleanly, persists ownership for identical imported values, and handles legacy minimal, configured, and imported state correctly. `go vet ./...`, `go test ./...`, and the full 23-resource live lifecycle suite pass with zero drift or failures.

### Reviewer note

Replacement is deliberate rather than an in-place legacy update: LiteLLM v1.98.0 removes some arbitrary keys through its full endpoint but retains declared fields such as `timeout`, `max_retries`, and `tags`. Replacement is the only uniform behavior that cannot silently claim a failed deletion.

### Diff size

**Docs** — 2 files · `+4 / -1`

Documents replacement and import ownership semantics and records #151 under Unreleased.

**Implementation** — 2 files · `+245 / -34`

Adds removal and ownership plan modifiers, import handling, null validation, and legacy-state migration. Most deletions are mechanical struct-field realignment after adding the ownership state field.

**Tests** — 1 file · `+273 / -0`

Covers removal decisions, ownership/adoption boundaries, null and unknown values, and deterministic legacy-key inference.
