### PR TITLE
fix(model): wait for stable update reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`litellm_model`**: Preserve configured formatting for semantically equivalent JSON-valued `additional_litellm_params`, avoiding post-apply inconsistencies caused only by whitespace or key ordering. ([#126](https://github.com/ncecere/terraform-provider-litellm/issues/126)) — thanks @msabramo
 - **`litellm_model`**: Preserve configured `additional_litellm_params` values when LiteLLM masks direct secrets such as `azure_ad_token` or nested JSON secret values during read-back, while continuing to surface unmasked remote drift. ([#119](https://github.com/ncecere/terraform-provider-litellm/issues/119)) — thanks @msabramo
 - **`litellm_model`**: Plan model replacement when configured `additional_litellm_params` keys are removed or cleared, ensuring LiteLLM actually drops the remote values instead of silently retaining them through merge-style updates. Imported or API-computed parameters remain adopted while the argument is omitted. ([#151](https://github.com/ncecere/terraform-provider-litellm/issues/151))
+- **`litellm_model`**: Retry post-update reads until changed fields remain at their planned values across consecutive reads, preventing stale LiteLLM router-cache responses from causing inconsistent results after updates such as `base_model` changes. ([#148](https://github.com/ncecere/terraform-provider-litellm/issues/148))
 
 ## [2.0.1] - 2026-06-12
 

--- a/internal/provider/resource_model.go
+++ b/internal/provider/resource_model.go
@@ -375,6 +375,7 @@ func (r *ModelResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	}
 
 	data.ID = state.ID
+	plannedData := data
 
 	// Use PATCH endpoint for partial updates
 	if err := r.patchModel(ctx, &data); err != nil {
@@ -382,9 +383,9 @@ func (r *ModelResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		return
 	}
 
-	if err := r.readModel(ctx, &data); err != nil {
-		finalizeModelComputedDefaults(&data)
-		resp.Diagnostics.AddWarning("Read Error", fmt.Sprintf("Model updated but failed to read back: %s", err))
+	if err := r.readModelAfterUpdate(ctx, &data, plannedData, state, 8); err != nil {
+		resp.Diagnostics.AddError("Model Update Not Yet Consistent", fmt.Sprintf("LiteLLM accepted the model update but did not return the planned values before the consistency timeout: %s", err))
+		return
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -864,6 +865,91 @@ func (r *ModelResource) readModelWithRetry(ctx context.Context, data *ModelResou
 	}
 
 	return err
+}
+
+func (r *ModelResource) readModelAfterUpdate(ctx context.Context, data *ModelResourceModel, planned, prior ModelResourceModel, maxRetries int) error {
+	if maxRetries < 1 {
+		return fmt.Errorf("maxRetries must be at least 1")
+	}
+
+	delay := 250 * time.Millisecond
+	maxDelay := 2 * time.Second
+	var lastErr error
+	var staleFields []string
+	changedFields := changedModelFieldsNotConverged(planned, prior, prior)
+	consecutiveMatches := 0
+
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		candidate := planned
+		lastErr = r.readModel(ctx, &candidate)
+		if lastErr == nil {
+			staleFields = changedModelFieldsNotConverged(planned, prior, candidate)
+			if len(staleFields) == 0 {
+				consecutiveMatches++
+				// LiteLLM's router cache can briefly return the new value and then
+				// regress to the old value during reload. Require two consecutive
+				// matching reads before publishing post-update state.
+				if consecutiveMatches >= 2 {
+					*data = candidate
+					return nil
+				}
+			} else {
+				consecutiveMatches = 0
+			}
+		} else if !IsNotFoundError(lastErr) {
+			return lastErr
+		} else {
+			consecutiveMatches = 0
+		}
+
+		if attempt == maxRetries-1 {
+			break
+		}
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+		delay *= 2
+		if delay > maxDelay {
+			delay = maxDelay
+		}
+	}
+
+	if lastErr != nil {
+		return lastErr
+	}
+	if len(staleFields) == 0 {
+		staleFields = changedFields
+	}
+	return fmt.Errorf("fields did not remain at their planned values after %d reads: %s", maxRetries, strings.Join(staleFields, ", "))
+}
+
+func changedModelFieldsNotConverged(planned, prior, observed ModelResourceModel) []string {
+	plannedValue := reflect.ValueOf(planned)
+	priorValue := reflect.ValueOf(prior)
+	observedValue := reflect.ValueOf(observed)
+	modelType := plannedValue.Type()
+
+	var stale []string
+	for i := 0; i < plannedValue.NumField(); i++ {
+		plannedAttr, plannedOK := plannedValue.Field(i).Interface().(attr.Value)
+		priorAttr, priorOK := priorValue.Field(i).Interface().(attr.Value)
+		observedAttr, observedOK := observedValue.Field(i).Interface().(attr.Value)
+		if !plannedOK || !priorOK || !observedOK || plannedAttr.IsUnknown() || plannedAttr.Equal(priorAttr) {
+			continue
+		}
+		if !plannedAttr.Equal(observedAttr) {
+			name := modelType.Field(i).Tag.Get("tfsdk")
+			if name == "" {
+				name = modelType.Field(i).Name
+			}
+			stale = append(stale, name)
+		}
+	}
+	return stale
 }
 
 // patchModel uses the PATCH /model/{model_id}/update endpoint for partial updates

--- a/internal/provider/resource_model_update_consistency_test.go
+++ b/internal/provider/resource_model_update_consistency_test.go
@@ -1,0 +1,164 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestChangedModelFieldsNotConverged(t *testing.T) {
+	t.Parallel()
+
+	prior := consistencyTestModel("gpt-4o-mini", "free")
+	planned := consistencyTestModel("gpt-4o", "free")
+
+	tests := []struct {
+		name     string
+		observed ModelResourceModel
+		want     []string
+	}{
+		{
+			name:     "changed base model is stale",
+			observed: consistencyTestModel("gpt-4o-mini", "free"),
+			want:     []string{"base_model"},
+		},
+		{
+			name:     "changed base model converged",
+			observed: consistencyTestModel("gpt-4o", "free"),
+			want:     nil,
+		},
+		{
+			name:     "unchanged field is not part of post-update wait",
+			observed: consistencyTestModel("gpt-4o", "paid"),
+			want:     nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if got := changedModelFieldsNotConverged(planned, prior, test.observed); !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("stale fields = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestReadModelAfterUpdateRequiresStableValues(t *testing.T) {
+	t.Parallel()
+
+	var reads atomic.Int32
+	sequence := []string{"gpt-4o", "gpt-4o-mini", "gpt-4o", "gpt-4o"}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		index := int(reads.Add(1)) - 1
+		if index >= len(sequence) {
+			index = len(sequence) - 1
+		}
+		writeConsistencyModelResponse(w, sequence[index])
+	}))
+	defer server.Close()
+
+	resource := &ModelResource{client: &Client{APIBase: server.URL, APIKey: "test-key", HTTPClient: server.Client()}}
+	prior := consistencyTestModel("gpt-4o-mini", "free")
+	planned := consistencyTestModel("gpt-4o", "free")
+	data := planned
+
+	if err := resource.readModelAfterUpdate(context.Background(), &data, planned, prior, 5); err != nil {
+		t.Fatalf("readModelAfterUpdate returned error: %v", err)
+	}
+	if got := reads.Load(); got != 4 {
+		t.Fatalf("read count = %d, want 4", got)
+	}
+	if got := data.BaseModel.ValueString(); got != "gpt-4o" {
+		t.Fatalf("base_model = %q, want gpt-4o", got)
+	}
+}
+
+func TestReadModelAfterUpdateReportsPersistentStaleValues(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeConsistencyModelResponse(w, "gpt-4o-mini")
+	}))
+	defer server.Close()
+
+	resource := &ModelResource{client: &Client{APIBase: server.URL, APIKey: "test-key", HTTPClient: server.Client()}}
+	prior := consistencyTestModel("gpt-4o-mini", "free")
+	planned := consistencyTestModel("gpt-4o", "free")
+	data := planned
+
+	err := resource.readModelAfterUpdate(context.Background(), &data, planned, prior, 2)
+	if err == nil || !strings.Contains(err.Error(), "base_model") {
+		t.Fatalf("error = %v, want stale base_model diagnostic", err)
+	}
+}
+
+func TestReadModelAfterUpdateCancellation(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeConsistencyModelResponse(w, "gpt-4o-mini")
+	}))
+	defer server.Close()
+
+	resource := &ModelResource{client: &Client{APIBase: server.URL, APIKey: "test-key", HTTPClient: server.Client()}}
+	prior := consistencyTestModel("gpt-4o-mini", "free")
+	planned := consistencyTestModel("gpt-4o", "free")
+	data := planned
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	started := time.Now()
+	err := resource.readModelAfterUpdate(ctx, &data, planned, prior, 8)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+	if elapsed := time.Since(started); elapsed >= 200*time.Millisecond {
+		t.Fatalf("cancellation took %s, want less than 200ms", elapsed)
+	}
+}
+
+func consistencyTestModel(baseModel, tier string) ModelResourceModel {
+	return ModelResourceModel{
+		ID:                                types.StringValue("model-123"),
+		ModelName:                         types.StringValue("test-model"),
+		CustomLLMProvider:                 types.StringValue("openai"),
+		BaseModel:                         types.StringValue(baseModel),
+		Tier:                              types.StringValue(tier),
+		AccessGroups:                      types.ListUnknown(types.StringType),
+		AdditionalLiteLLMParams:           types.MapUnknown(types.StringType),
+		AdditionalLiteLLMParamsConfigured: types.BoolValue(false),
+	}
+}
+
+func writeConsistencyModelResponse(w http.ResponseWriter, baseModel string) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"data": []interface{}{
+			map[string]interface{}{
+				"model_name": "test-model",
+				"litellm_params": map[string]interface{}{
+					"custom_llm_provider": "openai",
+					"model":               "openai/" + baseModel,
+				},
+				"model_info": map[string]interface{}{
+					"base_model": baseModel,
+					"tier":       "free",
+				},
+			},
+		},
+	})
+}


### PR DESCRIPTION
### Summary

Closes #148. `litellm_model` post-update reads now retry until fields changed by the plan remain at their planned values across two consecutive reads, preventing LiteLLM router-cache propagation from returning stale `base_model`, `tier`, or other changed values to Terraform.

The consistency wait is limited to Update and to known fields that actually changed. Ordinary Read remains authoritative for remote drift, and a value that never stabilizes returns an error instead of writing falsely converged state.

### Validation

Reproduced the reported v1.98.0 failure exactly: LiteLLM accepted `base_model = "gpt-4o"`, the immediate read returned `"gpt-4o-mini"`, Terraform failed, and the API showed the new value moments later. Live validation now confirms both `base_model` and `tier` update in place with stable IDs and immediate clean plans. Focused tests cover changed-field selection, a new→old→new→new cache sequence, persistent stale values, and context cancellation; `go vet ./...`, `go test ./...`, and the full 23-resource live lifecycle suite pass with zero drift or failures.

### Reviewer note

Two matching reads are intentional: live testing showed LiteLLM can briefly expose the new value and then regress to the old router-cache value before settling.

### Diff size

**Docs** — 1 file · `+1 / -0`

Records the fix in the Unreleased changelog.

**Implementation** — 1 file · `+89 / -3`

Adds changed-field comparison and bounded, context-cancellable stable-read retries to the Update path.

**Tests** — 1 file · `+164 / -0`

Covers convergence, cache regression, timeout diagnostics, cancellation, and unchanged-field boundaries.
