### PR TITLE
fix(model): preserve known collection state in plans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`litellm_model`**: Preserve configured `additional_litellm_params` values when LiteLLM masks direct secrets such as `azure_ad_token` or nested JSON secret values during read-back, while continuing to surface unmasked remote drift. ([#119](https://github.com/ncecere/terraform-provider-litellm/issues/119)) — thanks @msabramo
 - **`litellm_model`**: Plan model replacement when configured `additional_litellm_params` keys are removed or cleared, ensuring LiteLLM actually drops the remote values instead of silently retaining them through merge-style updates. Imported or API-computed parameters remain adopted while the argument is omitted. ([#151](https://github.com/ncecere/terraform-provider-litellm/issues/151))
 - **`litellm_model`**: Retry post-update reads until changed fields remain at their planned values across consecutive reads, preventing stale LiteLLM router-cache responses from causing inconsistent results after updates such as `base_model` changes. ([#148](https://github.com/ncecere/terraform-provider-litellm/issues/148))
+- **`litellm_model`**: Preserve known `access_groups` state during unrelated updates so plans no longer show spurious `(known after apply)` noise. `additional_litellm_params` receives the same stable-plan behavior through its removal-aware ownership modifier. ([#139](https://github.com/ncecere/terraform-provider-litellm/issues/139)) — thanks @runixer
 
 ## [2.0.1] - 2026-06-12
 

--- a/internal/provider/resource_model.go
+++ b/internal/provider/resource_model.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -232,6 +233,9 @@ func (r *ModelResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 				Optional:    true,
 				Computed:    true,
 				ElementType: types.StringType,
+				PlanModifiers: []planmodifier.List{
+					listplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"additional_litellm_params": schema.MapAttribute{
 				Description: "Additional parameters to pass to litellm_params. Removing configured keys replaces the model so LiteLLM cannot silently retain them.",

--- a/internal/provider/resource_model_plan_modifier_test.go
+++ b/internal/provider/resource_model_plan_modifier_test.go
@@ -227,6 +227,39 @@ func TestConfiguredAdditionalParamKeysSorted(t *testing.T) {
 	}
 }
 
+func TestModelComputedCollectionPlanModifiers(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	var schemaResp resource.SchemaResponse
+	(&ModelResource{}).Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("schema diagnostics: %v", schemaResp.Diagnostics)
+	}
+
+	accessGroups, ok := schemaResp.Schema.Attributes["access_groups"].(resourceschema.ListAttribute)
+	if !ok {
+		t.Fatal("access_groups is not a list attribute")
+	}
+	if len(accessGroups.PlanModifiers) != 1 {
+		t.Fatalf("access_groups plan modifiers = %d, want 1", len(accessGroups.PlanModifiers))
+	}
+	if got := accessGroups.PlanModifiers[0].Description(ctx); got != "Once set, the value of this attribute in state will not change." {
+		t.Fatalf("unexpected access_groups plan modifier: %q", got)
+	}
+
+	additionalParams, ok := schemaResp.Schema.Attributes["additional_litellm_params"].(resourceschema.MapAttribute)
+	if !ok {
+		t.Fatal("additional_litellm_params is not a map attribute")
+	}
+	if len(additionalParams.PlanModifiers) != 1 {
+		t.Fatalf("additional_litellm_params plan modifiers = %d, want only the removal-aware modifier", len(additionalParams.PlanModifiers))
+	}
+	if got := additionalParams.PlanModifiers[0].Description(ctx); got != "Replaces the model when configured additional LiteLLM parameter keys are removed." {
+		t.Fatalf("unexpected additional_litellm_params plan modifier: %q", got)
+	}
+}
+
 func TestModelAdditionalParamsRejectNullValues(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
### Summary

Closes #139. `litellm_model.access_groups` now carries known state through unrelated update plans instead of displaying `(known after apply)` noise.

This integrates @runixer's PR #142 with the current #151 removal semantics. The contributor's `UseStateForUnknown` modifier is retained for `access_groups`; `additional_litellm_params` continues using its newer removal-aware ownership modifier, which already preserves adopted state and must be allowed to produce an intentional unknown replacement plan when configured keys are removed.

### Validation

A live LiteLLM v1.98.0 update plan now displays only the changed `base_model`, with neither collection shown as `(known after apply)`; apply preserves the model ID and the following plan is clean. Schema regression coverage locks in exactly one list state modifier and one removal-aware map modifier. `go vet ./...`, `go test ./...`, and the full 23-resource live lifecycle suite pass with zero drift or failures.

### Diff size

**Docs** — 1 file · `+1 / -0`

Records the fix and contributor attribution in the Unreleased changelog.

**Implementation** — 1 file · `+4 / -0`

Adds the contributor's state-preserving list plan modifier for `access_groups`.

**Tests** — 1 file · `+33 / -0`

Verifies both collection attributes retain the intended non-conflicting modifier configuration.
