### PR TITLE
fix(model): refresh configured costs from LiteLLM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`litellm_model`**: Plan model replacement when configured `additional_litellm_params` keys are removed or cleared, ensuring LiteLLM actually drops the remote values instead of silently retaining them through merge-style updates. Imported or API-computed parameters remain adopted while the argument is omitted. ([#151](https://github.com/ncecere/terraform-provider-litellm/issues/151))
 - **`litellm_model`**: Retry post-update reads until changed fields remain at their planned values across consecutive reads, preventing stale LiteLLM router-cache responses from causing inconsistent results after updates such as `base_model` changes. ([#148](https://github.com/ncecere/terraform-provider-litellm/issues/148))
 - **`litellm_model`**: Preserve known `access_groups` state during unrelated updates so plans no longer show spurious `(known after apply)` noise. `additional_litellm_params` receives the same stable-plan behavior through its removal-aware ownership modifier. ([#139](https://github.com/ncecere/terraform-provider-litellm/issues/139)) — thanks @runixer
+- **`litellm_model`**: Read configured per-token, per-pixel, and per-second costs back from LiteLLM so out-of-band billing changes become visible in Terraform plans, while scaling per-token values and tolerating floating-point round-trip noise. ([#138](https://github.com/ncecere/terraform-provider-litellm/issues/138)) — thanks @runixer
 
 ## [2.0.1] - 2026-06-12
 

--- a/internal/provider/resource_model.go
+++ b/internal/provider/resource_model.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"reflect"
 	"strconv"
 	"strings"
@@ -308,11 +309,14 @@ func (r *ModelResource) Create(ctx context.Context, req resource.CreateRequest, 
 
 	data.ID = types.StringValue(modelID)
 
+	planned := data
+
 	// Read back to ensure consistency
 	if err := r.readModelWithRetry(ctx, &data, 8); err != nil {
 		finalizeModelComputedDefaults(&data)
 		resp.Diagnostics.AddWarning("Read Error", fmt.Sprintf("Model created but failed to read back: %s", err))
 	}
+	reassertPlannedCosts(&data, &planned)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -387,10 +391,13 @@ func (r *ModelResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		return
 	}
 
+	planned := data
+
 	if err := r.readModelAfterUpdate(ctx, &data, plannedData, state, 8); err != nil {
 		resp.Diagnostics.AddError("Model Update Not Yet Consistent", fmt.Sprintf("LiteLLM accepted the model update but did not return the planned values before the consistency timeout: %s", err))
 		return
 	}
+	reassertPlannedCosts(&data, &planned)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -631,6 +638,17 @@ func (r *ModelResource) readModel(ctx context.Context, data *ModelResourceModel)
 		if credName, ok := litellmParams["litellm_credential_name"].(string); ok && credName != "" {
 			data.LiteLLMCredentialName = types.StringValue(credName)
 		}
+		// Read back cost attributes. The API stores costs per token while the
+		// resource exposes them per million tokens, so scale on the way back.
+		// Like tpm/rpm above, only update when the attribute is set in the
+		// config (!IsNull) — costs inferred by LiteLLM from its model cost map
+		// must not create drift for users who never configured them.
+		data.InputCostPerMillionTokens = readBackCost(data.InputCostPerMillionTokens, litellmParams["input_cost_per_token"], 1000000.0)
+		data.OutputCostPerMillionTokens = readBackCost(data.OutputCostPerMillionTokens, litellmParams["output_cost_per_token"], 1000000.0)
+		data.InputCostPerPixel = readBackCost(data.InputCostPerPixel, litellmParams["input_cost_per_pixel"], 1.0)
+		data.OutputCostPerPixel = readBackCost(data.OutputCostPerPixel, litellmParams["output_cost_per_pixel"], 1.0)
+		data.InputCostPerSecond = readBackCost(data.InputCostPerSecond, litellmParams["input_cost_per_second"], 1.0)
+		data.OutputCostPerSecond = readBackCost(data.OutputCostPerSecond, litellmParams["output_cost_per_second"], 1.0)
 		// NOTE: merge_reasoning_content_in_choices is intentionally NOT read into the
 		// top-level attribute here. It can be passed both as a top-level attribute and
 		// via additional_litellm_params. Since templates commonly use additional_litellm_params,
@@ -830,6 +848,59 @@ func (r *ModelResource) readModel(ctx context.Context, data *ModelResourceModel)
 	}
 
 	return nil
+}
+
+// reassertPlannedCosts restores the planned cost values after the post-apply
+// consistency read. LiteLLM's /model/info serves from an in-memory router
+// that can lag a just-issued write, so the read-back may still echo the old
+// cost. Cost attributes are not Computed — the post-apply state must equal
+// the planned value anyway — so trusting a possibly stale echo here only
+// produces "Provider produced inconsistent result after apply" errors.
+// Out-of-band changes are still detected during Refresh, where readModel
+// reads the settled value.
+func reassertPlannedCosts(data *ModelResourceModel, planned *ModelResourceModel) {
+	data.InputCostPerMillionTokens = planned.InputCostPerMillionTokens
+	data.OutputCostPerMillionTokens = planned.OutputCostPerMillionTokens
+	data.InputCostPerPixel = planned.InputCostPerPixel
+	data.OutputCostPerPixel = planned.OutputCostPerPixel
+	data.InputCostPerSecond = planned.InputCostPerSecond
+	data.OutputCostPerSecond = planned.OutputCostPerSecond
+}
+
+// readBackCost returns the refreshed value for a cost attribute from the raw
+// API value, scaled (per-token → per-million-tokens where applicable). The
+// state value is kept when:
+//   - the attribute is not set in state (null/unknown) — API-inferred costs
+//     must not surface as drift for users who never configured them;
+//   - the API value is missing or not numeric;
+//   - the scaled value matches the state within a small relative tolerance,
+//     so the per-token round-trip (x/1e6*1e6) doesn't churn the state.
+func readBackCost(current types.Float64, raw interface{}, scale float64) types.Float64 {
+	if current.IsNull() || current.IsUnknown() {
+		return current
+	}
+
+	var value float64
+	switch v := raw.(type) {
+	case float64:
+		value = v
+	case string:
+		parsed, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			return current
+		}
+		value = parsed
+	default:
+		return current
+	}
+
+	value *= scale
+	stateValue := current.ValueFloat64()
+	tolerance := 1e-9 * math.Max(math.Abs(stateValue), math.Abs(value))
+	if math.Abs(value-stateValue) <= tolerance {
+		return current
+	}
+	return types.Float64Value(value)
 }
 
 func finalizeModelComputedDefaults(data *ModelResourceModel) {

--- a/internal/provider/resource_model.go
+++ b/internal/provider/resource_model.go
@@ -391,13 +391,10 @@ func (r *ModelResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		return
 	}
 
-	planned := data
-
 	if err := r.readModelAfterUpdate(ctx, &data, plannedData, state, 8); err != nil {
 		resp.Diagnostics.AddError("Model Update Not Yet Consistent", fmt.Sprintf("LiteLLM accepted the model update but did not return the planned values before the consistency timeout: %s", err))
 		return
 	}
-	reassertPlannedCosts(&data, &planned)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -850,14 +847,11 @@ func (r *ModelResource) readModel(ctx context.Context, data *ModelResourceModel)
 	return nil
 }
 
-// reassertPlannedCosts restores the planned cost values after the post-apply
-// consistency read. LiteLLM's /model/info serves from an in-memory router
-// that can lag a just-issued write, so the read-back may still echo the old
-// cost. Cost attributes are not Computed — the post-apply state must equal
-// the planned value anyway — so trusting a possibly stale echo here only
-// produces "Provider produced inconsistent result after apply" errors.
-// Out-of-band changes are still detected during Refresh, where readModel
-// reads the settled value.
+// reassertPlannedCosts restores planned cost values after Create's read-back.
+// LiteLLM's router can lag a just-created database row, while Terraform
+// requires these non-Computed attributes to equal the creation plan. Update
+// uses readModelAfterUpdate instead and verifies changed costs stabilize before
+// publishing state. Ordinary Read remains authoritative for out-of-band drift.
 func reassertPlannedCosts(data *ModelResourceModel, planned *ModelResourceModel) {
 	data.InputCostPerMillionTokens = planned.InputCostPerMillionTokens
 	data.OutputCostPerMillionTokens = planned.OutputCostPerMillionTokens

--- a/internal/provider/resource_model_test.go
+++ b/internal/provider/resource_model_test.go
@@ -1310,3 +1310,249 @@ func TestReadModelImportReadsAllAdditionalParams(t *testing.T) {
 		t.Fatal("custom_flag missing after import")
 	}
 }
+
+func TestReadBackCost(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		current types.Float64
+		raw     interface{}
+		scale   float64
+		want    types.Float64
+	}{
+		{
+			name:    "null state stays null even when API returns a value",
+			current: types.Float64Null(),
+			raw:     2.5e-06,
+			scale:   1000000.0,
+			want:    types.Float64Null(),
+		},
+		{
+			name:    "changed API value updates state with scaling",
+			current: types.Float64Value(3.0),
+			raw:     2.5e-06,
+			scale:   1000000.0,
+			want:    types.Float64Value(2.5),
+		},
+		{
+			name:    "per-token round-trip within tolerance keeps state value",
+			current: types.Float64Value(3.0),
+			raw:     3.0 / 1000000.0,
+			scale:   1000000.0,
+			want:    types.Float64Value(3.0),
+		},
+		{
+			name:    "numeric string from API is parsed",
+			current: types.Float64Value(3.0),
+			raw:     "2.5e-06",
+			scale:   1000000.0,
+			want:    types.Float64Value(2.5),
+		},
+		{
+			name:    "missing API value keeps state",
+			current: types.Float64Value(3.0),
+			raw:     nil,
+			scale:   1000000.0,
+			want:    types.Float64Value(3.0),
+		},
+		{
+			name:    "non-numeric API value keeps state",
+			current: types.Float64Value(3.0),
+			raw:     "not-a-number",
+			scale:   1000000.0,
+			want:    types.Float64Value(3.0),
+		},
+		{
+			name:    "unscaled cost (per pixel) updates directly",
+			current: types.Float64Value(0.001),
+			raw:     0.002,
+			scale:   1.0,
+			want:    types.Float64Value(0.002),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := readBackCost(tc.current, tc.raw, tc.scale)
+			if !got.Equal(tc.want) {
+				t.Fatalf("readBackCost() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestReadModelReadsBackTokenCosts(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": []interface{}{
+				map[string]interface{}{
+					"model_name": "gpt-4o-mini",
+					"litellm_params": map[string]interface{}{
+						"custom_llm_provider":   "openai",
+						"model":                 "openai/gpt-4o-mini",
+						"input_cost_per_token":  2.5e-06,
+						"output_cost_per_token": 1e-05,
+						"input_cost_per_pixel":  0.002,
+					},
+					"model_info": map[string]interface{}{
+						"base_model": "gpt-4o-mini",
+					},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	r := &ModelResource{
+		client: &Client{
+			APIBase:    server.URL,
+			APIKey:     "test-key",
+			HTTPClient: server.Client(),
+		},
+	}
+
+	data := ModelResourceModel{
+		ID: types.StringValue("model-789"),
+		// Costs were changed out-of-band (e.g. via the UI); state has the old values.
+		InputCostPerMillionTokens:  types.Float64Value(3.0),
+		OutputCostPerMillionTokens: types.Float64Value(15.0),
+		// input_cost_per_pixel was never configured — the API-returned value
+		// must not surface, otherwise apply would report an inconsistent result.
+		InputCostPerPixel: types.Float64Null(),
+		AccessGroups:      types.ListUnknown(types.StringType),
+	}
+	data.AdditionalLiteLLMParams, _ = types.MapValue(types.StringType, map[string]attr.Value{})
+
+	if err := r.readModel(context.Background(), &data); err != nil {
+		t.Fatalf("readModel returned error: %v", err)
+	}
+
+	if got := data.InputCostPerMillionTokens.ValueFloat64(); got != 2.5 {
+		t.Fatalf("expected input_cost_per_million_tokens=2.5, got %v", got)
+	}
+	if got := data.OutputCostPerMillionTokens.ValueFloat64(); got != 10.0 {
+		t.Fatalf("expected output_cost_per_million_tokens=10, got %v", got)
+	}
+	if !data.InputCostPerPixel.IsNull() {
+		t.Fatalf("expected input_cost_per_pixel to stay null, got %v", data.InputCostPerPixel)
+	}
+}
+
+func TestReadModelCostRoundTripCausesNoDrift(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": []interface{}{
+				map[string]interface{}{
+					"model_name": "claude-sonnet",
+					"litellm_params": map[string]interface{}{
+						"custom_llm_provider": "anthropic",
+						"model":               "anthropic/claude-sonnet",
+						// Exactly what createOrUpdateModel sends for a configured 3.0.
+						"input_cost_per_token":  3.0 / 1000000.0,
+						"output_cost_per_token": 15.0 / 1000000.0,
+					},
+					"model_info": map[string]interface{}{
+						"base_model": "claude-sonnet",
+					},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	r := &ModelResource{
+		client: &Client{
+			APIBase:    server.URL,
+			APIKey:     "test-key",
+			HTTPClient: server.Client(),
+		},
+	}
+
+	inputCost := types.Float64Value(3.0)
+	outputCost := types.Float64Value(15.0)
+	data := ModelResourceModel{
+		ID:                         types.StringValue("model-round-trip"),
+		InputCostPerMillionTokens:  inputCost,
+		OutputCostPerMillionTokens: outputCost,
+		AccessGroups:               types.ListUnknown(types.StringType),
+	}
+	data.AdditionalLiteLLMParams, _ = types.MapValue(types.StringType, map[string]attr.Value{})
+
+	if err := r.readModel(context.Background(), &data); err != nil {
+		t.Fatalf("readModel returned error: %v", err)
+	}
+
+	// The read-back value must be bit-identical to the configured one so the
+	// framework does not report drift after the per-token round-trip.
+	if !data.InputCostPerMillionTokens.Equal(inputCost) {
+		t.Fatalf("input cost drifted after round-trip: %v", data.InputCostPerMillionTokens)
+	}
+	if !data.OutputCostPerMillionTokens.Equal(outputCost) {
+		t.Fatalf("output cost drifted after round-trip: %v", data.OutputCostPerMillionTokens)
+	}
+}
+
+func TestReassertPlannedCostsOverridesStaleReadBack(t *testing.T) {
+	t.Parallel()
+
+	// Simulate the post-apply consistency read hitting a stale router:
+	// the plan set output cost to 16, but /model/info still echoes 15.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": []interface{}{
+				map[string]interface{}{
+					"model_name": "gpt-4o-mini",
+					"litellm_params": map[string]interface{}{
+						"custom_llm_provider":   "openai",
+						"model":                 "openai/gpt-4o-mini",
+						"output_cost_per_token": 15.0 / 1000000.0, // stale
+					},
+					"model_info": map[string]interface{}{
+						"base_model": "gpt-4o-mini",
+					},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	r := &ModelResource{
+		client: &Client{
+			APIBase:    server.URL,
+			APIKey:     "test-key",
+			HTTPClient: server.Client(),
+		},
+	}
+
+	data := ModelResourceModel{
+		ID:                         types.StringValue("model-stale"),
+		OutputCostPerMillionTokens: types.Float64Value(16.0),
+		AccessGroups:               types.ListUnknown(types.StringType),
+	}
+	data.AdditionalLiteLLMParams, _ = types.MapValue(types.StringType, map[string]attr.Value{})
+
+	planned := data
+
+	if err := r.readModel(context.Background(), &data); err != nil {
+		t.Fatalf("readModel returned error: %v", err)
+	}
+
+	// Without reassertion the stale echo would clobber the planned value…
+	if got := data.OutputCostPerMillionTokens.ValueFloat64(); got != 15.0 {
+		t.Fatalf("precondition failed: expected stale read-back 15, got %v", got)
+	}
+
+	// …which is exactly what reassertPlannedCosts prevents in Create/Update.
+	reassertPlannedCosts(&data, &planned)
+	if got := data.OutputCostPerMillionTokens.ValueFloat64(); got != 16.0 {
+		t.Fatalf("expected planned cost 16 after reassert, got %v", got)
+	}
+}

--- a/internal/provider/resource_model_update_consistency_test.go
+++ b/internal/provider/resource_model_update_consistency_test.go
@@ -83,6 +83,38 @@ func TestReadModelAfterUpdateRequiresStableValues(t *testing.T) {
 	}
 }
 
+func TestReadModelAfterUpdateWaitsForStableCost(t *testing.T) {
+	t.Parallel()
+
+	var reads atomic.Int32
+	sequence := []float64{16, 15, 16, 16}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		index := int(reads.Add(1)) - 1
+		if index >= len(sequence) {
+			index = len(sequence) - 1
+		}
+		writeConsistencyModelResponseWithCost(w, "gpt-4o-mini", sequence[index])
+	}))
+	defer server.Close()
+
+	resource := &ModelResource{client: &Client{APIBase: server.URL, APIKey: "test-key", HTTPClient: server.Client()}}
+	prior := consistencyTestModel("gpt-4o-mini", "free")
+	prior.OutputCostPerMillionTokens = types.Float64Value(15)
+	planned := prior
+	planned.OutputCostPerMillionTokens = types.Float64Value(16)
+	data := planned
+
+	if err := resource.readModelAfterUpdate(context.Background(), &data, planned, prior, 5); err != nil {
+		t.Fatalf("readModelAfterUpdate returned error: %v", err)
+	}
+	if got := reads.Load(); got != 4 {
+		t.Fatalf("read count = %d, want 4", got)
+	}
+	if got := data.OutputCostPerMillionTokens.ValueFloat64(); got != 16 {
+		t.Fatalf("output cost = %v, want 16", got)
+	}
+}
+
 func TestReadModelAfterUpdateReportsPersistentStaleValues(t *testing.T) {
 	t.Parallel()
 
@@ -145,15 +177,28 @@ func consistencyTestModel(baseModel, tier string) ModelResourceModel {
 }
 
 func writeConsistencyModelResponse(w http.ResponseWriter, baseModel string) {
+	writeConsistencyModelResponseBody(w, baseModel, nil)
+}
+
+func writeConsistencyModelResponseWithCost(w http.ResponseWriter, baseModel string, outputCostPerMillion float64) {
+	writeConsistencyModelResponseBody(w, baseModel, &outputCostPerMillion)
+}
+
+func writeConsistencyModelResponseBody(w http.ResponseWriter, baseModel string, outputCostPerMillion *float64) {
+	litellmParams := map[string]interface{}{
+		"custom_llm_provider": "openai",
+		"model":               "openai/" + baseModel,
+	}
+	if outputCostPerMillion != nil {
+		litellmParams["output_cost_per_token"] = *outputCostPerMillion / 1000000
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]interface{}{
 		"data": []interface{}{
 			map[string]interface{}{
-				"model_name": "test-model",
-				"litellm_params": map[string]interface{}{
-					"custom_llm_provider": "openai",
-					"model":               "openai/" + baseModel,
-				},
+				"model_name":     "test-model",
+				"litellm_params": litellmParams,
 				"model_info": map[string]interface{}{
 					"base_model": baseModel,
 					"tier":       "free",


### PR DESCRIPTION
### Summary

Closes #138. `litellm_model` now refreshes configured per-token, per-pixel, and per-second costs from LiteLLM, making out-of-band billing changes visible to Terraform instead of silently retaining stale state.

This integrates @runixer's PR #141 with the current #148 consistency design: token costs are scaled to the provider's per-million units, floating-point round-trip noise is tolerated, and API-inferred costs remain absent when users did not configure them. Update reads wait for changed costs to stabilize rather than blindly reasserting planned values; Create retains narrow planned-cost preservation for its initial router-lag read.

### Validation

Live LiteLLM v1.98.0 validation confirmed an in-place `15 -> 16` cost update with stable ID and clean plan, then an out-of-band API change to 99 appeared as `output_cost_per_million_tokens = 99 -> 16`. Focused coverage exercises all six cost fields, scaling, strings, nulls, tolerance, round trips, initial read-back, and a new→old→new→new Update sequence. `go vet ./...`, `go test ./...`, and the full 23-resource live lifecycle suite pass with zero drift or failures.

### Diff size

**Docs** — 1 file · `+1 / -0`

Records #138 and contributor attribution in the Unreleased changelog.

**Implementation** — 1 file · `+65 / -0`

Adds configured-only cost read-back, scaling/tolerance handling, and narrow Create consistency preservation.

**Tests** — 2 files · `+296 / -5`

Covers cost conversion/read-back, drift and null boundaries, and stable Update integration with #148.
