### PR TITLE
feat(model): support additional model info metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`litellm_model`**: Retry post-update reads until changed fields remain at their planned values across consecutive reads, preventing stale LiteLLM router-cache responses from causing inconsistent results after updates such as `base_model` changes. ([#148](https://github.com/ncecere/terraform-provider-litellm/issues/148))
 - **`litellm_model`**: Preserve known `access_groups` state during unrelated updates so plans no longer show spurious `(known after apply)` noise. `additional_litellm_params` receives the same stable-plan behavior through its removal-aware ownership modifier. ([#139](https://github.com/ncecere/terraform-provider-litellm/issues/139)) — thanks @runixer
 - **`litellm_model`**: Read configured per-token, per-pixel, and per-second costs back from LiteLLM so out-of-band billing changes become visible in Terraform plans, while scaling per-token values and tolerating floating-point round-trip noise. ([#138](https://github.com/ncecere/terraform-provider-litellm/issues/138)) — thanks @runixer
+- **`litellm_model`**: Add `additional_model_info` for managing capability flags and other custom `model_info` metadata without adopting LiteLLM cost-map-derived fields. ([#140](https://github.com/ncecere/terraform-provider-litellm/issues/140)) — thanks @runixer
 
 ## [2.0.1] - 2026-06-12
 

--- a/docs/resources/model.md
+++ b/docs/resources/model.md
@@ -266,6 +266,26 @@ The following arguments are supported:
   }
   ```
 
+* `additional_model_info` - (Optional) map(string). A map of arbitrary additional fields that will be merged into the `model_info` object sent to the LiteLLM API. The main use case is declaring capability flags (`supports_vision`, `supports_function_calling`, `supports_reasoning`, `supports_response_schema`, …) for models that are missing from LiteLLM's model cost map, so that `/model/info` and `/v1/models` advertise the model's capabilities to clients.
+
+  * Values follow the same string-to-native conversion rules as `additional_litellm_params` (booleans, integers, floats, JSON).
+  * Only keys configured here are managed. LiteLLM merges metadata derived from its model cost map (`max_tokens`, `supports_*`, `litellm_provider`, …) into `/model/info` responses; those derived fields are ignored on read so they never appear as drift, and they are not captured on import.
+  * **Limitation: keys cannot be deleted via update.** Same PATCH-merge behavior as `additional_litellm_params` — to fully remove a key, recreate the resource with `terraform apply -replace`.
+
+  ```hcl
+  resource "litellm_model" "kimi_k3" {
+    model_name          = "kimi-k3"
+    custom_llm_provider = "openrouter"
+    base_model          = "moonshotai/kimi-k3"
+    mode                = "chat"
+
+    additional_model_info = {
+      "supports_vision"           = "true"  # becomes boolean true
+      "supports_function_calling" = "true"
+    }
+  }
+  ```
+
 ### AWS-specific Configuration
 
 * `aws_access_key_id` - (Optional) string (Sensitive). AWS access key ID for AWS-based models.

--- a/docs/resources/model.md
+++ b/docs/resources/model.md
@@ -270,7 +270,10 @@ The following arguments are supported:
 
   * Values follow the same string-to-native conversion rules as `additional_litellm_params` (booleans, integers, floats, JSON).
   * Only keys configured here are managed. LiteLLM merges metadata derived from its model cost map (`max_tokens`, `supports_*`, `litellm_provider`, …) into `/model/info` responses; those derived fields are ignored on read so they never appear as drift, and they are not captured on import.
-  * **Limitation: keys cannot be deleted via update.** Same PATCH-merge behavior as `additional_litellm_params` — to fully remove a key, recreate the resource with `terraform apply -replace`.
+  * Adding keys or changing values uses an in-place model update.
+  * **Removing a key, clearing the map, or removing the argument replaces the model.** LiteLLM merges `model_info` during updates, so replacement ensures removed capability metadata is not silently retained.
+  * LiteLLM fields managed by dedicated resource arguments (`base_model`, `tier`, `mode`, `team_id`, `access_groups`, and internal identity fields) are rejected as reserved keys.
+  * Imported and cost-map-derived metadata is not adopted into this map. Set `additional_model_info` explicitly when Terraform should manage selected fields.
 
   ```hcl
   resource "litellm_model" "kimi_k3" {

--- a/docs/resources/model.md
+++ b/docs/resources/model.md
@@ -272,7 +272,7 @@ The following arguments are supported:
   * Only keys configured here are managed. LiteLLM merges metadata derived from its model cost map (`max_tokens`, `supports_*`, `litellm_provider`, …) into `/model/info` responses; those derived fields are ignored on read so they never appear as drift, and they are not captured on import.
   * Adding keys or changing values uses an in-place model update.
   * **Removing a key, clearing the map, or removing the argument replaces the model.** LiteLLM merges `model_info` during updates, so replacement ensures removed capability metadata is not silently retained.
-  * LiteLLM fields managed by dedicated resource arguments (`base_model`, `tier`, `mode`, `team_id`, `access_groups`, and internal identity fields) are rejected as reserved keys.
+  * LiteLLM fields managed by dedicated resource arguments (`base_model`, `tier`, `mode`, `team_id`, `access_groups`), internal identity fields, and system-managed audit fields are rejected as reserved keys.
   * Imported and cost-map-derived metadata is not adopted into this map. Set `additional_model_info` explicitly when Terraform should manage selected fields.
 
   ```hcl

--- a/internal/provider/resource_model.go
+++ b/internal/provider/resource_model.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -77,6 +76,7 @@ type ModelResourceModel struct {
 	AdditionalLiteLLMParams           types.Map     `tfsdk:"additional_litellm_params"`
 	AdditionalLiteLLMParamsConfigured types.Bool    `tfsdk:"additional_litellm_params_configured"`
 	AdditionalModelInfo               types.Map     `tfsdk:"additional_model_info"`
+	AdditionalModelInfoConfigured     types.Bool    `tfsdk:"additional_model_info_configured"`
 }
 
 func (r *ModelResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -268,8 +268,19 @@ func (r *ModelResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 				Optional:    true,
 				Computed:    true,
 				ElementType: types.StringType,
+				Validators: []validator.Map{
+					mapvalidator.NoNullValues(),
+					modelInfoReservedKeysValidator{},
+				},
 				PlanModifiers: []planmodifier.Map{
-					mapplanmodifier.UseStateForUnknown(),
+					modelAdditionalModelInfoRemovalModifier{},
+				},
+			},
+			"additional_model_info_configured": schema.BoolAttribute{
+				Description: "Internal state marker indicating whether additional_model_info is explicitly managed by configuration.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.Bool{
+					modelAdditionalModelInfoOwnershipModifier{},
 				},
 			},
 		},
@@ -311,6 +322,16 @@ func (r *ModelResource) Create(ctx context.Context, req resource.CreateRequest, 
 	}
 	data.AdditionalLiteLLMParamsConfigured = types.BoolValue(!configuredAdditionalParams.IsNull() && !configuredAdditionalParams.IsUnknown())
 
+	var configuredModelInfo types.Map
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("additional_model_info"), &configuredModelInfo)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if !configuredModelInfo.IsNull() && !configuredModelInfo.IsUnknown() {
+		data.AdditionalModelInfo = configuredModelInfo
+	}
+	data.AdditionalModelInfoConfigured = types.BoolValue(!configuredModelInfo.IsNull() && !configuredModelInfo.IsUnknown())
+
 	// Normalise numeric strings in string-map attributes so that planned values
 	// use the same canonical form as their API read-back values.
 	data.AdditionalLiteLLMParams = normalizeAdditionalParams(ctx, data.AdditionalLiteLLMParams)
@@ -346,6 +367,7 @@ func (r *ModelResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	}
 
 	priorAdditionalParams := data.AdditionalLiteLLMParams
+	priorModelInfo := data.AdditionalModelInfo
 	importedMarker, privateDiags := req.Private.GetKey(ctx, modelImportedPrivateKey)
 	resp.Diagnostics.Append(privateDiags...)
 	if resp.Diagnostics.HasError() {
@@ -369,6 +391,13 @@ func (r *ModelResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		}
 		data.AdditionalLiteLLMParamsConfigured = types.BoolValue(configured)
 	}
+	if data.AdditionalModelInfoConfigured.IsNull() || data.AdditionalModelInfoConfigured.IsUnknown() {
+		configured := len(configuredAdditionalParamKeys(priorModelInfo)) > 0
+		if string(importedMarker) == "true" {
+			configured = false
+		}
+		data.AdditionalModelInfoConfigured = types.BoolValue(configured)
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -387,6 +416,13 @@ func (r *ModelResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		return
 	}
 	data.AdditionalLiteLLMParamsConfigured = types.BoolValue(!configuredAdditionalParams.IsNull() && !configuredAdditionalParams.IsUnknown())
+
+	var configuredModelInfo types.Map
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("additional_model_info"), &configuredModelInfo)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	data.AdditionalModelInfoConfigured = types.BoolValue(!configuredModelInfo.IsNull() && !configuredModelInfo.IsUnknown())
 
 	// Normalise numeric strings in string-map attributes so that planned values
 	// use the same canonical form as their API read-back values.
@@ -865,16 +901,24 @@ func (r *ModelResource) readModel(ctx context.Context, data *ModelResourceModel)
 	// Read back additional_model_info. Only keys configured in state are
 	// consulted because /model/info also merges model cost-map metadata.
 	if !data.AdditionalModelInfo.IsNull() && !data.AdditionalModelInfo.IsUnknown() {
+		priorValues := data.AdditionalModelInfo.Elements()
 		infoValues := make(map[string]attr.Value)
 		if hasModelInfo {
-			for key := range data.AdditionalModelInfo.Elements() {
+			for key, priorValue := range priorValues {
 				rawValue, exists := modelInfo[key]
 				if !exists {
 					continue
 				}
-				if value, ok := stringifyAPIValue(rawValue); ok {
-					infoValues[key] = value
+				value, ok := stringifyAPIValue(rawValue)
+				if !ok {
+					continue
 				}
+				priorString, hasPriorString := priorValue.(types.String)
+				readString, hasReadString := value.(types.String)
+				if hasPriorString && hasReadString && jsonSemanticallyEqual(priorString.ValueString(), readString.ValueString()) {
+					value = priorValue
+				}
+				infoValues[key] = value
 			}
 		}
 		data.AdditionalModelInfo, _ = types.MapValue(types.StringType, infoValues)

--- a/internal/provider/resource_model.go
+++ b/internal/provider/resource_model.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -75,6 +76,7 @@ type ModelResourceModel struct {
 	AccessGroups                      types.List    `tfsdk:"access_groups"`
 	AdditionalLiteLLMParams           types.Map     `tfsdk:"additional_litellm_params"`
 	AdditionalLiteLLMParamsConfigured types.Bool    `tfsdk:"additional_litellm_params_configured"`
+	AdditionalModelInfo               types.Map     `tfsdk:"additional_model_info"`
 }
 
 func (r *ModelResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -257,6 +259,19 @@ func (r *ModelResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 					modelAdditionalParamsOwnershipModifier{},
 				},
 			},
+			"additional_model_info": schema.MapAttribute{
+				Description: "Additional fields to store in model_info, e.g. capability flags " +
+					"(supports_vision, supports_function_calling, supports_reasoning, …) for models " +
+					"missing from LiteLLM's model cost map. Values are strings and are converted to " +
+					"native JSON types (int, float, bool, JSON) for the API. Only keys configured " +
+					"here are managed; fields LiteLLM derives from its model cost map are left alone.",
+				Optional:    true,
+				Computed:    true,
+				ElementType: types.StringType,
+				PlanModifiers: []planmodifier.Map{
+					mapplanmodifier.UseStateForUnknown(),
+				},
+			},
 		},
 	}
 }
@@ -296,9 +311,10 @@ func (r *ModelResource) Create(ctx context.Context, req resource.CreateRequest, 
 	}
 	data.AdditionalLiteLLMParamsConfigured = types.BoolValue(!configuredAdditionalParams.IsNull() && !configuredAdditionalParams.IsUnknown())
 
-	// Normalise numeric strings in additional_litellm_params so that the
-	// planned value uses the same canonical form as the read-back value.
+	// Normalise numeric strings in string-map attributes so that planned values
+	// use the same canonical form as their API read-back values.
 	data.AdditionalLiteLLMParams = normalizeAdditionalParams(ctx, data.AdditionalLiteLLMParams)
+	data.AdditionalModelInfo = normalizeAdditionalParams(ctx, data.AdditionalModelInfo)
 
 	modelID := uuid.New().String()
 
@@ -372,9 +388,10 @@ func (r *ModelResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	}
 	data.AdditionalLiteLLMParamsConfigured = types.BoolValue(!configuredAdditionalParams.IsNull() && !configuredAdditionalParams.IsUnknown())
 
-	// Normalise numeric strings in additional_litellm_params so that the
-	// planned value uses the same canonical form as the read-back value.
+	// Normalise numeric strings in string-map attributes so that planned values
+	// use the same canonical form as their API read-back values.
 	data.AdditionalLiteLLMParams = normalizeAdditionalParams(ctx, data.AdditionalLiteLLMParams)
+	data.AdditionalModelInfo = normalizeAdditionalParams(ctx, data.AdditionalModelInfo)
 
 	var state ModelResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
@@ -551,6 +568,16 @@ func (r *ModelResource) createOrUpdateModel(ctx context.Context, data *ModelReso
 		data.AccessGroups.ElementsAs(ctx, &accessGroups, false)
 		if len(accessGroups) > 0 {
 			modelInfo["access_groups"] = accessGroups
+		}
+	}
+
+	// Add additional_model_info to the request. Like additional_litellm_params,
+	// values are strings in Terraform but converted to native types for the API.
+	if !data.AdditionalModelInfo.IsNull() && !data.AdditionalModelInfo.IsUnknown() {
+		elements := make(map[string]string)
+		data.AdditionalModelInfo.ElementsAs(ctx, &elements, false)
+		for key, value := range elements {
+			modelInfo[key] = convertStringValue(value)
 		}
 	}
 
@@ -835,6 +862,26 @@ func (r *ModelResource) readModel(ctx context.Context, data *ModelResourceModel)
 		data.AccessGroups, _ = types.ListValue(types.StringType, []attr.Value{})
 	}
 
+	// Read back additional_model_info. Only keys configured in state are
+	// consulted because /model/info also merges model cost-map metadata.
+	if !data.AdditionalModelInfo.IsNull() && !data.AdditionalModelInfo.IsUnknown() {
+		infoValues := make(map[string]attr.Value)
+		if hasModelInfo {
+			for key := range data.AdditionalModelInfo.Elements() {
+				rawValue, exists := modelInfo[key]
+				if !exists {
+					continue
+				}
+				if value, ok := stringifyAPIValue(rawValue); ok {
+					infoValues[key] = value
+				}
+			}
+		}
+		data.AdditionalModelInfo, _ = types.MapValue(types.StringType, infoValues)
+	} else {
+		data.AdditionalModelInfo, _ = types.MapValue(types.StringType, map[string]attr.Value{})
+	}
+
 	// Ensure mode is never Unknown after a Read. Terraform requires all
 	// Computed attributes to resolve to a known (or null) value after apply.
 	// Wildcard routes (e.g. openai/*) may not have a mode set in the API
@@ -897,6 +944,32 @@ func readBackCost(current types.Float64, raw interface{}, scale float64) types.F
 	return types.Float64Value(value)
 }
 
+// stringifyAPIValue converts a raw JSON value into the canonical string
+// representation used by string-map attributes.
+func stringifyAPIValue(rawValue interface{}) (attr.Value, bool) {
+	switch value := rawValue.(type) {
+	case string:
+		if number, err := strconv.ParseFloat(value, 64); err == nil {
+			return types.StringValue(strconv.FormatFloat(number, 'f', -1, 64)), true
+		}
+		return types.StringValue(value), true
+	case bool:
+		return types.StringValue(strconv.FormatBool(value)), true
+	case float64:
+		return types.StringValue(strconv.FormatFloat(value, 'f', -1, 64)), true
+	case int:
+		return types.StringValue(strconv.Itoa(value)), true
+	case int64:
+		return types.StringValue(strconv.FormatInt(value, 10)), true
+	default:
+		jsonValue, err := json.Marshal(value)
+		if err != nil {
+			return nil, false
+		}
+		return types.StringValue(string(jsonValue)), true
+	}
+}
+
 func finalizeModelComputedDefaults(data *ModelResourceModel) {
 	if data.Mode.IsUnknown() {
 		data.Mode = types.StringNull()
@@ -906,6 +979,9 @@ func finalizeModelComputedDefaults(data *ModelResourceModel) {
 	}
 	if data.AdditionalLiteLLMParams.IsUnknown() {
 		data.AdditionalLiteLLMParams, _ = types.MapValue(types.StringType, map[string]attr.Value{})
+	}
+	if data.AdditionalModelInfo.IsUnknown() {
+		data.AdditionalModelInfo, _ = types.MapValue(types.StringType, map[string]attr.Value{})
 	}
 }
 
@@ -1158,6 +1234,16 @@ func (r *ModelResource) patchModel(ctx context.Context, data *ModelResourceModel
 		data.AccessGroups.ElementsAs(ctx, &accessGroups, false)
 		if len(accessGroups) > 0 {
 			modelInfo["access_groups"] = accessGroups
+		}
+	}
+
+	// Add additional_model_info to the request. Like additional_litellm_params,
+	// values are strings in Terraform but converted to native types for the API.
+	if !data.AdditionalModelInfo.IsNull() && !data.AdditionalModelInfo.IsUnknown() {
+		elements := make(map[string]string)
+		data.AdditionalModelInfo.ElementsAs(ctx, &elements, false)
+		for key, value := range elements {
+			modelInfo[key] = convertStringValue(value)
 		}
 	}
 

--- a/internal/provider/resource_model_info_validator.go
+++ b/internal/provider/resource_model_info_validator.go
@@ -9,12 +9,16 @@ import (
 var reservedAdditionalModelInfoKeys = []string{
 	"access_groups",
 	"base_model",
+	"created_at",
+	"created_by",
 	"db_model",
 	"id",
 	"mode",
 	"team_id",
 	"team_public_model_name",
 	"tier",
+	"updated_at",
+	"updated_by",
 }
 
 type modelInfoReservedKeysValidator struct{}

--- a/internal/provider/resource_model_info_validator.go
+++ b/internal/provider/resource_model_info_validator.go
@@ -1,0 +1,47 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+var reservedAdditionalModelInfoKeys = []string{
+	"access_groups",
+	"base_model",
+	"db_model",
+	"id",
+	"mode",
+	"team_id",
+	"team_public_model_name",
+	"tier",
+}
+
+type modelInfoReservedKeysValidator struct{}
+
+var _ validator.Map = modelInfoReservedKeysValidator{}
+
+func (modelInfoReservedKeysValidator) Description(context.Context) string {
+	return "Keys managed by dedicated litellm_model attributes cannot be set in additional_model_info."
+}
+
+func (v modelInfoReservedKeysValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (modelInfoReservedKeysValidator) ValidateMap(ctx context.Context, req validator.MapRequest, resp *validator.MapResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	elements := req.ConfigValue.Elements()
+	for _, key := range reservedAdditionalModelInfoKeys {
+		if _, present := elements[key]; present {
+			resp.Diagnostics.AddAttributeError(
+				req.Path,
+				"Reserved Additional Model Information Key",
+				"additional_model_info cannot manage \""+key+"\" because the provider manages it through a dedicated litellm_model attribute.",
+			)
+		}
+	}
+}

--- a/internal/provider/resource_model_plan_modifier.go
+++ b/internal/provider/resource_model_plan_modifier.go
@@ -59,6 +59,41 @@ func (modelAdditionalParamsRemovalModifier) PlanModifyMap(ctx context.Context, r
 	)
 }
 
+type modelAdditionalModelInfoRemovalModifier struct{}
+
+var _ planmodifier.Map = modelAdditionalModelInfoRemovalModifier{}
+
+func (modelAdditionalModelInfoRemovalModifier) Description(context.Context) string {
+	return "Replaces the model when configured additional model information keys are removed."
+}
+
+func (m modelAdditionalModelInfoRemovalModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (modelAdditionalModelInfoRemovalModifier) PlanModifyMap(ctx context.Context, req planmodifier.MapRequest, resp *planmodifier.MapResponse) {
+	if req.State.Raw.IsNull() || req.ConfigValue.IsUnknown() || req.StateValue.IsNull() || req.StateValue.IsUnknown() {
+		return
+	}
+
+	var configuredState types.Bool
+	resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("additional_model_info_configured"), &configuredState)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	configured := !configuredState.IsNull() && !configuredState.IsUnknown() && configuredState.ValueBool()
+	if configuredState.IsNull() || configuredState.IsUnknown() {
+		configured = len(configuredAdditionalParamKeys(req.StateValue)) > 0
+	}
+
+	resp.PlanValue, resp.RequiresReplace = planAdditionalParamRemoval(
+		req.ConfigValue,
+		req.StateValue,
+		req.PlanValue,
+		configured,
+	)
+}
+
 func planAdditionalParamRemoval(config, state, proposedPlan types.Map, configured bool) (types.Map, bool) {
 	if config.IsUnknown() || state.IsNull() || state.IsUnknown() {
 		return proposedPlan, false
@@ -148,6 +183,31 @@ func (modelAdditionalParamsOwnershipModifier) PlanModifyBool(ctx context.Context
 
 	var configuredMap types.Map
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("additional_litellm_params"), &configuredMap)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.PlanValue = planAdditionalParamsOwnership(configuredMap)
+}
+
+type modelAdditionalModelInfoOwnershipModifier struct{}
+
+var _ planmodifier.Bool = modelAdditionalModelInfoOwnershipModifier{}
+
+func (modelAdditionalModelInfoOwnershipModifier) Description(context.Context) string {
+	return "Records whether additional_model_info is explicitly configured."
+}
+
+func (m modelAdditionalModelInfoOwnershipModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (modelAdditionalModelInfoOwnershipModifier) PlanModifyBool(ctx context.Context, req planmodifier.BoolRequest, resp *planmodifier.BoolResponse) {
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+
+	var configuredMap types.Map
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("additional_model_info"), &configuredMap)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/resource_model_plan_modifier_test.go
+++ b/internal/provider/resource_model_plan_modifier_test.go
@@ -329,7 +329,8 @@ func TestModelAdditionalInfoValidators(t *testing.T) {
 		wantError bool
 	}{
 		{"capability flag", map[string]attr.Value{"supports_vision": types.StringValue("true")}, false},
-		{"reserved key", map[string]attr.Value{"base_model": types.StringValue("other")}, true},
+		{"dedicated reserved key", map[string]attr.Value{"base_model": types.StringValue("other")}, true},
+		{"audit reserved key", map[string]attr.Value{"updated_by": types.StringValue("someone")}, true},
 		{"null value", map[string]attr.Value{"supports_vision": types.StringNull()}, true},
 	}
 	for _, test := range tests {

--- a/internal/provider/resource_model_plan_modifier_test.go
+++ b/internal/provider/resource_model_plan_modifier_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	resourceschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -258,6 +259,17 @@ func TestModelComputedCollectionPlanModifiers(t *testing.T) {
 	if got := additionalParams.PlanModifiers[0].Description(ctx); got != "Replaces the model when configured additional LiteLLM parameter keys are removed." {
 		t.Fatalf("unexpected additional_litellm_params plan modifier: %q", got)
 	}
+
+	additionalInfo, ok := schemaResp.Schema.Attributes["additional_model_info"].(resourceschema.MapAttribute)
+	if !ok {
+		t.Fatal("additional_model_info is not a map attribute")
+	}
+	if len(additionalInfo.PlanModifiers) != 1 {
+		t.Fatalf("additional_model_info plan modifiers = %d, want only the removal-aware modifier", len(additionalInfo.PlanModifiers))
+	}
+	if got := additionalInfo.PlanModifiers[0].Description(ctx); got != "Replaces the model when configured additional model information keys are removed." {
+		t.Fatalf("unexpected additional_model_info plan modifier: %q", got)
+	}
 }
 
 func TestModelAdditionalParamsRejectNullValues(t *testing.T) {
@@ -287,6 +299,46 @@ func TestModelAdditionalParamsRejectNullValues(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			var validationResp validator.MapResponse
 			request := validator.MapRequest{ConfigValue: types.MapValueMust(types.StringType, map[string]attr.Value{"timeout": test.value})}
+			for _, mapValidator := range attribute.Validators {
+				mapValidator.ValidateMap(ctx, request, &validationResp)
+			}
+			if got := validationResp.Diagnostics.HasError(); got != test.wantError {
+				t.Fatalf("validation error = %v, want %v: %v", got, test.wantError, validationResp.Diagnostics)
+			}
+		})
+	}
+}
+
+func TestModelAdditionalInfoValidators(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	var schemaResp resource.SchemaResponse
+	(&ModelResource{}).Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("schema diagnostics: %v", schemaResp.Diagnostics)
+	}
+	attribute, ok := schemaResp.Schema.Attributes["additional_model_info"].(resourceschema.MapAttribute)
+	if !ok {
+		t.Fatal("additional_model_info is not a map attribute")
+	}
+
+	tests := []struct {
+		name      string
+		values    map[string]attr.Value
+		wantError bool
+	}{
+		{"capability flag", map[string]attr.Value{"supports_vision": types.StringValue("true")}, false},
+		{"reserved key", map[string]attr.Value{"base_model": types.StringValue("other")}, true},
+		{"null value", map[string]attr.Value{"supports_vision": types.StringNull()}, true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var validationResp validator.MapResponse
+			request := validator.MapRequest{
+				Path:        path.Root("additional_model_info"),
+				ConfigValue: types.MapValueMust(types.StringType, test.values),
+			}
 			for _, mapValidator := range attribute.Validators {
 				mapValidator.ValidateMap(ctx, request, &validationResp)
 			}

--- a/internal/provider/resource_model_test.go
+++ b/internal/provider/resource_model_test.go
@@ -1684,8 +1684,9 @@ func TestReadModelExtractsAdditionalModelInfoOnlyForConfiguredKeys(t *testing.T)
 						"model":               "openrouter/moonshotai/kimi-k3",
 					},
 					"model_info": map[string]interface{}{
-						"base_model":      "moonshotai/kimi-k3",
-						"supports_vision": true,
+						"base_model":       "moonshotai/kimi-k3",
+						"supports_vision":  true,
+						"request_template": map[string]interface{}{"inputs": "{prompt}"},
 						// Metadata merged from LiteLLM's model cost map — the
 						// user never configured these and they must NOT be
 						// read into additional_model_info.
@@ -1709,7 +1710,8 @@ func TestReadModelExtractsAdditionalModelInfoOnlyForConfiguredKeys(t *testing.T)
 	}
 
 	priorInfo, _ := types.MapValue(types.StringType, map[string]attr.Value{
-		"supports_vision": types.StringValue("true"),
+		"supports_vision":  types.StringValue("true"),
+		"request_template": types.StringValue(`{ "inputs": "{prompt}" }`),
 	})
 
 	data := ModelResourceModel{
@@ -1731,7 +1733,10 @@ func TestReadModelExtractsAdditionalModelInfoOnlyForConfiguredKeys(t *testing.T)
 	if got := info["supports_vision"]; got != "true" {
 		t.Fatalf("expected supports_vision=true, got %q", got)
 	}
-	if len(info) != 1 {
+	if got := info["request_template"]; got != `{ "inputs": "{prompt}" }` {
+		t.Fatalf("expected semantically equal JSON formatting to be preserved, got %q", got)
+	}
+	if len(info) != 2 {
 		t.Fatalf("expected only configured keys to be read back, got %v", info)
 	}
 }

--- a/internal/provider/resource_model_test.go
+++ b/internal/provider/resource_model_test.go
@@ -1556,3 +1556,235 @@ func TestReassertPlannedCostsOverridesStaleReadBack(t *testing.T) {
 		t.Fatalf("expected planned cost 16 after reassert, got %v", got)
 	}
 }
+
+func TestCreateModelSendsAdditionalModelInfo(t *testing.T) {
+	t.Parallel()
+
+	var capturedBody map[string]interface{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" {
+			_ = json.NewDecoder(r.Body).Decode(&capturedBody)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok"})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	r := &ModelResource{
+		client: &Client{
+			APIBase:    server.URL,
+			APIKey:     "test-key",
+			HTTPClient: server.Client(),
+		},
+	}
+
+	additionalInfo, _ := types.MapValue(types.StringType, map[string]attr.Value{
+		"supports_vision":           types.StringValue("true"),
+		"supports_function_calling": types.StringValue("true"),
+		"max_input_tokens":          types.StringValue("128000"),
+	})
+
+	data := &ModelResourceModel{
+		ModelName:           types.StringValue("kimi-k3"),
+		CustomLLMProvider:   types.StringValue("openrouter"),
+		BaseModel:           types.StringValue("moonshotai/kimi-k3"),
+		AdditionalModelInfo: additionalInfo,
+	}
+
+	if err := r.createOrUpdateModel(context.Background(), data, "test-id", false); err != nil {
+		t.Fatalf("createOrUpdateModel returned error: %v", err)
+	}
+
+	modelInfo, ok := capturedBody["model_info"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("model_info missing in request body: %v", capturedBody)
+	}
+
+	if got := modelInfo["supports_vision"]; got != true {
+		t.Fatalf("expected supports_vision=true (bool), got %v (%T)", got, got)
+	}
+	if got := modelInfo["supports_function_calling"]; got != true {
+		t.Fatalf("expected supports_function_calling=true (bool), got %v (%T)", got, got)
+	}
+	// convertStringValue turns "128000" into an integer.
+	if got := modelInfo["max_input_tokens"]; got != float64(128000) {
+		t.Fatalf("expected max_input_tokens=128000, got %v (%T)", got, got)
+	}
+	// Fixed fields must still be present.
+	if got := modelInfo["base_model"]; got != "moonshotai/kimi-k3" {
+		t.Fatalf("expected base_model to be preserved, got %v", got)
+	}
+}
+
+func TestPatchModelSendsAdditionalModelInfo(t *testing.T) {
+	t.Parallel()
+
+	var capturedBody map[string]interface{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "PATCH" {
+			_ = json.NewDecoder(r.Body).Decode(&capturedBody)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok"})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	r := &ModelResource{
+		client: &Client{
+			APIBase:    server.URL,
+			APIKey:     "test-key",
+			HTTPClient: server.Client(),
+		},
+	}
+
+	additionalInfo, _ := types.MapValue(types.StringType, map[string]attr.Value{
+		"supports_reasoning": types.StringValue("true"),
+	})
+
+	data := &ModelResourceModel{
+		ID:                  types.StringValue("model-info-patch"),
+		ModelName:           types.StringValue("kimi-k3"),
+		CustomLLMProvider:   types.StringValue("openrouter"),
+		BaseModel:           types.StringValue("moonshotai/kimi-k3"),
+		AdditionalModelInfo: additionalInfo,
+	}
+
+	if err := r.patchModel(context.Background(), data); err != nil {
+		t.Fatalf("patchModel returned error: %v", err)
+	}
+
+	modelInfo, ok := capturedBody["model_info"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("model_info missing in request body: %v", capturedBody)
+	}
+	if got := modelInfo["supports_reasoning"]; got != true {
+		t.Fatalf("expected supports_reasoning=true (bool), got %v (%T)", got, got)
+	}
+}
+
+func TestReadModelExtractsAdditionalModelInfoOnlyForConfiguredKeys(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": []interface{}{
+				map[string]interface{}{
+					"model_name": "kimi-k3",
+					"litellm_params": map[string]interface{}{
+						"custom_llm_provider": "openrouter",
+						"model":               "openrouter/moonshotai/kimi-k3",
+					},
+					"model_info": map[string]interface{}{
+						"base_model":      "moonshotai/kimi-k3",
+						"supports_vision": true,
+						// Metadata merged from LiteLLM's model cost map — the
+						// user never configured these and they must NOT be
+						// read into additional_model_info.
+						"max_tokens":              8192.0,
+						"supports_prompt_caching": false,
+						"litellm_provider":        "openrouter",
+						"input_cost_per_token":    2.5e-07,
+					},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	r := &ModelResource{
+		client: &Client{
+			APIBase:    server.URL,
+			APIKey:     "test-key",
+			HTTPClient: server.Client(),
+		},
+	}
+
+	priorInfo, _ := types.MapValue(types.StringType, map[string]attr.Value{
+		"supports_vision": types.StringValue("true"),
+	})
+
+	data := ModelResourceModel{
+		ID:                      types.StringValue("model-info-read"),
+		AccessGroups:            types.ListUnknown(types.StringType),
+		AdditionalLiteLLMParams: types.MapUnknown(types.StringType),
+		AdditionalModelInfo:     priorInfo,
+	}
+
+	if err := r.readModel(context.Background(), &data); err != nil {
+		t.Fatalf("readModel returned error: %v", err)
+	}
+
+	info := map[string]string{}
+	if diags := data.AdditionalModelInfo.ElementsAs(context.Background(), &info, false); diags.HasError() {
+		t.Fatalf("failed to decode additional_model_info: %v", diags)
+	}
+
+	if got := info["supports_vision"]; got != "true" {
+		t.Fatalf("expected supports_vision=true, got %q", got)
+	}
+	if len(info) != 1 {
+		t.Fatalf("expected only configured keys to be read back, got %v", info)
+	}
+}
+
+func TestReadModelResolvesUnknownAdditionalModelInfo(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": []interface{}{
+				map[string]interface{}{
+					"model_name": "gpt-4o-mini",
+					"litellm_params": map[string]interface{}{
+						"custom_llm_provider": "openai",
+						"model":               "openai/gpt-4o-mini",
+					},
+					"model_info": map[string]interface{}{
+						"base_model": "gpt-4o-mini",
+						// Cost-map metadata that must not be captured.
+						"max_tokens":      16384.0,
+						"supports_vision": true,
+					},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	r := &ModelResource{
+		client: &Client{
+			APIBase:    server.URL,
+			APIKey:     "test-key",
+			HTTPClient: server.Client(),
+		},
+	}
+
+	// Simulate Create (or Import) where additional_model_info was not configured.
+	data := ModelResourceModel{
+		ID:                      types.StringValue("model-info-unknown"),
+		AccessGroups:            types.ListUnknown(types.StringType),
+		AdditionalLiteLLMParams: types.MapUnknown(types.StringType),
+		AdditionalModelInfo:     types.MapUnknown(types.StringType),
+	}
+
+	if err := r.readModel(context.Background(), &data); err != nil {
+		t.Fatalf("readModel returned error: %v", err)
+	}
+
+	if data.AdditionalModelInfo.IsUnknown() {
+		t.Fatal("additional_model_info must be known after read")
+	}
+	if got := len(data.AdditionalModelInfo.Elements()); got != 0 {
+		t.Fatalf("expected empty additional_model_info, got %d elements: %v", got, data.AdditionalModelInfo)
+	}
+}

--- a/internal/provider/resource_model_update_consistency_test.go
+++ b/internal/provider/resource_model_update_consistency_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -173,6 +174,8 @@ func consistencyTestModel(baseModel, tier string) ModelResourceModel {
 		AccessGroups:                      types.ListUnknown(types.StringType),
 		AdditionalLiteLLMParams:           types.MapUnknown(types.StringType),
 		AdditionalLiteLLMParamsConfigured: types.BoolValue(false),
+		AdditionalModelInfo:               types.MapValueMust(types.StringType, map[string]attr.Value{}),
+		AdditionalModelInfoConfigured:     types.BoolValue(false),
 	}
 }
 


### PR DESCRIPTION
### Summary

Closes #140. `litellm_model` now supports `additional_model_info`, allowing users to manage capability flags and arbitrary custom `model_info` metadata for models absent from LiteLLM's cost map.

This integrates @runixer's PR #143 with the current provider semantics. Values use the existing string-to-native conversion rules, only explicitly managed keys are refreshed, and cost-map-derived fields are ignored. Adding/changing metadata updates in place; removing a configured key, clearing the map, or removing the argument replaces the model because LiteLLM PATCH merges metadata. Imported omitted metadata remains unowned until explicitly configured. Dedicated fields and null map elements are rejected.

### Validation

Live LiteLLM v1.98.0 validation covered capability creation/API advertisement, in-place changes/additions, visible out-of-band drift, key and whole-map replacement/removal, import filtering, identical-value ownership, and subsequent removal. Unit coverage verifies payload conversion, configured-key filtering, JSON preservation, validation, modifier boundaries, and consistency integration. `go vet ./...`, `go test ./...`, and the full 23-resource live lifecycle suite pass with zero drift or failures.

### Diff size

**Docs** — 2 files · `+24 / -0`

Documents conversion, filtering, ownership/removal semantics, reserved fields, examples, and the Unreleased entry with contributor credit.

**Implementation** — 3 files · `+245 / -4`

Adds schema/state, API write/read conversion, reserved-key validation, ownership tracking, and removal-aware replacement.

**Tests** — 3 files · `+293 / -0`

Covers request payloads, selective read-back, formatting, validation, replacement planning, and stable Update state.
