### PR TITLE
fix(user): reconcile unordered team membership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`litellm_model`**: Preserve known `access_groups` state during unrelated updates so plans no longer show spurious `(known after apply)` noise. `additional_litellm_params` receives the same stable-plan behavior through its removal-aware ownership modifier. ([#139](https://github.com/ncecere/terraform-provider-litellm/issues/139)) — thanks @runixer
 - **`litellm_model`**: Read configured per-token, per-pixel, and per-second costs back from LiteLLM so out-of-band billing changes become visible in Terraform plans, while scaling per-token values and tolerating floating-point round-trip noise. ([#138](https://github.com/ncecere/terraform-provider-litellm/issues/138)) — thanks @runixer
 - **`litellm_model`**: Add `additional_model_info` for managing capability flags and other custom `model_info` metadata without adopting LiteLLM cost-map-derived fields. ([#140](https://github.com/ncecere/terraform-provider-litellm/issues/140)) — thanks @runixer
+- **`litellm_user`**: Treat `teams` as unordered membership during read-back and reconcile additions/removals through LiteLLM's dedicated team-member endpoints, preventing order-only inconsistent results while preserving real membership drift. ([#150](https://github.com/ncecere/terraform-provider-litellm/issues/150))
 
 ## [2.0.1] - 2026-06-12
 

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -48,7 +48,7 @@ The following arguments are supported:
 * `tpm_limit` - (Optional) Tokens per minute limit for the user.
 * `rpm_limit` - (Optional) Requests per minute limit for the user.
 * `auto_create_key` - (Optional) Whether to automatically create an API key when the user is created. Defaults to `true`.
-* `teams` - (Optional) List of team IDs the user belongs to.
+* `teams` - (Optional) Unique team IDs the user belongs to. Membership order is not significant. Updates reconcile additions and removals through LiteLLM's team-member endpoints.
 * `models` - (Optional) List of model names the user is allowed to use.
 * `metadata` - (Optional) A map of key-value metadata pairs for the user.
 

--- a/internal/provider/resource_user.go
+++ b/internal/provider/resource_user.go
@@ -544,12 +544,10 @@ func (r *UserResource) reconcileUserTeams(ctx context.Context, userID string, cu
 	sort.Strings(removals)
 	sort.Strings(additions)
 
-	for _, teamID := range removals {
-		request := map[string]interface{}{"team_id": teamID, "user_id": userID}
-		if err := r.client.DoRequestWithResponse(ctx, "POST", "/team/member_delete", request, nil); err != nil {
-			return fmt.Errorf("remove user from team %s: %w", teamID, err)
-		}
-	}
+	// Add destinations before removing old memberships. A failed destination
+	// must not revoke existing access or delete LiteLLM team-scoped keys. If a
+	// later removal fails, refresh exposes the temporary extra membership and a
+	// subsequent apply can safely retry the removal.
 	for _, teamID := range additions {
 		request := map[string]interface{}{
 			"team_id": teamID,
@@ -560,6 +558,12 @@ func (r *UserResource) reconcileUserTeams(ctx context.Context, userID string, cu
 		}
 		if err := r.client.DoRequestWithResponse(ctx, "POST", "/team/member_add", request, nil); err != nil {
 			return fmt.Errorf("add user to team %s: %w", teamID, err)
+		}
+	}
+	for _, teamID := range removals {
+		request := map[string]interface{}{"team_id": teamID, "user_id": userID}
+		if err := r.client.DoRequestWithResponse(ctx, "POST", "/team/member_delete", request, nil); err != nil {
+			return fmt.Errorf("remove user from team %s: %w", teamID, err)
 		}
 	}
 	return nil

--- a/internal/provider/resource_user.go
+++ b/internal/provider/resource_user.go
@@ -3,7 +3,10 @@ package provider
 import (
 	"context"
 	"fmt"
+	"sort"
+	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -91,10 +94,13 @@ func (r *UserResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 				},
 			},
 			"teams": schema.ListAttribute{
-				Description: "List of team IDs the user belongs to.",
+				Description: "List of team IDs the user belongs to. Membership order is not significant.",
 				Optional:    true,
 				Computed:    true,
 				ElementType: types.StringType,
+				Validators: []validator.List{
+					listvalidator.UniqueValues(),
+				},
 			},
 			"models": schema.ListAttribute{
 				Description: "Model names the user is allowed to call. Set to ['no-default-models'] to block all model access.",
@@ -235,14 +241,26 @@ func (r *UserResource) Update(ctx context.Context, req resource.UpdateRequest, r
 
 	userReq := r.buildUserRequest(ctx, &data)
 	userReq["user_id"] = data.UserID.ValueString()
+	// LiteLLM v1.98 accepts teams on /user/update but does not reconcile team
+	// membership there. Manage membership through the dedicated team endpoints.
+	delete(userReq, "teams")
 
 	if err := r.client.DoRequestWithResponse(ctx, "POST", "/user/update", userReq, nil); err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update user: %s", err))
 		return
 	}
 
-	// Read back for full state
-	if err := r.readUser(ctx, &data); err != nil {
+	teamsChanged := userTeamMembershipsDiffer(state.Teams, data.Teams)
+	if teamsChanged {
+		if err := r.reconcileUserTeams(ctx, data.UserID.ValueString(), state.Teams, data.Teams); err != nil {
+			resp.Diagnostics.AddError("Team Membership Error", fmt.Sprintf("Unable to update user team membership: %s", err))
+			return
+		}
+		if err := r.readUserTeamsAfterUpdate(ctx, &data, 8); err != nil {
+			resp.Diagnostics.AddError("User Team Update Not Yet Consistent", fmt.Sprintf("LiteLLM accepted the team membership update but did not return the planned membership before the consistency timeout: %s", err))
+			return
+		}
+	} else if err := r.readUser(ctx, &data); err != nil {
 		resp.Diagnostics.AddWarning("Read Error", fmt.Sprintf("User updated but failed to read back: %s", err))
 	}
 
@@ -388,18 +406,12 @@ func (r *UserResource) readUser(ctx context.Context, data *UserResourceModel) er
 		data.RPMLimit = types.Int64Value(int64(rpmLimit))
 	}
 
-	// Handle teams list - preserve null when API returns empty and config didn't specify teams
-	if teams, ok := userInfo["teams"].([]interface{}); ok && len(teams) > 0 {
-		teamsList := make([]attr.Value, len(teams))
-		for i, t := range teams {
-			if str, ok := t.(string); ok {
-				teamsList[i] = types.StringValue(str)
-			}
-		}
-		data.Teams, _ = types.ListValue(types.StringType, teamsList)
-	} else if !data.Teams.IsNull() {
-		// User specified teams in config but API returned empty — set to empty list
-		data.Teams, _ = types.ListValue(types.StringType, []attr.Value{})
+	// Team membership is unordered in LiteLLM. Preserve Terraform's current
+	// ordering when the API returns the same members in a different order; when
+	// membership truly changes, use a stable canonical order so drift remains
+	// visible without positional churn.
+	if teams, ok := userInfo["teams"].([]interface{}); ok {
+		data.Teams = reconcileUnorderedUserTeams(data.Teams, teams)
 	}
 
 	// Handle models list - preserve null when API returns empty and config didn't specify models
@@ -431,4 +443,170 @@ func (r *UserResource) readUser(ctx context.Context, data *UserResourceModel) er
 	}
 
 	return nil
+}
+
+func reconcileUnorderedUserTeams(current types.List, rawTeams []interface{}) types.List {
+	remoteTeams := make([]string, 0, len(rawTeams))
+	for _, rawTeam := range rawTeams {
+		if team, ok := rawTeam.(string); ok {
+			remoteTeams = append(remoteTeams, team)
+		}
+	}
+
+	if len(remoteTeams) == 0 {
+		if current.IsNull() {
+			return current
+		}
+		return types.ListValueMust(types.StringType, []attr.Value{})
+	}
+	if userTeamMembershipEqual(current, remoteTeams) {
+		return current
+	}
+
+	sort.Strings(remoteTeams)
+	values := make([]attr.Value, len(remoteTeams))
+	for i, team := range remoteTeams {
+		values[i] = types.StringValue(team)
+	}
+	return types.ListValueMust(types.StringType, values)
+}
+
+func userTeamMembershipEqual(current types.List, remoteTeams []string) bool {
+	if current.IsNull() || current.IsUnknown() || len(current.Elements()) != len(remoteTeams) {
+		return false
+	}
+
+	counts := make(map[string]int, len(remoteTeams))
+	for _, team := range remoteTeams {
+		counts[team]++
+	}
+	for _, element := range current.Elements() {
+		team, ok := element.(types.String)
+		if !ok || team.IsNull() || team.IsUnknown() || counts[team.ValueString()] == 0 {
+			return false
+		}
+		counts[team.ValueString()]--
+	}
+	return true
+}
+
+func userTeamIDs(value types.List) ([]string, bool) {
+	if value.IsNull() || value.IsUnknown() {
+		return nil, false
+	}
+	ids := make([]string, 0, len(value.Elements()))
+	for _, element := range value.Elements() {
+		team, ok := element.(types.String)
+		if !ok || team.IsNull() || team.IsUnknown() {
+			return nil, false
+		}
+		ids = append(ids, team.ValueString())
+	}
+	return ids, true
+}
+
+func userTeamMembershipsDiffer(current, planned types.List) bool {
+	plannedIDs, managed := userTeamIDs(planned)
+	if !managed {
+		return false
+	}
+	return !userTeamMembershipEqual(current, plannedIDs)
+}
+
+func (r *UserResource) reconcileUserTeams(ctx context.Context, userID string, current, planned types.List) error {
+	desiredIDs, managed := userTeamIDs(planned)
+	if !managed {
+		return nil
+	}
+	currentIDs, _ := userTeamIDs(current)
+
+	desired := make(map[string]struct{}, len(desiredIDs))
+	for _, teamID := range desiredIDs {
+		desired[teamID] = struct{}{}
+	}
+	existing := make(map[string]struct{}, len(currentIDs))
+	for _, teamID := range currentIDs {
+		existing[teamID] = struct{}{}
+	}
+
+	removals := make([]string, 0)
+	for teamID := range existing {
+		if _, keep := desired[teamID]; !keep {
+			removals = append(removals, teamID)
+		}
+	}
+	additions := make([]string, 0)
+	for teamID := range desired {
+		if _, present := existing[teamID]; !present {
+			additions = append(additions, teamID)
+		}
+	}
+	sort.Strings(removals)
+	sort.Strings(additions)
+
+	for _, teamID := range removals {
+		request := map[string]interface{}{"team_id": teamID, "user_id": userID}
+		if err := r.client.DoRequestWithResponse(ctx, "POST", "/team/member_delete", request, nil); err != nil {
+			return fmt.Errorf("remove user from team %s: %w", teamID, err)
+		}
+	}
+	for _, teamID := range additions {
+		request := map[string]interface{}{
+			"team_id": teamID,
+			"member": map[string]interface{}{
+				"role":    "user",
+				"user_id": userID,
+			},
+		}
+		if err := r.client.DoRequestWithResponse(ctx, "POST", "/team/member_add", request, nil); err != nil {
+			return fmt.Errorf("add user to team %s: %w", teamID, err)
+		}
+	}
+	return nil
+}
+
+func (r *UserResource) readUserTeamsAfterUpdate(ctx context.Context, data *UserResourceModel, maxRetries int) error {
+	if maxRetries < 1 {
+		return fmt.Errorf("maxRetries must be at least 1")
+	}
+
+	expected := data.Teams
+	delay := 250 * time.Millisecond
+	maxDelay := 2 * time.Second
+	consecutiveMatches := 0
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		candidate := *data
+		err := r.readUser(ctx, &candidate)
+		if err == nil {
+			if !userTeamMembershipsDiffer(candidate.Teams, expected) {
+				consecutiveMatches++
+				if consecutiveMatches >= 2 {
+					*data = candidate
+					return nil
+				}
+			} else {
+				consecutiveMatches = 0
+			}
+		} else if !IsNotFoundError(err) {
+			return err
+		} else {
+			consecutiveMatches = 0
+		}
+
+		if attempt == maxRetries-1 {
+			break
+		}
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+		delay *= 2
+		if delay > maxDelay {
+			delay = maxDelay
+		}
+	}
+	return fmt.Errorf("team membership did not remain at its planned value after %d reads", maxRetries)
 }

--- a/internal/provider/resource_user_test.go
+++ b/internal/provider/resource_user_test.go
@@ -353,12 +353,39 @@ func TestReconcileUserTeamsUsesDedicatedEndpoints(t *testing.T) {
 	if len(requests) != 2 {
 		t.Fatalf("request count = %d, want 2", len(requests))
 	}
-	if requests[0].path != "/team/member_delete" || requests[0].body["team_id"] != "team-b" || requests[0].body["user_id"] != "user-1" {
-		t.Fatalf("unexpected delete request: %#v", requests[0])
+	member, ok := requests[0].body["member"].(map[string]interface{})
+	if requests[0].path != "/team/member_add" || requests[0].body["team_id"] != "team-c" || !ok || member["user_id"] != "user-1" || member["role"] != "user" {
+		t.Fatalf("unexpected add request: %#v", requests[0])
 	}
-	member, ok := requests[1].body["member"].(map[string]interface{})
-	if requests[1].path != "/team/member_add" || requests[1].body["team_id"] != "team-c" || !ok || member["user_id"] != "user-1" || member["role"] != "user" {
-		t.Fatalf("unexpected add request: %#v", requests[1])
+	if requests[1].path != "/team/member_delete" || requests[1].body["team_id"] != "team-b" || requests[1].body["user_id"] != "user-1" {
+		t.Fatalf("unexpected delete request: %#v", requests[1])
+	}
+}
+
+func TestReconcileUserTeamsDoesNotRemoveWhenAdditionFails(t *testing.T) {
+	t.Parallel()
+
+	var paths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		paths = append(paths, request.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		if request.URL.Path == "/team/member_add" {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"detail":"destination team does not exist"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	resource := &UserResource{client: &Client{APIBase: server.URL, APIKey: "test-key", HTTPClient: server.Client()}}
+	current := types.ListValueMust(types.StringType, []attr.Value{types.StringValue("team-old")})
+	planned := types.ListValueMust(types.StringType, []attr.Value{types.StringValue("team-invalid")})
+	if err := resource.reconcileUserTeams(context.Background(), "user-1", current, planned); err == nil {
+		t.Fatal("reconcileUserTeams returned nil error for failed addition")
+	}
+	if len(paths) != 1 || paths[0] != "/team/member_add" {
+		t.Fatalf("requests after failed addition = %v, want only /team/member_add", paths)
 	}
 }
 

--- a/internal/provider/resource_user_test.go
+++ b/internal/provider/resource_user_test.go
@@ -5,9 +5,14 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	resourceschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -252,6 +257,188 @@ func TestNullMapPreservation(t *testing.T) {
 // Before the fix, readUser would unconditionally set teams to [] from the API
 // response even when the user didn't specify teams, causing:
 // "Provider produced inconsistent result after apply: .teams: was null, but now cty.ListValEmpty(cty.String)"
+func TestReconcileUnorderedUserTeams(t *testing.T) {
+	t.Parallel()
+
+	configured := types.ListValueMust(types.StringType, []attr.Value{
+		types.StringValue("team-b"),
+		types.StringValue("team-a"),
+	})
+
+	tests := []struct {
+		name    string
+		current types.List
+		remote  []interface{}
+		want    types.List
+	}{
+		{
+			name:    "reordered API membership preserves configured order",
+			current: configured,
+			remote:  []interface{}{"team-a", "team-b"},
+			want:    configured,
+		},
+		{
+			name:    "actual membership drift is sorted canonically",
+			current: configured,
+			remote:  []interface{}{"team-c", "team-a"},
+			want: types.ListValueMust(types.StringType, []attr.Value{
+				types.StringValue("team-a"),
+				types.StringValue("team-c"),
+			}),
+		},
+		{
+			name:    "unconfigured empty membership remains null",
+			current: types.ListNull(types.StringType),
+			remote:  []interface{}{},
+			want:    types.ListNull(types.StringType),
+		},
+		{
+			name:    "configured membership cleared remotely becomes empty",
+			current: configured,
+			remote:  []interface{}{},
+			want:    types.ListValueMust(types.StringType, []attr.Value{}),
+		},
+		{
+			name:    "unknown import state adopts canonical API order",
+			current: types.ListUnknown(types.StringType),
+			remote:  []interface{}{"team-b", "team-a"},
+			want: types.ListValueMust(types.StringType, []attr.Value{
+				types.StringValue("team-a"),
+				types.StringValue("team-b"),
+			}),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got := reconcileUnorderedUserTeams(test.current, test.remote)
+			if !got.Equal(test.want) {
+				t.Fatalf("teams = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestReconcileUserTeamsUsesDedicatedEndpoints(t *testing.T) {
+	t.Parallel()
+
+	type capturedRequest struct {
+		path string
+		body map[string]interface{}
+	}
+	var requests []capturedRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		var body map[string]interface{}
+		_ = json.NewDecoder(request.Body).Decode(&body)
+		requests = append(requests, capturedRequest{path: request.URL.Path, body: body})
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	resource := &UserResource{client: &Client{APIBase: server.URL, APIKey: "test-key", HTTPClient: server.Client()}}
+	current := types.ListValueMust(types.StringType, []attr.Value{
+		types.StringValue("team-b"),
+		types.StringValue("team-a"),
+	})
+	planned := types.ListValueMust(types.StringType, []attr.Value{
+		types.StringValue("team-c"),
+		types.StringValue("team-a"),
+	})
+
+	if err := resource.reconcileUserTeams(context.Background(), "user-1", current, planned); err != nil {
+		t.Fatalf("reconcileUserTeams returned error: %v", err)
+	}
+	if len(requests) != 2 {
+		t.Fatalf("request count = %d, want 2", len(requests))
+	}
+	if requests[0].path != "/team/member_delete" || requests[0].body["team_id"] != "team-b" || requests[0].body["user_id"] != "user-1" {
+		t.Fatalf("unexpected delete request: %#v", requests[0])
+	}
+	member, ok := requests[1].body["member"].(map[string]interface{})
+	if requests[1].path != "/team/member_add" || requests[1].body["team_id"] != "team-c" || !ok || member["user_id"] != "user-1" || member["role"] != "user" {
+		t.Fatalf("unexpected add request: %#v", requests[1])
+	}
+}
+
+func TestReadUserTeamsAfterUpdateRequiresStableMembership(t *testing.T) {
+	t.Parallel()
+
+	var reads atomic.Int32
+	sequence := [][]interface{}{
+		{"team-c", "team-a"},
+		{"team-b", "team-a"},
+		{"team-a", "team-c"},
+		{"team-c", "team-a"},
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		index := int(reads.Add(1)) - 1
+		if index >= len(sequence) {
+			index = len(sequence) - 1
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"user_info": map[string]interface{}{
+				"user_id": "user-1",
+				"teams":   sequence[index],
+			},
+		})
+	}))
+	defer server.Close()
+
+	resource := &UserResource{client: &Client{APIBase: server.URL, APIKey: "test-key", HTTPClient: server.Client()}}
+	data := UserResourceModel{
+		ID:     types.StringValue("user-1"),
+		UserID: types.StringValue("user-1"),
+		Teams: types.ListValueMust(types.StringType, []attr.Value{
+			types.StringValue("team-c"),
+			types.StringValue("team-a"),
+		}),
+	}
+
+	if err := resource.readUserTeamsAfterUpdate(context.Background(), &data, 5); err != nil {
+		t.Fatalf("readUserTeamsAfterUpdate returned error: %v", err)
+	}
+	if got := reads.Load(); got != 4 {
+		t.Fatalf("read count = %d, want 4", got)
+	}
+	want := types.ListValueMust(types.StringType, []attr.Value{
+		types.StringValue("team-c"),
+		types.StringValue("team-a"),
+	})
+	if !data.Teams.Equal(want) {
+		t.Fatalf("teams = %v, want planned order %v", data.Teams, want)
+	}
+}
+
+func TestUserTeamsRejectDuplicateMemberships(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	var schemaResp resource.SchemaResponse
+	(&UserResource{}).Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+	attribute, ok := schemaResp.Schema.Attributes["teams"].(resourceschema.ListAttribute)
+	if !ok {
+		t.Fatal("teams is not a list attribute")
+	}
+
+	var validationResp validator.ListResponse
+	request := validator.ListRequest{
+		Path: path.Root("teams"),
+		ConfigValue: types.ListValueMust(types.StringType, []attr.Value{
+			types.StringValue("team-a"),
+			types.StringValue("team-a"),
+		}),
+	}
+	for _, listValidator := range attribute.Validators {
+		listValidator.ValidateList(ctx, request, &validationResp)
+	}
+	if !validationResp.Diagnostics.HasError() {
+		t.Fatal("duplicate team membership did not produce a validation error")
+	}
+}
+
 func TestOldBehaviorWouldFail(t *testing.T) {
 	t.Run("OLD behavior: null teams overwritten to empty list (the bug)", func(t *testing.T) {
 		// Simulate old readUser behavior:


### PR DESCRIPTION
### Summary

Closes #150. `litellm_user.teams` now behaves as unordered membership while retaining the existing list schema for state compatibility.

Read-back preserves Terraform's configured ordering when LiteLLM returns the same members in a different order, while true remote membership changes are sorted deterministically and remain visible as drift. Updates now use LiteLLM's dedicated `/team/member_delete` and `/team/member_add` endpoints because v1.98.0 accepts but ignores `teams` on `/user/update`. Destinations are added before old memberships are removed so a failed add cannot revoke existing access or team-scoped keys. Changed membership must stabilize across two consecutive reads before state is published, and duplicate team IDs fail validation.

### Validation

Live LiteLLM v1.98.0 testing reproduced the original actual-membership failure, then verified reorder-only config updates, stable IDs, dedicated membership removal/addition, clean immediate plans, API delete/re-add ordering changes with zero Terraform drift, visible out-of-band membership drift, and successful restoration. Focused tests cover null/empty/import behavior, unordered equality, deterministic drift, endpoint payloads, safe add-failure ordering, duplicate validation, and new→old→new→new convergence. `go vet ./...`, full tests, race tests, and the 23-resource real-dev lifecycle suite pass with zero drift or failures.

### Diff size

**Docs** — 2 files · `+2 / -1`

Documents unordered membership/reconciliation and records #150 in the Unreleased changelog.

**Implementation** — 1 file · `+197 / -15`

Adds stable unordered reads, unique validation, dedicated endpoint reconciliation, and bounded post-update convergence.

**Tests** — 1 file · `+214 / -0`

Covers ordering, actual drift, request deltas, validation, and consistency sequences.
