### PR TITLE
fix(agent): make capability read-back authoritative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`litellm_model`**: Read configured per-token, per-pixel, and per-second costs back from LiteLLM so out-of-band billing changes become visible in Terraform plans, while scaling per-token values and tolerating floating-point round-trip noise. ([#138](https://github.com/ncecere/terraform-provider-litellm/issues/138)) — thanks @runixer
 - **`litellm_model`**: Add `additional_model_info` for managing capability flags and other custom `model_info` metadata without adopting LiteLLM cost-map-derived fields. ([#140](https://github.com/ncecere/terraform-provider-litellm/issues/140)) — thanks @runixer
 - **`litellm_user`**: Treat `teams` as unordered membership during read-back and reconcile additions/removals through LiteLLM's dedicated team-member endpoints, preventing order-only inconsistent results while preserving real membership drift. ([#150](https://github.com/ncecere/terraform-provider-litellm/issues/150))
+- **`litellm_agent`**: Make configured capability read-back authoritative when LiteLLM omits unsupported flags, wait for stable post-update values, and add the A2A `supports_authenticated_extended_card` field. ([#124](https://github.com/ncecere/terraform-provider-litellm/issues/124))
 
 ## [2.0.1] - 2026-06-12
 

--- a/docs/resources/agent.md
+++ b/docs/resources/agent.md
@@ -49,7 +49,8 @@ resource "litellm_agent" "full" {
 
     preferred_transport = "httpsse"
     icon_url            = "https://example.com/icon.png"
-    documentation_url   = "https://docs.example.com/code-reviewer"
+    documentation_url                   = "https://docs.example.com/code-reviewer"
+    supports_authenticated_extended_card = true
 
     capabilities {
       streaming                = true
@@ -113,12 +114,15 @@ resource "litellm_agent" "full" {
 * `preferred_transport` - (Optional) Preferred transport protocol (e.g. `httpsse`, `websocket`).
 * `icon_url` - (Optional) URL for the agent's icon.
 * `documentation_url` - (Optional) URL for the agent's documentation.
+* `supports_authenticated_extended_card` - (Optional) Whether the agent supports an authenticated extended A2A card.
 
 ### capabilities Block (Optional, inside agent_card)
 
 * `streaming` - (Optional) Whether the agent supports streaming responses.
 * `push_notifications` - (Optional) Whether the agent supports push notifications.
 * `state_transition_history` - (Optional) Whether the agent supports state transition history.
+
+Configured capability values are read authoritatively. If LiteLLM accepts a flag but omits it from read-back, the provider treats the effective value as `false` and reports the rejected update instead of retaining false clean state. Unconfigured fields remain unmanaged.
 
 ### provider Block (Optional, inside agent_card)
 

--- a/internal/provider/resource_agent.go
+++ b/internal/provider/resource_agent.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -57,19 +59,20 @@ type AgentObjectPermissionModel struct {
 }
 
 type AgentCardModel struct {
-	Name               types.String            `tfsdk:"name"`
-	Description        types.String            `tfsdk:"description"`
-	URL                types.String            `tfsdk:"url"`
-	Version            types.String            `tfsdk:"version"`
-	ProtocolVersion    types.String            `tfsdk:"protocol_version"`
-	DefaultInputModes  types.List              `tfsdk:"default_input_modes"`
-	DefaultOutputModes types.List              `tfsdk:"default_output_modes"`
-	Capabilities       *AgentCapabilitiesModel `tfsdk:"capabilities"`
-	Skills             []AgentSkillModel       `tfsdk:"skills"`
-	Provider           *AgentProviderModel     `tfsdk:"provider"`
-	PreferredTransport types.String            `tfsdk:"preferred_transport"`
-	IconURL            types.String            `tfsdk:"icon_url"`
-	DocumentationURL   types.String            `tfsdk:"documentation_url"`
+	Name                              types.String            `tfsdk:"name"`
+	Description                       types.String            `tfsdk:"description"`
+	URL                               types.String            `tfsdk:"url"`
+	Version                           types.String            `tfsdk:"version"`
+	ProtocolVersion                   types.String            `tfsdk:"protocol_version"`
+	DefaultInputModes                 types.List              `tfsdk:"default_input_modes"`
+	DefaultOutputModes                types.List              `tfsdk:"default_output_modes"`
+	Capabilities                      *AgentCapabilitiesModel `tfsdk:"capabilities"`
+	Skills                            []AgentSkillModel       `tfsdk:"skills"`
+	Provider                          *AgentProviderModel     `tfsdk:"provider"`
+	PreferredTransport                types.String            `tfsdk:"preferred_transport"`
+	IconURL                           types.String            `tfsdk:"icon_url"`
+	DocumentationURL                  types.String            `tfsdk:"documentation_url"`
+	SupportsAuthenticatedExtendedCard types.Bool              `tfsdk:"supports_authenticated_extended_card"`
 }
 
 type AgentResourceModel struct {
@@ -207,6 +210,10 @@ func (r *AgentResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 					},
 					"documentation_url": schema.StringAttribute{
 						Description: "URL for the agent's documentation.",
+						Optional:    true,
+					},
+					"supports_authenticated_extended_card": schema.BoolAttribute{
+						Description: "Whether the agent supports an authenticated extended A2A card.",
 						Optional:    true,
 					},
 				},
@@ -397,7 +404,13 @@ func (r *AgentResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		return
 	}
 
-	if err := r.readAgent(ctx, &data); err != nil {
+	changedCapabilities := changedAgentCapabilityFieldsNotConverged(data, state, state)
+	if len(changedCapabilities) > 0 {
+		if err := r.readAgentCapabilitiesAfterUpdate(ctx, &data, data, state, 8); err != nil {
+			resp.Diagnostics.AddError("Agent Capability Update Not Yet Consistent", fmt.Sprintf("LiteLLM accepted the agent update but did not return the planned capability values before the consistency timeout: %s", err))
+			return
+		}
+	} else if err := r.readAgent(ctx, &data); err != nil {
 		resp.Diagnostics.AddWarning("Read Error", fmt.Sprintf("Agent updated but failed to read back: %s", err))
 	}
 
@@ -452,6 +465,9 @@ func (r *AgentResource) buildAgentRequest(data *AgentResourceModel) map[string]i
 		}
 		if !data.AgentCard.DocumentationURL.IsNull() && !data.AgentCard.DocumentationURL.IsUnknown() {
 			card["documentationUrl"] = data.AgentCard.DocumentationURL.ValueString()
+		}
+		if !data.AgentCard.SupportsAuthenticatedExtendedCard.IsNull() && !data.AgentCard.SupportsAuthenticatedExtendedCard.IsUnknown() {
+			card["supportsAuthenticatedExtendedCard"] = data.AgentCard.SupportsAuthenticatedExtendedCard.ValueBool()
 		}
 		if !data.AgentCard.DefaultInputModes.IsNull() && !data.AgentCard.DefaultInputModes.IsUnknown() {
 			card["defaultInputModes"] = listToStringSlice(data.AgentCard.DefaultInputModes)
@@ -732,6 +748,14 @@ func (r *AgentResource) readAgentCard(cardRaw map[string]interface{}, data *Agen
 	if v, ok := cardRaw["documentationUrl"].(string); ok && v != "" && (populateAll || !card.DocumentationURL.IsNull()) {
 		card.DocumentationURL = types.StringValue(v)
 	}
+	if populateAll {
+		if value, ok := cardRaw["supportsAuthenticatedExtendedCard"].(bool); ok {
+			card.SupportsAuthenticatedExtendedCard = types.BoolValue(value)
+		}
+	} else if !card.SupportsAuthenticatedExtendedCard.IsNull() {
+		value, _ := cardRaw["supportsAuthenticatedExtendedCard"].(bool)
+		card.SupportsAuthenticatedExtendedCard = types.BoolValue(value)
+	}
 
 	// Default modes
 	if modes, ok := cardRaw["defaultInputModes"].([]interface{}); ok && len(modes) > 0 {
@@ -745,19 +769,25 @@ func (r *AgentResource) readAgentCard(cardRaw map[string]interface{}, data *Agen
 		card.DefaultOutputModes = types.ListNull(types.StringType)
 	}
 
-	// Capabilities
-	if capsRaw, ok := cardRaw["capabilities"].(map[string]interface{}); ok && (populateAll || card.Capabilities != nil) {
-		if card.Capabilities == nil {
-			card.Capabilities = &AgentCapabilitiesModel{}
+	// Capabilities are authoritative when the block/field is managed. LiteLLM
+	// may accept unsupported flags but omit them from subsequent reads; an
+	// omitted managed key therefore means false, not "preserve planned state".
+	capsRaw, hasCapabilities := cardRaw["capabilities"].(map[string]interface{})
+	if populateAll && hasCapabilities {
+		card.Capabilities = &AgentCapabilitiesModel{
+			Streaming:              types.BoolValue(agentCapabilityValue(capsRaw, "streaming")),
+			PushNotifications:      types.BoolValue(agentCapabilityValue(capsRaw, "pushNotifications")),
+			StateTransitionHistory: types.BoolValue(agentCapabilityValue(capsRaw, "stateTransitionHistory")),
 		}
-		if v, ok := capsRaw["streaming"].(bool); ok && (populateAll || !card.Capabilities.Streaming.IsNull()) {
-			card.Capabilities.Streaming = types.BoolValue(v)
+	} else if !populateAll && card.Capabilities != nil {
+		if !card.Capabilities.Streaming.IsNull() {
+			card.Capabilities.Streaming = types.BoolValue(agentCapabilityValue(capsRaw, "streaming"))
 		}
-		if v, ok := capsRaw["pushNotifications"].(bool); ok && (populateAll || !card.Capabilities.PushNotifications.IsNull()) {
-			card.Capabilities.PushNotifications = types.BoolValue(v)
+		if !card.Capabilities.PushNotifications.IsNull() {
+			card.Capabilities.PushNotifications = types.BoolValue(agentCapabilityValue(capsRaw, "pushNotifications"))
 		}
-		if v, ok := capsRaw["stateTransitionHistory"].(bool); ok && (populateAll || !card.Capabilities.StateTransitionHistory.IsNull()) {
-			card.Capabilities.StateTransitionHistory = types.BoolValue(v)
+		if !card.Capabilities.StateTransitionHistory.IsNull() {
+			card.Capabilities.StateTransitionHistory = types.BoolValue(agentCapabilityValue(capsRaw, "stateTransitionHistory"))
 		}
 	}
 
@@ -814,6 +844,162 @@ func (r *AgentResource) readAgentCard(cardRaw map[string]interface{}, data *Agen
 		}
 		card.Skills = skills
 	}
+}
+
+func agentCapabilityValue(capabilities map[string]interface{}, key string) bool {
+	value, _ := capabilities[key].(bool)
+	return value
+}
+
+func changedAgentCapabilityFieldsNotConverged(planned, prior, observed AgentResourceModel) []string {
+	if planned.AgentCard == nil {
+		return nil
+	}
+
+	var priorCard, observedCard *AgentCardModel
+	priorCard = prior.AgentCard
+	observedCard = observed.AgentCard
+	stale := make([]string, 0, 4)
+	check := func(name string, plannedValue types.Bool, priorValue types.Bool, priorPresent bool, observedValue types.Bool, observedPresent bool) {
+		if plannedValue.IsNull() || plannedValue.IsUnknown() {
+			return
+		}
+		if priorPresent && plannedValue.Equal(priorValue) {
+			return
+		}
+		if !observedPresent || !plannedValue.Equal(observedValue) {
+			stale = append(stale, name)
+		}
+	}
+
+	check(
+		"agent_card.supports_authenticated_extended_card",
+		planned.AgentCard.SupportsAuthenticatedExtendedCard,
+		priorAuthValue(priorCard),
+		priorCard != nil,
+		priorAuthValue(observedCard),
+		observedCard != nil,
+	)
+
+	plannedCapabilities := planned.AgentCard.Capabilities
+	if plannedCapabilities == nil {
+		return stale
+	}
+	var priorCapabilities, observedCapabilities *AgentCapabilitiesModel
+	if priorCard != nil {
+		priorCapabilities = priorCard.Capabilities
+	}
+	if observedCard != nil {
+		observedCapabilities = observedCard.Capabilities
+	}
+	checkCapability := func(name string, plannedValue types.Bool, priorValue types.Bool, observedValue types.Bool) {
+		check(name, plannedValue, priorValue, priorCapabilities != nil, observedValue, observedCapabilities != nil)
+	}
+	checkCapability("agent_card.capabilities.streaming", plannedCapabilities.Streaming, capabilityStreaming(priorCapabilities), capabilityStreaming(observedCapabilities))
+	checkCapability("agent_card.capabilities.push_notifications", plannedCapabilities.PushNotifications, capabilityPushNotifications(priorCapabilities), capabilityPushNotifications(observedCapabilities))
+	checkCapability("agent_card.capabilities.state_transition_history", plannedCapabilities.StateTransitionHistory, capabilityStateTransitionHistory(priorCapabilities), capabilityStateTransitionHistory(observedCapabilities))
+	return stale
+}
+
+func priorAuthValue(card *AgentCardModel) types.Bool {
+	if card == nil {
+		return types.BoolNull()
+	}
+	return card.SupportsAuthenticatedExtendedCard
+}
+
+func capabilityStreaming(capabilities *AgentCapabilitiesModel) types.Bool {
+	if capabilities == nil {
+		return types.BoolNull()
+	}
+	return capabilities.Streaming
+}
+
+func capabilityPushNotifications(capabilities *AgentCapabilitiesModel) types.Bool {
+	if capabilities == nil {
+		return types.BoolNull()
+	}
+	return capabilities.PushNotifications
+}
+
+func capabilityStateTransitionHistory(capabilities *AgentCapabilitiesModel) types.Bool {
+	if capabilities == nil {
+		return types.BoolNull()
+	}
+	return capabilities.StateTransitionHistory
+}
+
+func (r *AgentResource) readAgentCapabilitiesAfterUpdate(ctx context.Context, data *AgentResourceModel, planned, prior AgentResourceModel, maxRetries int) error {
+	if maxRetries < 1 {
+		return fmt.Errorf("maxRetries must be at least 1")
+	}
+
+	delay := 250 * time.Millisecond
+	maxDelay := 2 * time.Second
+	var lastErr error
+	var staleFields []string
+	consecutiveMatches := 0
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		candidate := cloneAgentResourceModel(planned)
+		lastErr = r.readAgent(ctx, &candidate)
+		if lastErr == nil {
+			staleFields = changedAgentCapabilityFieldsNotConverged(planned, prior, candidate)
+			if len(staleFields) == 0 {
+				consecutiveMatches++
+				if consecutiveMatches >= 2 {
+					*data = candidate
+					return nil
+				}
+			} else {
+				consecutiveMatches = 0
+			}
+		} else if !IsNotFoundError(lastErr) {
+			return lastErr
+		} else {
+			consecutiveMatches = 0
+		}
+
+		if attempt == maxRetries-1 {
+			break
+		}
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+		delay *= 2
+		if delay > maxDelay {
+			delay = maxDelay
+		}
+	}
+	if lastErr != nil {
+		return lastErr
+	}
+	return fmt.Errorf("capability fields did not remain at their planned values after %d reads: %s", maxRetries, strings.Join(staleFields, ", "))
+}
+
+func cloneAgentResourceModel(source AgentResourceModel) AgentResourceModel {
+	cloned := source
+	if source.AgentCard != nil {
+		card := *source.AgentCard
+		cloned.AgentCard = &card
+		if source.AgentCard.Capabilities != nil {
+			capabilities := *source.AgentCard.Capabilities
+			cloned.AgentCard.Capabilities = &capabilities
+		}
+		if source.AgentCard.Provider != nil {
+			provider := *source.AgentCard.Provider
+			cloned.AgentCard.Provider = &provider
+		}
+		cloned.AgentCard.Skills = append([]AgentSkillModel(nil), source.AgentCard.Skills...)
+	}
+	if source.ObjectPermission != nil {
+		permission := *source.ObjectPermission
+		cloned.ObjectPermission = &permission
+	}
+	return cloned
 }
 
 func (r *AgentResource) readObjectPermission(permRaw map[string]interface{}, data *AgentResourceModel) {

--- a/internal/provider/resource_agent_test.go
+++ b/internal/provider/resource_agent_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -69,16 +71,17 @@ func TestBuildAgentRequest_Full(t *testing.T) {
 	data := &AgentResourceModel{
 		AgentName: types.StringValue("full-agent"),
 		AgentCard: &AgentCardModel{
-			Name:               types.StringValue("Full Agent"),
-			Description:        types.StringValue("A fully configured agent"),
-			URL:                types.StringValue("https://agent.example.com/a2a"),
-			Version:            types.StringValue("1.0.0"),
-			ProtocolVersion:    types.StringValue("0.2.6"),
-			DefaultInputModes:  stringListValue("application/json"),
-			DefaultOutputModes: stringListValue("application/json", "text/plain"),
-			PreferredTransport: types.StringValue("httpsse"),
-			IconURL:            types.StringValue("https://example.com/icon.png"),
-			DocumentationURL:   types.StringValue("https://docs.example.com"),
+			Name:                              types.StringValue("Full Agent"),
+			Description:                       types.StringValue("A fully configured agent"),
+			URL:                               types.StringValue("https://agent.example.com/a2a"),
+			Version:                           types.StringValue("1.0.0"),
+			ProtocolVersion:                   types.StringValue("0.2.6"),
+			DefaultInputModes:                 stringListValue("application/json"),
+			DefaultOutputModes:                stringListValue("application/json", "text/plain"),
+			PreferredTransport:                types.StringValue("httpsse"),
+			IconURL:                           types.StringValue("https://example.com/icon.png"),
+			DocumentationURL:                  types.StringValue("https://docs.example.com"),
+			SupportsAuthenticatedExtendedCard: types.BoolValue(true),
 			Capabilities: &AgentCapabilitiesModel{
 				Streaming:              types.BoolValue(true),
 				PushNotifications:      types.BoolValue(false),
@@ -131,6 +134,9 @@ func TestBuildAgentRequest_Full(t *testing.T) {
 	}
 	if card["preferredTransport"] != "httpsse" {
 		t.Errorf("expected preferredTransport 'httpsse', got %v", card["preferredTransport"])
+	}
+	if card["supportsAuthenticatedExtendedCard"] != true {
+		t.Errorf("expected supportsAuthenticatedExtendedCard true, got %v", card["supportsAuthenticatedExtendedCard"])
 	}
 
 	caps, ok := card["capabilities"].(map[string]interface{})
@@ -187,11 +193,12 @@ func TestReadAgent_PopulatesState(t *testing.T) {
 			"agent_id":   "agent-abc-123",
 			"agent_name": "my-agent",
 			"agent_card_params": map[string]interface{}{
-				"name":            "My Agent",
-				"description":     "A helpful agent",
-				"url":             "https://agent.example.com",
-				"version":         "1.0.0",
-				"protocolVersion": "0.2.6",
+				"name":                              "My Agent",
+				"description":                       "A helpful agent",
+				"url":                               "https://agent.example.com",
+				"version":                           "1.0.0",
+				"protocolVersion":                   "0.2.6",
+				"supportsAuthenticatedExtendedCard": true,
 				"capabilities": map[string]interface{}{
 					"streaming":         true,
 					"pushNotifications": false,
@@ -295,6 +302,9 @@ func TestReadAgent_PopulatesState(t *testing.T) {
 	if data.AgentCard.ProtocolVersion.ValueString() != "0.2.6" {
 		t.Errorf("expected protocolVersion '0.2.6', got %q", data.AgentCard.ProtocolVersion.ValueString())
 	}
+	if !data.AgentCard.SupportsAuthenticatedExtendedCard.ValueBool() {
+		t.Error("expected supportsAuthenticatedExtendedCard true")
+	}
 
 	// Capabilities
 	if data.AgentCard.Capabilities == nil {
@@ -348,6 +358,184 @@ func TestReadAgent_PopulatesState(t *testing.T) {
 	// Extra headers
 	if data.ExtraHeaders.IsNull() || data.ExtraHeaders.IsUnknown() {
 		t.Fatal("expected extra_headers to be populated")
+	}
+}
+
+func TestReadAgentCardMissingManagedCapabilitiesBecomeFalse(t *testing.T) {
+	t.Parallel()
+
+	resource := &AgentResource{}
+	data := AgentResourceModel{AgentCard: &AgentCardModel{
+		SupportsAuthenticatedExtendedCard: types.BoolValue(true),
+		Capabilities: &AgentCapabilitiesModel{
+			Streaming:              types.BoolValue(true),
+			PushNotifications:      types.BoolValue(true),
+			StateTransitionHistory: types.BoolValue(true),
+		},
+	}}
+
+	resource.readAgentCard(map[string]interface{}{
+		"capabilities": map[string]interface{}{"streaming": true},
+	}, &data)
+
+	if !data.AgentCard.Capabilities.Streaming.ValueBool() {
+		t.Error("expected returned streaming capability to remain true")
+	}
+	if data.AgentCard.Capabilities.PushNotifications.ValueBool() {
+		t.Error("expected omitted pushNotifications capability to become false")
+	}
+	if data.AgentCard.Capabilities.StateTransitionHistory.ValueBool() {
+		t.Error("expected omitted stateTransitionHistory capability to become false")
+	}
+	if data.AgentCard.SupportsAuthenticatedExtendedCard.ValueBool() {
+		t.Error("expected omitted supportsAuthenticatedExtendedCard to become false")
+	}
+}
+
+func TestReadAgentCardMissingCapabilitiesMapClearsManagedValues(t *testing.T) {
+	t.Parallel()
+
+	resource := &AgentResource{}
+	data := AgentResourceModel{AgentCard: &AgentCardModel{Capabilities: &AgentCapabilitiesModel{
+		Streaming:         types.BoolValue(true),
+		PushNotifications: types.BoolValue(true),
+	}}}
+	resource.readAgentCard(map[string]interface{}{}, &data)
+
+	if data.AgentCard.Capabilities.Streaming.ValueBool() || data.AgentCard.Capabilities.PushNotifications.ValueBool() {
+		t.Fatalf("omitted capabilities map retained managed values: %#v", data.AgentCard.Capabilities)
+	}
+}
+
+func TestReadAgentCardLeavesUnmanagedCapabilityNull(t *testing.T) {
+	t.Parallel()
+
+	resource := &AgentResource{}
+	data := AgentResourceModel{AgentCard: &AgentCardModel{Capabilities: &AgentCapabilitiesModel{
+		Streaming:         types.BoolValue(true),
+		PushNotifications: types.BoolNull(),
+	}}}
+	resource.readAgentCard(map[string]interface{}{
+		"capabilities": map[string]interface{}{
+			"streaming":         true,
+			"pushNotifications": true,
+		},
+	}, &data)
+
+	if !data.AgentCard.Capabilities.PushNotifications.IsNull() {
+		t.Fatalf("unmanaged push_notifications became %v, want null", data.AgentCard.Capabilities.PushNotifications)
+	}
+}
+
+func TestReadAgentCardImportPopulatesMissingCapabilitiesAsFalse(t *testing.T) {
+	t.Parallel()
+
+	resource := &AgentResource{}
+	data := AgentResourceModel{}
+	resource.readAgentCard(map[string]interface{}{
+		"capabilities": map[string]interface{}{"streaming": true},
+	}, &data)
+
+	if data.AgentCard == nil || data.AgentCard.Capabilities == nil {
+		t.Fatal("import did not populate capabilities")
+	}
+	if !data.AgentCard.Capabilities.Streaming.ValueBool() || data.AgentCard.Capabilities.PushNotifications.ValueBool() || data.AgentCard.Capabilities.StateTransitionHistory.ValueBool() {
+		t.Fatalf("unexpected imported capabilities: %#v", data.AgentCard.Capabilities)
+	}
+}
+
+func TestChangedAgentCapabilityFieldsNotConverged(t *testing.T) {
+	t.Parallel()
+
+	prior := AgentResourceModel{AgentCard: &AgentCardModel{
+		SupportsAuthenticatedExtendedCard: types.BoolValue(false),
+		Capabilities: &AgentCapabilitiesModel{
+			PushNotifications: types.BoolValue(false),
+		},
+	}}
+	planned := cloneAgentResourceModel(prior)
+	planned.AgentCard.SupportsAuthenticatedExtendedCard = types.BoolValue(true)
+	planned.AgentCard.Capabilities.PushNotifications = types.BoolValue(true)
+	observed := cloneAgentResourceModel(planned)
+	observed.AgentCard.Capabilities.PushNotifications = types.BoolValue(false)
+
+	got := changedAgentCapabilityFieldsNotConverged(planned, prior, observed)
+	want := []string{"agent_card.capabilities.push_notifications"}
+	if len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("stale fields = %v, want %v", got, want)
+	}
+}
+
+func TestReadAgentCapabilitiesAfterUpdateRequiresStableValues(t *testing.T) {
+	t.Parallel()
+
+	var reads atomic.Int32
+	sequence := []bool{true, false, true, true}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		index := int(reads.Add(1)) - 1
+		if index >= len(sequence) {
+			index = len(sequence) - 1
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"agent_id": "agent-1",
+			"agent_card_params": map[string]interface{}{
+				"supportsAuthenticatedExtendedCard": sequence[index],
+			},
+		})
+	}))
+	defer server.Close()
+
+	resource := &AgentResource{client: &Client{APIBase: server.URL, APIKey: "test-key", HTTPClient: server.Client()}}
+	prior := AgentResourceModel{
+		ID: types.StringValue("agent-1"),
+		AgentCard: &AgentCardModel{
+			SupportsAuthenticatedExtendedCard: types.BoolValue(false),
+		},
+	}
+	planned := cloneAgentResourceModel(prior)
+	planned.AgentCard.SupportsAuthenticatedExtendedCard = types.BoolValue(true)
+	data := cloneAgentResourceModel(planned)
+
+	if err := resource.readAgentCapabilitiesAfterUpdate(context.Background(), &data, planned, prior, 5); err != nil {
+		t.Fatalf("readAgentCapabilitiesAfterUpdate returned error: %v", err)
+	}
+	if got := reads.Load(); got != 4 {
+		t.Fatalf("read count = %d, want 4", got)
+	}
+	if !data.AgentCard.SupportsAuthenticatedExtendedCard.ValueBool() || !planned.AgentCard.SupportsAuthenticatedExtendedCard.ValueBool() {
+		t.Fatal("stable read did not preserve planned true value")
+	}
+}
+
+func TestReadAgentCapabilitiesAfterUpdateRejectsPersistentOmission(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"agent_id": "agent-1",
+			"agent_card_params": map[string]interface{}{
+				"capabilities": map[string]interface{}{"streaming": true},
+			},
+		})
+	}))
+	defer server.Close()
+
+	resource := &AgentResource{client: &Client{APIBase: server.URL, APIKey: "test-key", HTTPClient: server.Client()}}
+	prior := AgentResourceModel{
+		ID: types.StringValue("agent-1"),
+		AgentCard: &AgentCardModel{Capabilities: &AgentCapabilitiesModel{
+			PushNotifications: types.BoolValue(false),
+		}},
+	}
+	planned := cloneAgentResourceModel(prior)
+	planned.AgentCard.Capabilities.PushNotifications = types.BoolValue(true)
+	data := cloneAgentResourceModel(planned)
+
+	err := resource.readAgentCapabilitiesAfterUpdate(context.Background(), &data, planned, prior, 3)
+	if err == nil || !strings.Contains(err.Error(), "push_notifications") {
+		t.Fatalf("error = %v, want persistent push_notifications omission", err)
 	}
 }
 


### PR DESCRIPTION
### Summary

Closes #124. Configured `litellm_agent` capability values are now read authoritatively: when LiteLLM accepts a flag but omits it from read-back, the effective value becomes `false` instead of silently retaining the planned `true` in Terraform state. Unconfigured capability fields remain unmanaged, and imports capture omitted fields as false when a capabilities object exists.

Capability updates use deep-cloned post-update reads and must match on two consecutive responses, avoiding false failures during LiteLLM router propagation while still returning an explicit consistency error for persistently rejected flags. This also adds LiteLLM v1.98.0's top-level A2A AgentCard field `supports_authenticated_extended_card`.

### Validation

Live v1.98.0 validation confirmed `supports_authenticated_extended_card` persists through Create and Update with stable ID and clean plans. The first Update reproduced a stale immediate read and then converged with the retry fix. OSS persistently omits `push_notifications` and `state_transition_history`; apply now reports the rejected capability update and the following plan continues showing `false -> true` instead of going falsely clean. Focused omission/import/null/stability tests, `go vet`, full tests, race tests, and the 23-resource real-dev lifecycle suite pass.

### Diff size

**Docs** — 2 files · `+6 / -1`

Documents authoritative capability behavior, the authenticated extended card field, and the Unreleased fix.

**Implementation** — 1 file · `+210 / -24`

Adds schema/payload/read support, authoritative omission handling, safe deep cloning, and stable capability Update reads.

**Tests** — 1 file · `+203 / -15`

Covers payloads, omitted keys/maps, unmanaged nulls, import defaults, changed-field selection, stable cache sequences, and persistent rejection.
