### PR TITLE
fix(guardrail): ignore unconfigured nested nulls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`litellm_model`**: Add `additional_model_info` for managing capability flags and other custom `model_info` metadata without adopting LiteLLM cost-map-derived fields. ([#140](https://github.com/ncecere/terraform-provider-litellm/issues/140)) — thanks @runixer
 - **`litellm_user`**: Treat `teams` as unordered membership during read-back and reconcile additions/removals through LiteLLM's dedicated team-member endpoints, preventing order-only inconsistent results while preserving real membership drift. ([#150](https://github.com/ncecere/terraform-provider-litellm/issues/150))
 - **`litellm_agent`**: Make configured capability read-back authoritative when LiteLLM omits unsupported flags, wait for stable post-update values, and add the A2A `supports_authenticated_extended_card` field. ([#124](https://github.com/ncecere/terraform-provider-litellm/issues/124))
+- **`litellm_guardrail`**: Ignore nested null defaults that LiteLLM adds to configured `litellm_params` objects while retaining explicit nulls and real nested drift. ([#125](https://github.com/ncecere/terraform-provider-litellm/issues/125))
 
 ## [2.0.1] - 2026-06-12
 

--- a/docs/resources/guardrail.md
+++ b/docs/resources/guardrail.md
@@ -62,7 +62,7 @@ The following arguments are supported:
 
 - `guardrail_id` - (String, ForceNew) The unique identifier for the guardrail. If not provided, one will be generated automatically. Changing this forces creation of a new resource.
 - `default_on` - (Bool) Whether this guardrail is enabled by default for all requests.
-- `litellm_params` - (String) A JSON-encoded string containing provider-specific parameters. This field stores only additional configuration specific to the guardrail provider (it does not include `guardrail`, `mode`, or `default_on`, which are top-level attributes). When reading back from the API, only the keys originally configured by the user are preserved, preventing the API's default values from appearing in state.
+- `litellm_params` - (String) A JSON-encoded string containing provider-specific parameters. This field stores only additional configuration specific to the guardrail provider (it does not include `guardrail`, `mode`, or `default_on`, which are top-level attributes). Top-level API defaults are excluded during read-back. Within configured objects and arrays, null fields added by LiteLLM are ignored unless they were explicitly configured; non-null additions and missing or changed configured values remain visible as drift.
 - `guardrail_info` - (String) A JSON-encoded string containing additional metadata or information about the guardrail.
 
 ## Attribute Reference

--- a/internal/provider/resource_guardrail.go
+++ b/internal/provider/resource_guardrail.go
@@ -278,6 +278,39 @@ func (r *GuardrailResource) buildGuardrailRequest(ctx context.Context, data *Gua
 	}
 }
 
+func removeUnconfiguredGuardrailNulls(apiValue, configuredValue interface{}) interface{} {
+	switch apiValue := apiValue.(type) {
+	case map[string]interface{}:
+		configuredObject, _ := configuredValue.(map[string]interface{})
+		filtered := make(map[string]interface{}, len(apiValue))
+		for key, value := range apiValue {
+			configuredChild, configured := configuredObject[key]
+			if !configured && value == nil {
+				continue
+			}
+			if configured {
+				filtered[key] = removeUnconfiguredGuardrailNulls(value, configuredChild)
+			} else {
+				filtered[key] = value
+			}
+		}
+		return filtered
+	case []interface{}:
+		configuredArray, _ := configuredValue.([]interface{})
+		filtered := make([]interface{}, len(apiValue))
+		for index, value := range apiValue {
+			if index < len(configuredArray) {
+				filtered[index] = removeUnconfiguredGuardrailNulls(value, configuredArray[index])
+			} else {
+				filtered[index] = value
+			}
+		}
+		return filtered
+	default:
+		return apiValue
+	}
+}
+
 func (r *GuardrailResource) readGuardrail(ctx context.Context, data *GuardrailResourceModel) error {
 	guardrailID := data.GuardrailID.ValueString()
 	if guardrailID == "" {
@@ -325,18 +358,18 @@ func (r *GuardrailResource) readGuardrail(ctx context.Context, data *GuardrailRe
 
 		// Store other litellm_params as JSON (excluding guardrail, mode, default_on).
 		// Only update if the user originally configured litellm_params to avoid
-		// adopting the API's massive default parameter set.
-		// Additionally, only preserve the keys the user originally configured to
-		// prevent the API's expanded defaults from being stored in state.
+		// adopting the API's massive default parameter set. Top-level API defaults
+		// remain excluded. Within configured structures, remove only null object
+		// fields that the user omitted; retain explicit nulls and non-null additions
+		// so real server-side drift remains visible.
 		if !data.LitellmParams.IsNull() && !data.LitellmParams.IsUnknown() {
-			// Parse the user's original litellm_params to get configured keys
 			var userParams map[string]interface{}
 			if err := json.Unmarshal([]byte(data.LitellmParams.ValueString()), &userParams); err == nil {
 				otherParams := make(map[string]interface{})
-				for k := range userParams {
+				for k, configuredValue := range userParams {
 					if k != "guardrail" && k != "mode" && k != "default_on" {
-						if v, exists := litellmParams[k]; exists {
-							otherParams[k] = v
+						if apiValue, exists := litellmParams[k]; exists {
+							otherParams[k] = removeUnconfiguredGuardrailNulls(apiValue, configuredValue)
 						}
 					}
 				}

--- a/internal/provider/resource_guardrail_test.go
+++ b/internal/provider/resource_guardrail_test.go
@@ -1,0 +1,159 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestRemoveUnconfiguredGuardrailNulls(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		configured string
+		api        string
+		want       string
+	}{
+		"pattern default": {
+			configured: `[{"pattern_type":"regex","pattern":"*foo*","name":"test","action":"MASK"}]`,
+			api:        `[{"pattern_type":"regex","pattern":"*foo*","pattern_name":null,"name":"test","action":"MASK"}]`,
+			want:       `[{"pattern_type":"regex","pattern":"*foo*","name":"test","action":"MASK"}]`,
+		},
+		"rule defaults": {
+			configured: `[{"id":"allow_bash","tool_name":"Bash","decision":"allow"}]`,
+			api:        `[{"id":"allow_bash","tool_name":"Bash","decision":"allow","tool_type":null,"allowed_param_patterns":null}]`,
+			want:       `[{"id":"allow_bash","tool_name":"Bash","decision":"allow"}]`,
+		},
+		"explicit null retained": {
+			configured: `[{"id":"allow_bash","tool_type":null}]`,
+			api:        `[{"id":"allow_bash","tool_type":null,"decision":null}]`,
+			want:       `[{"id":"allow_bash","tool_type":null}]`,
+		},
+		"non-null addition retained": {
+			configured: `[{"id":"allow_bash"}]`,
+			api:        `[{"id":"allow_bash","decision":"deny","tool_type":null}]`,
+			want:       `[{"id":"allow_bash","decision":"deny"}]`,
+		},
+		"missing configured value remains missing": {
+			configured: `[{"id":"allow_bash","decision":"allow"}]`,
+			api:        `[{"id":"allow_bash"}]`,
+			want:       `[{"id":"allow_bash"}]`,
+		},
+		"extra array item retained": {
+			configured: `[{"id":"one"}]`,
+			api:        `[{"id":"one","decision":null},{"id":"two","decision":null}]`,
+			want:       `[{"id":"one"},{"id":"two","decision":null}]`,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			var configured, api, want interface{}
+			if err := json.Unmarshal([]byte(test.configured), &configured); err != nil {
+				t.Fatal(err)
+			}
+			if err := json.Unmarshal([]byte(test.api), &api); err != nil {
+				t.Fatal(err)
+			}
+			if err := json.Unmarshal([]byte(test.want), &want); err != nil {
+				t.Fatal(err)
+			}
+			got := removeUnconfiguredGuardrailNulls(api, configured)
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("filtered value = %#v, want %#v", got, want)
+			}
+		})
+	}
+}
+
+func TestReadGuardrailFiltersNestedNullDefaults(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(writer).Encode(map[string]interface{}{
+			"guardrail_id":   "guardrail-1",
+			"guardrail_name": "test",
+			"litellm_params": map[string]interface{}{
+				"guardrail":  "litellm_content_filter",
+				"mode":       "pre_call",
+				"default_on": true,
+				"patterns": []interface{}{
+					map[string]interface{}{
+						"pattern_type": "regex",
+						"pattern":      "*foo*",
+						"pattern_name": nil,
+						"name":         "test",
+						"action":       "MASK",
+					},
+				},
+				"api_default_not_configured": "ignored",
+			},
+		})
+	}))
+	defer server.Close()
+
+	resource := &GuardrailResource{client: &Client{APIBase: server.URL, APIKey: "test-key", HTTPClient: server.Client()}}
+	configured := `{"patterns":[{"action":"MASK","name":"test","pattern":"*foo*","pattern_type":"regex"}]}`
+	data := GuardrailResourceModel{
+		ID:            types.StringValue("guardrail-1"),
+		GuardrailID:   types.StringValue("guardrail-1"),
+		GuardrailName: types.StringValue("test"),
+		Guardrail:     types.StringValue("litellm_content_filter"),
+		Mode:          types.StringValue("pre_call"),
+		DefaultOn:     types.BoolValue(true),
+		LitellmParams: types.StringValue(configured),
+	}
+
+	if err := resource.readGuardrail(context.Background(), &data); err != nil {
+		t.Fatalf("readGuardrail returned error: %v", err)
+	}
+	if got := data.LitellmParams.ValueString(); got != configured {
+		t.Fatalf("litellm_params = %s, want %s", got, configured)
+	}
+}
+
+func TestReadGuardrailPreservesRealNestedDrift(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(writer).Encode(map[string]interface{}{
+			"guardrail_id": "guardrail-1",
+			"litellm_params": map[string]interface{}{
+				"guardrail": "tool_permission",
+				"mode":      "post_call",
+				"rules": []interface{}{
+					map[string]interface{}{
+						"id":                     "allow_bash",
+						"tool_name":              "Bash",
+						"decision":               "deny",
+						"tool_type":              nil,
+						"allowed_param_patterns": nil,
+					},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	resource := &GuardrailResource{client: &Client{APIBase: server.URL, APIKey: "test-key", HTTPClient: server.Client()}}
+	data := GuardrailResourceModel{
+		ID:            types.StringValue("guardrail-1"),
+		GuardrailID:   types.StringValue("guardrail-1"),
+		LitellmParams: types.StringValue(`{"rules":[{"decision":"allow","id":"allow_bash","tool_name":"Bash"}]}`),
+	}
+	if err := resource.readGuardrail(context.Background(), &data); err != nil {
+		t.Fatalf("readGuardrail returned error: %v", err)
+	}
+	want := `{"rules":[{"decision":"deny","id":"allow_bash","tool_name":"Bash"}]}`
+	if got := data.LitellmParams.ValueString(); got != want {
+		t.Fatalf("litellm_params = %s, want %s", got, want)
+	}
+}


### PR DESCRIPTION
### Summary

Closes #125. `litellm_guardrail` now recursively ignores null object fields that LiteLLM adds beneath configured `litellm_params` keys. This prevents `pattern_name`, `tool_type`, `allowed_param_patterns`, and similar omitted optional fields from invalidating state after apply.

The filtering is deliberately narrow: explicitly configured nulls remain in state, while non-null server additions, missing configured values, changed values, and extra array elements remain visible as real drift. Existing top-level filtering continues to avoid adopting LiteLLM's broad default parameter set.

### Validation

Both issue examples were reproduced against LiteLLM v1.98.0 before the fix. The content-filter pattern and tool-permission rule resources now create successfully and produce clean no-drift plans without spelling optional null fields in configuration. A live out-of-band rule decision change from `allow` to `deny` remained visible in Terraform while API-added nulls stayed suppressed; apply restored the configured value and the next plan was clean. Focused recursive/read tests, `go vet`, full tests, race tests, and the 23-resource real-dev lifecycle suite pass.

### Diff size

**Docs** — 2 files · `+2 / -1`

Documents nested-null normalization and records the Unreleased fix.

**Implementation** — 1 file · `+40 / -7`

Adds recursive, configuration-aware null filtering to guardrail read-back.

**Tests** — 1 file · `+159 / -0`

Covers both reported structures, explicit nulls, real additions/removals/changes, extra array items, and HTTP read behavior.
