### PR TITLE
fix(mcp): recover from read-back failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`litellm_agent`**: Make configured capability read-back authoritative when LiteLLM omits unsupported flags, wait for stable post-update values, and add the A2A `supports_authenticated_extended_card` field. ([#124](https://github.com/ncecere/terraform-provider-litellm/issues/124))
 - **`litellm_guardrail`**: Ignore nested null defaults that LiteLLM adds to configured `litellm_params` objects while retaining explicit nulls and real nested drift. ([#125](https://github.com/ncecere/terraform-provider-litellm/issues/125))
 - **`litellm_key`**: Mark `metadata` sensitive and preserve configured nested secret leaves when LiteLLM reads them back as encrypted values, while continuing to expose unmasked metadata drift. ([#115](https://github.com/ncecere/terraform-provider-litellm/issues/115))
+- **`litellm_mcp_server`**: Fall back to the MCP collection endpoint when individual read-back fails and resolve computed unknowns after successful mutations so backend read errors remain recoverable. ([#116](https://github.com/ncecere/terraform-provider-litellm/issues/116))
 
 ## [2.0.1] - 2026-06-12
 

--- a/docs/resources/mcp_server.md
+++ b/docs/resources/mcp_server.md
@@ -3,6 +3,8 @@
 Manages MCP (Model Context Protocol) server configurations in LiteLLM. MCP servers allow LLM models to access external tools and data sources through a standardized protocol.
 
 > **Note:** Server names and aliases **cannot contain hyphens** (`-`). The LiteLLM API rejects them. Use underscores (`_`) instead.
+>
+> The provider falls back to LiteLLM's MCP server collection endpoint if the individual server read returns an unexpected error. If all read-back paths fail after LiteLLM has already accepted a create or update, Terraform retains a recoverable state with known values and reports a warning instead of emitting cascading unknown-value errors.
 
 ## Example Usage
 

--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -4,10 +4,20 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 )
+
+type APIError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *APIError) Error() string {
+	return fmt.Sprintf("API request failed with status %d: %s", e.StatusCode, e.Body)
+}
 
 // DoRequest performs an HTTP request with context and standard headers.
 func (c *Client) DoRequest(ctx context.Context, method, path string, body interface{}) (*http.Response, error) {
@@ -59,7 +69,7 @@ func (c *Client) DoRequestWithResponse(ctx context.Context, method, path string,
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(bodyBytes))
+		return &APIError{StatusCode: resp.StatusCode, Body: string(bodyBytes)}
 	}
 
 	// If no result expected, return early
@@ -83,6 +93,10 @@ func (c *Client) DoRequestWithResponse(ctx context.Context, method, path string,
 func IsNotFoundError(err error) bool {
 	if err == nil {
 		return false
+	}
+	var apiErr *APIError
+	if errors.As(err, &apiErr) {
+		return apiErr.StatusCode == http.StatusNotFound
 	}
 	errStr := err.Error()
 	return contains(errStr, "not found") ||

--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -89,14 +89,22 @@ func (c *Client) DoRequestWithResponse(ctx context.Context, method, path string,
 	return nil
 }
 
-// IsNotFoundError checks if the error message indicates a not found condition.
+// IsAPIErrorStatus reports whether an error came from an HTTP API response
+// with the exact status code. Callers that must distinguish absence from an
+// unexpected error should use this instead of response-body heuristics.
+func IsAPIErrorStatus(err error, statusCode int) bool {
+	var apiErr *APIError
+	return errors.As(err, &apiErr) && apiErr.StatusCode == statusCode
+}
+
+// IsNotFoundError retains compatibility with LiteLLM endpoints that return
+// non-404 statuses (commonly 400) with a not-found message in the body.
 func IsNotFoundError(err error) bool {
 	if err == nil {
 		return false
 	}
-	var apiErr *APIError
-	if errors.As(err, &apiErr) {
-		return apiErr.StatusCode == http.StatusNotFound
+	if IsAPIErrorStatus(err, http.StatusNotFound) {
+		return true
 	}
 	errStr := err.Error()
 	return contains(errStr, "not found") ||

--- a/internal/provider/helpers_test.go
+++ b/internal/provider/helpers_test.go
@@ -21,6 +21,8 @@ func TestIsNotFoundError(t *testing.T) {
 		{"not found phrase", errors.New("resource not found"), true},
 		{"404 status", errors.New("request failed with status 404"), true},
 		{"does not exist", errors.New("the key does not exist"), true},
+		{"typed 404", &APIError{StatusCode: 404, Body: "internal error"}, true},
+		{"typed 500 body says not found and 404", &APIError{StatusCode: 500, Body: "server not found after 404 lookup"}, false},
 		{"unrelated", errors.New("internal server error"), false},
 	}
 	for _, tc := range cases {

--- a/internal/provider/helpers_test.go
+++ b/internal/provider/helpers_test.go
@@ -22,13 +22,21 @@ func TestIsNotFoundError(t *testing.T) {
 		{"404 status", errors.New("request failed with status 404"), true},
 		{"does not exist", errors.New("the key does not exist"), true},
 		{"typed 404", &APIError{StatusCode: 404, Body: "internal error"}, true},
-		{"typed 500 body says not found and 404", &APIError{StatusCode: 500, Body: "server not found after 404 lookup"}, false},
+		{"typed 500 body compatibility heuristic", &APIError{StatusCode: 500, Body: "server not found after 404 lookup"}, true},
 		{"unrelated", errors.New("internal server error"), false},
 	}
 	for _, tc := range cases {
 		if got := IsNotFoundError(tc.err); got != tc.want {
 			t.Errorf("%s: IsNotFoundError(%v) = %v, want %v", tc.name, tc.err, got, tc.want)
 		}
+	}
+
+	misleading := &APIError{StatusCode: 500, Body: "server not found after 404 lookup"}
+	if IsAPIErrorStatus(misleading, 404) {
+		t.Fatal("typed HTTP 500 was classified as exact 404")
+	}
+	if !IsAPIErrorStatus(&APIError{StatusCode: 404, Body: "anything"}, 404) {
+		t.Fatal("typed HTTP 404 was not classified as exact 404")
 	}
 }
 

--- a/internal/provider/resource_mcp_server.go
+++ b/internal/provider/resource_mcp_server.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -294,10 +295,17 @@ func (r *MCPServerResource) Create(ctx context.Context, req resource.CreateReque
 		data.ID = types.StringValue(serverID)
 	}
 
-	// Read back for full state
+	if data.ServerID.IsNull() || data.ServerID.IsUnknown() || data.ServerID.ValueString() == "" {
+		resp.Diagnostics.AddError("Invalid Create Response", "LiteLLM created the MCP server but did not return a server_id, so the provider cannot manage it.")
+		return
+	}
+
+	// Read back for full state. If every read path fails after a successful
+	// create, publish a recoverable state with no unknown computed values.
 	if err := r.readMCPServer(ctx, &data); err != nil {
 		resp.Diagnostics.AddWarning("Read Error", fmt.Sprintf("MCP server created but failed to read back: %s", err))
 	}
+	resolveUnknownMCPServerState(&data, nil)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -348,10 +356,12 @@ func (r *MCPServerResource) Update(ctx context.Context, req resource.UpdateReque
 		return
 	}
 
-	// Read back for full state
+	// Read back for full state. Preserve prior known computed values if every
+	// read path fails after LiteLLM accepted the update.
 	if err := r.readMCPServer(ctx, &data); err != nil {
 		resp.Diagnostics.AddWarning("Read Error", fmt.Sprintf("MCP server updated but failed to read back: %s", err))
 	}
+	resolveUnknownMCPServerState(&data, &state)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -580,16 +590,149 @@ func (r *MCPServerResource) buildMCPServerRequest(ctx context.Context, data *MCP
 	return mcpReq
 }
 
+func resolveUnknownMCPServerState(data *MCPServerResourceModel, previous *MCPServerResourceModel) {
+	var prior MCPServerResourceModel
+	if previous != nil {
+		prior = *previous
+	}
+
+	resolveString := func(current, fallback types.String) types.String {
+		if !current.IsUnknown() {
+			return current
+		}
+		if previous != nil && !fallback.IsUnknown() {
+			return fallback
+		}
+		return types.StringNull()
+	}
+	resolveBool := func(current, fallback types.Bool) types.Bool {
+		if !current.IsUnknown() {
+			return current
+		}
+		if previous != nil && !fallback.IsUnknown() {
+			return fallback
+		}
+		return types.BoolNull()
+	}
+	resolveList := func(current, fallback types.List) types.List {
+		if !current.IsUnknown() {
+			return current
+		}
+		if previous != nil && !fallback.IsUnknown() {
+			return fallback
+		}
+		return types.ListNull(types.StringType)
+	}
+	resolveStringMap := func(current, fallback types.Map) types.Map {
+		if !current.IsUnknown() {
+			return current
+		}
+		if previous != nil && !fallback.IsUnknown() {
+			return fallback
+		}
+		return types.MapNull(types.StringType)
+	}
+
+	data.ID = resolveString(data.ID, prior.ID)
+	data.ServerID = resolveString(data.ServerID, prior.ServerID)
+	data.ServerName = resolveString(data.ServerName, prior.ServerName)
+	data.Alias = resolveString(data.Alias, prior.Alias)
+	data.Description = resolveString(data.Description, prior.Description)
+	data.URL = resolveString(data.URL, prior.URL)
+	data.Transport = resolveString(data.Transport, prior.Transport)
+	data.SpecVersion = resolveString(data.SpecVersion, prior.SpecVersion)
+	data.AuthType = resolveString(data.AuthType, prior.AuthType)
+	data.Command = resolveString(data.Command, prior.Command)
+	data.AuthorizationURL = resolveString(data.AuthorizationURL, prior.AuthorizationURL)
+	data.TokenURL = resolveString(data.TokenURL, prior.TokenURL)
+	data.RegistrationURL = resolveString(data.RegistrationURL, prior.RegistrationURL)
+	data.CreatedAt = resolveString(data.CreatedAt, prior.CreatedAt)
+	data.CreatedBy = resolveString(data.CreatedBy, prior.CreatedBy)
+	data.AllowAllKeys = resolveBool(data.AllowAllKeys, prior.AllowAllKeys)
+	data.SkipURLValidation = resolveBool(data.SkipURLValidation, prior.SkipURLValidation)
+	data.MCPAccessGroups = resolveList(data.MCPAccessGroups, prior.MCPAccessGroups)
+	data.Args = resolveList(data.Args, prior.Args)
+	data.AllowedTools = resolveList(data.AllowedTools, prior.AllowedTools)
+	data.ExtraHeaders = resolveList(data.ExtraHeaders, prior.ExtraHeaders)
+	data.Env = resolveStringMap(data.Env, prior.Env)
+	data.Credentials = resolveStringMap(data.Credentials, prior.Credentials)
+	data.StaticHeaders = resolveStringMap(data.StaticHeaders, prior.StaticHeaders)
+
+	if data.MCPInfo != nil {
+		var priorInfo MCPInfoModel
+		if prior.MCPInfo != nil {
+			priorInfo = *prior.MCPInfo
+		}
+		data.MCPInfo.ServerName = resolveString(data.MCPInfo.ServerName, priorInfo.ServerName)
+		data.MCPInfo.Description = resolveString(data.MCPInfo.Description, priorInfo.Description)
+		data.MCPInfo.LogoURL = resolveString(data.MCPInfo.LogoURL, priorInfo.LogoURL)
+		if data.MCPInfo.MCPServerCostInfo != nil {
+			var priorCost MCPServerCostInfoModel
+			hasPriorCost := priorInfo.MCPServerCostInfo != nil
+			if hasPriorCost {
+				priorCost = *priorInfo.MCPServerCostInfo
+			}
+			if data.MCPInfo.MCPServerCostInfo.DefaultCostPerQuery.IsUnknown() {
+				if hasPriorCost && !priorCost.DefaultCostPerQuery.IsUnknown() {
+					data.MCPInfo.MCPServerCostInfo.DefaultCostPerQuery = priorCost.DefaultCostPerQuery
+				} else {
+					data.MCPInfo.MCPServerCostInfo.DefaultCostPerQuery = types.Float64Null()
+				}
+			}
+			if data.MCPInfo.MCPServerCostInfo.ToolNameToCostPerQuery.IsUnknown() {
+				if hasPriorCost && !priorCost.ToolNameToCostPerQuery.IsUnknown() {
+					data.MCPInfo.MCPServerCostInfo.ToolNameToCostPerQuery = priorCost.ToolNameToCostPerQuery
+				} else {
+					data.MCPInfo.MCPServerCostInfo.ToolNameToCostPerQuery = types.MapNull(types.Float64Type)
+				}
+			}
+		}
+	}
+}
+
+func (r *MCPServerResource) getMCPServer(ctx context.Context, serverID string) (map[string]interface{}, error) {
+	endpoint := fmt.Sprintf("/v1/mcp/server/%s", serverID)
+	var result map[string]interface{}
+	individualErr := r.client.DoRequestWithResponse(ctx, "GET", endpoint, nil, &result)
+	if individualErr == nil || IsNotFoundError(individualErr) {
+		return result, individualErr
+	}
+
+	// Older LiteLLM versions can return 500 for the individual endpoint while
+	// the collection endpoint still returns the successfully created server.
+	delay := 250 * time.Millisecond
+	for attempt := 0; attempt < 5; attempt++ {
+		var servers []map[string]interface{}
+		if err := r.client.DoRequestWithResponse(ctx, "GET", "/v1/mcp/server", nil, &servers); err == nil {
+			for _, server := range servers {
+				if id, ok := server["server_id"].(string); ok && id == serverID {
+					return server, nil
+				}
+			}
+		}
+		if attempt == 4 {
+			break
+		}
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
+		delay *= 2
+	}
+	return nil, individualErr
+}
+
 func (r *MCPServerResource) readMCPServer(ctx context.Context, data *MCPServerResourceModel) error {
 	serverID := data.ID.ValueString()
 	if serverID == "" {
 		serverID = data.ServerID.ValueString()
 	}
 
-	endpoint := fmt.Sprintf("/v1/mcp/server/%s", serverID)
-
-	var result map[string]interface{}
-	if err := r.client.DoRequestWithResponse(ctx, "GET", endpoint, nil, &result); err != nil {
+	result, err := r.getMCPServer(ctx, serverID)
+	if err != nil {
 		return err
 	}
 

--- a/internal/provider/resource_mcp_server.go
+++ b/internal/provider/resource_mcp_server.go
@@ -319,7 +319,7 @@ func (r *MCPServerResource) Read(ctx context.Context, req resource.ReadRequest, 
 	}
 
 	if err := r.readMCPServer(ctx, &data); err != nil {
-		if IsNotFoundError(err) {
+		if IsAPIErrorStatus(err, 404) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
@@ -381,7 +381,7 @@ func (r *MCPServerResource) Delete(ctx context.Context, req resource.DeleteReque
 
 	endpoint := fmt.Sprintf("/v1/mcp/server/%s", serverID)
 	if err := r.client.DoRequestWithResponse(ctx, "DELETE", endpoint, nil, nil); err != nil {
-		if !IsNotFoundError(err) {
+		if !IsAPIErrorStatus(err, 404) {
 			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete MCP server: %s", err))
 			return
 		}
@@ -694,7 +694,7 @@ func (r *MCPServerResource) getMCPServer(ctx context.Context, serverID string) (
 	endpoint := fmt.Sprintf("/v1/mcp/server/%s", serverID)
 	var result map[string]interface{}
 	individualErr := r.client.DoRequestWithResponse(ctx, "GET", endpoint, nil, &result)
-	if individualErr == nil || IsNotFoundError(individualErr) {
+	if individualErr == nil || IsAPIErrorStatus(individualErr, 404) {
 		return result, individualErr
 	}
 

--- a/internal/provider/resource_mcp_server_test.go
+++ b/internal/provider/resource_mcp_server_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -27,6 +28,122 @@ func TestBuildMCPServerRequestIncludesSkipURLValidation(t *testing.T) {
 
 	if got, ok := req["skip_url_validation"].(bool); !ok || !got {
 		t.Fatalf("expected skip_url_validation=true, got %T: %v", req["skip_url_validation"], req["skip_url_validation"])
+	}
+}
+
+func TestReadMCPServerFallsBackToCollection(t *testing.T) {
+	t.Parallel()
+
+	var collectionReads atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		if request.URL.Path == "/v1/mcp/server/server-1" {
+			writer.WriteHeader(http.StatusInternalServerError)
+			_, _ = writer.Write([]byte(`{"error":"individual read failed"}`))
+			return
+		}
+		if request.URL.Path == "/v1/mcp/server" {
+			if collectionReads.Add(1) < 3 {
+				_ = json.NewEncoder(writer).Encode([]map[string]interface{}{})
+				return
+			}
+			_ = json.NewEncoder(writer).Encode([]map[string]interface{}{
+				{
+					"server_id":         "server-1",
+					"server_name":       "test-mcp",
+					"url":               "http://mcp.internal/mcp",
+					"transport":         "http",
+					"auth_type":         "none",
+					"allow_all_keys":    true,
+					"mcp_access_groups": []interface{}{},
+					"args":              []interface{}{},
+					"env":               map[string]interface{}{},
+					"credentials":       map[string]interface{}{},
+					"allowed_tools":     []interface{}{},
+					"extra_headers":     []interface{}{},
+					"static_headers":    map[string]interface{}{},
+				},
+			})
+			return
+		}
+		http.NotFound(writer, request)
+	}))
+	defer server.Close()
+
+	resource := &MCPServerResource{client: &Client{APIBase: server.URL, APIKey: "test-key", HTTPClient: server.Client()}}
+	data := MCPServerResourceModel{
+		ID:              types.StringValue("server-1"),
+		ServerID:        types.StringValue("server-1"),
+		MCPAccessGroups: types.ListUnknown(types.StringType),
+		Args:            types.ListUnknown(types.StringType),
+		Env:             types.MapUnknown(types.StringType),
+		Credentials:     types.MapUnknown(types.StringType),
+		AllowedTools:    types.ListUnknown(types.StringType),
+		ExtraHeaders:    types.ListUnknown(types.StringType),
+		StaticHeaders:   types.MapUnknown(types.StringType),
+	}
+
+	if err := resource.readMCPServer(context.Background(), &data); err != nil {
+		t.Fatalf("readMCPServer returned error: %v", err)
+	}
+	if data.ServerName.ValueString() != "test-mcp" || data.URL.ValueString() != "http://mcp.internal/mcp" {
+		t.Fatalf("collection fallback did not populate server: %#v", data)
+	}
+	assertMCPServerCollectionsKnown(t, data)
+	if got := collectionReads.Load(); got != 3 {
+		t.Fatalf("collection reads = %d, want 3", got)
+	}
+}
+
+func TestResolveUnknownMCPServerStateAfterFailedCreate(t *testing.T) {
+	t.Parallel()
+
+	data := MCPServerResourceModel{
+		ID:              types.StringValue("server-1"),
+		ServerID:        types.StringValue("server-1"),
+		MCPAccessGroups: types.ListUnknown(types.StringType),
+		Args:            types.ListUnknown(types.StringType),
+		Env:             types.MapUnknown(types.StringType),
+		Credentials:     types.MapUnknown(types.StringType),
+		AllowedTools:    types.ListUnknown(types.StringType),
+		ExtraHeaders:    types.ListUnknown(types.StringType),
+		StaticHeaders:   types.MapUnknown(types.StringType),
+		CreatedAt:       types.StringUnknown(),
+		CreatedBy:       types.StringUnknown(),
+		MCPInfo: &MCPInfoModel{MCPServerCostInfo: &MCPServerCostInfoModel{
+			ToolNameToCostPerQuery: types.MapUnknown(types.Float64Type),
+		}},
+	}
+
+	resolveUnknownMCPServerState(&data, nil)
+	assertMCPServerCollectionsKnown(t, data)
+	if data.CreatedAt.IsUnknown() || data.CreatedBy.IsUnknown() || data.MCPInfo.MCPServerCostInfo.ToolNameToCostPerQuery.IsUnknown() {
+		t.Fatalf("failed create retained unknown computed state: %#v", data)
+	}
+}
+
+func TestResolveUnknownMCPServerStatePreservesPriorValues(t *testing.T) {
+	t.Parallel()
+
+	data := MCPServerResourceModel{
+		AllowedTools: types.ListUnknown(types.StringType),
+		CreatedAt:    types.StringUnknown(),
+	}
+	prior := MCPServerResourceModel{
+		AllowedTools: stringListValue("search"),
+		CreatedAt:    types.StringValue("2026-01-01T00:00:00Z"),
+	}
+	resolveUnknownMCPServerState(&data, &prior)
+
+	if !data.AllowedTools.Equal(prior.AllowedTools) || !data.CreatedAt.Equal(prior.CreatedAt) {
+		t.Fatalf("prior values not preserved: %#v", data)
+	}
+}
+
+func assertMCPServerCollectionsKnown(t *testing.T, data MCPServerResourceModel) {
+	t.Helper()
+	if data.MCPAccessGroups.IsUnknown() || data.Args.IsUnknown() || data.Env.IsUnknown() || data.Credentials.IsUnknown() || data.AllowedTools.IsUnknown() || data.ExtraHeaders.IsUnknown() || data.StaticHeaders.IsUnknown() {
+		t.Fatalf("MCP server retained unknown collection state: %#v", data)
 	}
 }
 

--- a/internal/provider/resource_mcp_server_test.go
+++ b/internal/provider/resource_mcp_server_test.go
@@ -39,7 +39,7 @@ func TestReadMCPServerFallsBackToCollection(t *testing.T) {
 		writer.Header().Set("Content-Type", "application/json")
 		if request.URL.Path == "/v1/mcp/server/server-1" {
 			writer.WriteHeader(http.StatusInternalServerError)
-			_, _ = writer.Write([]byte(`{"error":"individual read failed"}`))
+			_, _ = writer.Write([]byte(`{"error":"server not found after internal 404 lookup"}`))
 			return
 		}
 		if request.URL.Path == "/v1/mcp/server" {


### PR DESCRIPTION
### Summary

Closes #116. MCP server read-back now falls back to LiteLLM's collection endpoint when the individual server endpoint returns an unexpected non-404 error. The fallback retries boundedly for collection propagation and selects only the exact `server_id`.

If all read paths fail after LiteLLM has accepted a Create or Update, the provider resolves every remaining unknown to a typed known value. Create retains a recoverable ID-bearing state with a warning; Update preserves prior known computed values. This prevents the cascade of invalid-result errors reported in the issue. Create also rejects a successful-looking API response that lacks the required `server_id`.

### Validation

The exact Kubernetes-internal URL configuration from the issue creates, updates in place, and plans cleanly on LiteLLM v1.98.0, indicating the original individual-endpoint 500 was fixed upstream. Fault-injection validation forced the individual GET to 500: collection fallback created successfully and produced a clean plan without warnings. With both individual and collection GETs forced to 500, Create still exited successfully with a warning and recoverable ID state, emitted no unknown/value-conversion errors, the next plan returned an explicit read error, and refresh-free destroy succeeded. Focused fallback/state tests, `go vet`, full tests, race tests, and the 23-resource real-dev lifecycle suite pass.

### Diff size

**Docs** — 2 files · `+3 / -0`

Documents MCP read recovery and records the Unreleased fix.

**Implementation** — 2 files · `+175 / -10`

Adds bounded collection fallback, exact ID lookup, typed unknown resolution, prior-state preservation, create-response validation, and status-aware API errors so MCP state handling treats only actual HTTP 404 responses as absence while preserving compatibility for other LiteLLM endpoints.

**Tests** — 2 files · `+127 / -0`

Covers eventual collection propagation, misleading 500 response bodies, strict 404 classification, failed-create unknown resolution, nested computed state, and Update prior-value preservation.
