### PR TITLE
fix(user): safely adopt exact existing accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`litellm_guardrail`**: Ignore nested null defaults that LiteLLM adds to configured `litellm_params` objects while retaining explicit nulls and real nested drift. ([#125](https://github.com/ncecere/terraform-provider-litellm/issues/125))
 - **`litellm_key`**: Mark `metadata` sensitive and preserve configured nested secret leaves when LiteLLM reads them back as encrypted values, while continuing to expose unmasked metadata drift. ([#115](https://github.com/ncecere/terraform-provider-litellm/issues/115))
 - **`litellm_mcp_server`**: Fall back to the MCP collection endpoint when individual read-back fails and resolve computed unknowns after successful mutations so backend read errors remain recoverable. ([#116](https://github.com/ncecere/terraform-provider-litellm/issues/116))
+- **`litellm_user`**: Safely adopt an existing exact-email account after an HTTP 409, verify any configured ID, converge managed fields and team membership, and avoid generating an unrecoverable key. ([#117](https://github.com/ncecere/terraform-provider-litellm/issues/117))
 
 ## [2.0.1] - 2026-06-12
 

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -57,7 +57,7 @@ The following arguments are supported:
 In addition to the arguments above, the following attributes are exported:
 
 * `id` - The unique identifier of the user (same as `user_id`).
-* `key` - (Sensitive) The API key generated for the user. Only populated when `auto_create_key` is `true`.
+* `key` - (Sensitive) The API key generated for a newly created user. It is not available when adopting or importing an existing user because LiteLLM cannot return existing raw keys.
 
 The following attributes are both Optional and Computed (they are read back from the API if not explicitly set):
 
@@ -77,8 +77,14 @@ terraform import litellm_user.example <user-id>
 
 ~> **Note:** The `key` attribute will not be populated after import, as API keys cannot be retrieved from the LiteLLM API after creation.
 
+## Adopting an Existing User
+
+If `/user/new` returns HTTP 409, the provider can adopt an existing user when `user_email` is known and `/user/list` returns exactly one account with that exact email. If `user_id` is configured, it must also match the existing account. Partial, missing, ambiguous, or conflicting identity matches fail without updating the account.
+
+After identity verification, configured user fields and team memberships are reconciled. Adoption does not request another auto-created key because its raw value could not be recovered into Terraform state. Once adopted, Terraform owns the user: destroying the resource deletes the existing LiteLLM user.
+
 ## Notes
 
-- The `user_email` attribute is **not** required.
+- The `user_email` attribute is **not** required for a new user, but it is required for safe automatic adoption after a conflict.
 - The `user_id` attribute is ForceNew — changing it will destroy and recreate the resource.
-- When `auto_create_key` is `true` (the default), a `key` is generated on creation and stored in state.
+- When `auto_create_key` is `true` (the default), a `key` is generated and stored in state only when LiteLLM creates a new user.

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -81,7 +81,7 @@ terraform import litellm_user.example <user-id>
 
 If `/user/new` returns HTTP 409, the provider can adopt an existing user when `user_email` is known and `/user/list` returns exactly one account with that exact email. If `user_id` is configured, it must also match the existing account. Partial, missing, ambiguous, or conflicting identity matches fail without updating the account.
 
-After identity verification, configured user fields and team memberships are reconciled. Adoption does not request another auto-created key because its raw value could not be recovered into Terraform state. Once adopted, Terraform owns the user: destroying the resource deletes the existing LiteLLM user.
+After identity verification, configured user fields and team memberships are reconciled. Adoption fails before mutation if configuration would require clearing a non-empty alias, models list, or metadata map because LiteLLM ignores empty values for those fields. Adoption does not request another auto-created key because its raw value could not be recovered into Terraform state. Removing an existing team membership calls LiteLLM's `/team/member_delete`, which also deletes that user's keys scoped to the removed team. Once adopted, Terraform owns the user: destroying the resource deletes the existing LiteLLM user.
 
 ## Notes
 

--- a/internal/provider/resource_user.go
+++ b/internal/provider/resource_user.go
@@ -179,7 +179,11 @@ func (r *UserResource) Create(ctx context.Context, req resource.CreateRequest, r
 	var result map[string]interface{}
 	if err := r.client.DoRequestWithResponse(ctx, "POST", "/user/new", userReq, &result); err != nil {
 		if IsAPIErrorStatus(err, 409) {
-			if adoptErr := r.adoptExistingUser(ctx, &data); adoptErr != nil {
+			mutated, adoptErr := r.adoptExistingUser(ctx, &data)
+			if adoptErr != nil {
+				if mutated {
+					resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+				}
 				resp.Diagnostics.AddError("User Adoption Error", fmt.Sprintf("LiteLLM reported that the user already exists, but the provider could not safely adopt an exact matching account: %s", adoptErr))
 				return
 			}
@@ -349,30 +353,64 @@ func (r *UserResource) findExistingUserByExactEmail(ctx context.Context, email s
 	return "", fmt.Errorf("exact user lookup returned no usable user ID")
 }
 
-func (r *UserResource) adoptExistingUser(ctx context.Context, data *UserResourceModel) error {
+func (r *UserResource) adoptExistingUser(ctx context.Context, data *UserResourceModel) (bool, error) {
 	if data.UserEmail.IsNull() || data.UserEmail.IsUnknown() || data.UserEmail.ValueString() == "" {
-		return fmt.Errorf("user_email must be known and non-empty")
+		return false, fmt.Errorf("user_email must be known and non-empty")
 	}
 	planned := *data
 	email := planned.UserEmail.ValueString()
 	userID, err := r.findExistingUserByExactEmail(ctx, email)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if !planned.UserID.IsNull() && !planned.UserID.IsUnknown() && planned.UserID.ValueString() != "" && planned.UserID.ValueString() != userID {
-		return fmt.Errorf("the exact email match has user_id %q, not the configured user_id %q", userID, planned.UserID.ValueString())
+		return false, fmt.Errorf("the exact email match has user_id %q, not the configured user_id %q", userID, planned.UserID.ValueString())
 	}
 
+	// Clear the pre-seeded identity fields so verification only succeeds when
+	// /user/info explicitly returns both values.
 	current := planned
 	current.ID = types.StringValue(userID)
-	current.UserID = types.StringValue(userID)
+	current.UserID = types.StringNull()
+	current.UserEmail = types.StringNull()
 	current.Key = types.StringNull()
 	if err := r.readUser(ctx, &current); err != nil {
-		return fmt.Errorf("unable to verify the existing user: %w", err)
+		return false, fmt.Errorf("unable to verify the existing user: %w", err)
 	}
-	if current.UserID.ValueString() != userID || current.UserEmail.ValueString() != email {
-		return fmt.Errorf("the user identity changed during verification")
+	if current.UserID.IsNull() || current.UserID.IsUnknown() || current.UserEmail.IsNull() || current.UserEmail.IsUnknown() || current.UserID.ValueString() != userID || current.UserEmail.ValueString() != email {
+		return false, fmt.Errorf("the user identity was missing or changed during verification")
 	}
+	if !planned.UserAlias.IsNull() && !planned.UserAlias.IsUnknown() && planned.UserAlias.ValueString() == "" && !current.UserAlias.IsNull() && current.UserAlias.ValueString() != "" {
+		return false, fmt.Errorf("LiteLLM cannot clear the existing user_alias during adoption")
+	}
+	if !planned.Models.IsNull() && !planned.Models.IsUnknown() && len(planned.Models.Elements()) == 0 && !current.Models.IsNull() && !current.Models.IsUnknown() && len(current.Models.Elements()) > 0 {
+		return false, fmt.Errorf("LiteLLM cannot clear the existing models list during adoption")
+	}
+	if !planned.Metadata.IsNull() && !planned.Metadata.IsUnknown() && len(planned.Metadata.Elements()) == 0 && !current.Metadata.IsNull() && !current.Metadata.IsUnknown() && len(current.Metadata.Elements()) > 0 {
+		return false, fmt.Errorf("LiteLLM cannot clear the existing metadata map during adoption")
+	}
+
+	prepareRecoverableState := func(refresh bool) {
+		*data = planned
+		data.ID = types.StringValue(userID)
+		data.UserID = types.StringValue(userID)
+		data.Key = types.StringNull()
+		if refresh {
+			if err := r.readUser(ctx, data); err == nil {
+				return
+			}
+		}
+		if data.Teams.IsUnknown() {
+			data.Teams = current.Teams
+		}
+		if data.Models.IsUnknown() {
+			data.Models = current.Models
+		}
+		if data.Metadata.IsUnknown() {
+			data.Metadata = current.Metadata
+		}
+	}
+	prepareRecoverableState(false)
 
 	updateRequest := r.buildUserRequest(ctx, &planned)
 	updateRequest["user_id"] = userID
@@ -381,31 +419,29 @@ func (r *UserResource) adoptExistingUser(ctx context.Context, data *UserResource
 	// key while adopting an account whose existing raw keys cannot be read back.
 	delete(updateRequest, "auto_create_key")
 	if err := r.client.DoRequestWithResponse(ctx, "POST", "/user/update", updateRequest, nil); err != nil {
-		return fmt.Errorf("unable to converge the existing user: %w", err)
+		prepareRecoverableState(true)
+		return true, fmt.Errorf("unable to converge the existing user: %w", err)
 	}
 
 	teamsChanged := userTeamMembershipsDiffer(current.Teams, planned.Teams)
 	if teamsChanged {
 		if err := r.reconcileUserTeams(ctx, userID, current.Teams, planned.Teams); err != nil {
-			return fmt.Errorf("unable to converge existing user team membership: %w", err)
+			prepareRecoverableState(true)
+			return true, fmt.Errorf("unable to converge existing user team membership: %w", err)
 		}
 	}
 
-	*data = planned
-	data.ID = types.StringValue(userID)
-	data.UserID = types.StringValue(userID)
-	data.Key = types.StringNull()
+	prepareRecoverableState(false)
 	if teamsChanged {
 		if err := r.readUserTeamsAfterUpdate(ctx, data, 8); err != nil {
-			return fmt.Errorf("existing user team membership did not converge: %w", err)
+			prepareRecoverableState(true)
+			return true, fmt.Errorf("existing user team membership did not converge: %w", err)
 		}
 	} else if err := r.readUser(ctx, data); err != nil {
-		return fmt.Errorf("unable to read the adopted user: %w", err)
+		prepareRecoverableState(false)
+		return true, fmt.Errorf("unable to read the adopted user: %w", err)
 	}
-	if planned.UserAlias.IsNull() {
-		data.UserAlias = planned.UserAlias
-	}
-	return nil
+	return true, nil
 }
 
 func (r *UserResource) buildUserRequest(ctx context.Context, data *UserResourceModel) map[string]interface{} {
@@ -456,18 +492,15 @@ func (r *UserResource) buildUserRequest(ctx context.Context, data *UserResourceM
 	if !data.Models.IsNull() && !data.Models.IsUnknown() {
 		var models []string
 		data.Models.ElementsAs(ctx, &models, false)
-		if len(models) > 0 {
-			userReq["models"] = models
-		}
+		userReq["models"] = models
 	}
 
-	// Map fields - check IsNull, IsUnknown, and len > 0
+	// Send explicitly configured empty metadata so existing values can be
+	// cleared during Update or adoption.
 	if !data.Metadata.IsNull() && !data.Metadata.IsUnknown() {
 		var metadata map[string]string
 		data.Metadata.ElementsAs(ctx, &metadata, false)
-		if len(metadata) > 0 {
-			userReq["metadata"] = metadata
-		}
+		userReq["metadata"] = metadata
 	}
 
 	return userReq
@@ -497,7 +530,7 @@ func (r *UserResource) readUser(ctx context.Context, data *UserResourceModel) er
 		data.UserID = types.StringValue(userID)
 		data.ID = types.StringValue(userID)
 	}
-	if alias, ok := userInfo["user_alias"].(string); ok {
+	if alias, ok := userInfo["user_alias"].(string); ok && !data.UserAlias.IsNull() {
 		data.UserAlias = types.StringValue(alias)
 	}
 	if email, ok := userInfo["user_email"].(string); ok {

--- a/internal/provider/resource_user.go
+++ b/internal/provider/resource_user.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"sort"
 	"time"
 
@@ -177,6 +178,14 @@ func (r *UserResource) Create(ctx context.Context, req resource.CreateRequest, r
 
 	var result map[string]interface{}
 	if err := r.client.DoRequestWithResponse(ctx, "POST", "/user/new", userReq, &result); err != nil {
+		if IsAPIErrorStatus(err, 409) {
+			if adoptErr := r.adoptExistingUser(ctx, &data); adoptErr != nil {
+				resp.Diagnostics.AddError("User Adoption Error", fmt.Sprintf("LiteLLM reported that the user already exists, but the provider could not safely adopt an exact matching account: %s", adoptErr))
+				return
+			}
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+			return
+		}
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create user: %s", err))
 		return
 	}
@@ -290,6 +299,113 @@ func (r *UserResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 func (r *UserResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("user_id"), req.ID)...)
+}
+
+type userListResponse struct {
+	Users      []map[string]interface{} `json:"users"`
+	TotalPages int                      `json:"total_pages"`
+}
+
+func (r *UserResource) findExistingUserByExactEmail(ctx context.Context, email string) (string, error) {
+	if email == "" {
+		return "", fmt.Errorf("user_email must be configured to adopt an existing user")
+	}
+
+	matches := make(map[string]struct{})
+	totalPages := 1
+	for page := 1; page <= totalPages; page++ {
+		if page > 100 {
+			return "", fmt.Errorf("user lookup exceeded 100 pages")
+		}
+		endpoint := fmt.Sprintf("/user/list?user_email=%s&page=%d&page_size=100", url.QueryEscape(email), page)
+		var response userListResponse
+		if err := r.client.DoRequestWithResponse(ctx, "GET", endpoint, nil, &response); err != nil {
+			return "", fmt.Errorf("unable to list users by email: %w", err)
+		}
+		if response.TotalPages > totalPages {
+			totalPages = response.TotalPages
+		}
+		if totalPages > 100 {
+			return "", fmt.Errorf("user lookup returned %d pages, exceeding the safe lookup limit", totalPages)
+		}
+		for _, user := range response.Users {
+			candidateEmail, emailOK := user["user_email"].(string)
+			candidateID, idOK := user["user_id"].(string)
+			if emailOK && candidateEmail == email && idOK && candidateID != "" {
+				matches[candidateID] = struct{}{}
+			}
+		}
+	}
+
+	if len(matches) == 0 {
+		return "", fmt.Errorf("no user with the exact email %q was returned by /user/list", email)
+	}
+	if len(matches) > 1 {
+		return "", fmt.Errorf("multiple user IDs matched the exact email %q", email)
+	}
+	for userID := range matches {
+		return userID, nil
+	}
+	return "", fmt.Errorf("exact user lookup returned no usable user ID")
+}
+
+func (r *UserResource) adoptExistingUser(ctx context.Context, data *UserResourceModel) error {
+	if data.UserEmail.IsNull() || data.UserEmail.IsUnknown() || data.UserEmail.ValueString() == "" {
+		return fmt.Errorf("user_email must be known and non-empty")
+	}
+	planned := *data
+	email := planned.UserEmail.ValueString()
+	userID, err := r.findExistingUserByExactEmail(ctx, email)
+	if err != nil {
+		return err
+	}
+	if !planned.UserID.IsNull() && !planned.UserID.IsUnknown() && planned.UserID.ValueString() != "" && planned.UserID.ValueString() != userID {
+		return fmt.Errorf("the exact email match has user_id %q, not the configured user_id %q", userID, planned.UserID.ValueString())
+	}
+
+	current := planned
+	current.ID = types.StringValue(userID)
+	current.UserID = types.StringValue(userID)
+	current.Key = types.StringNull()
+	if err := r.readUser(ctx, &current); err != nil {
+		return fmt.Errorf("unable to verify the existing user: %w", err)
+	}
+	if current.UserID.ValueString() != userID || current.UserEmail.ValueString() != email {
+		return fmt.Errorf("the user identity changed during verification")
+	}
+
+	updateRequest := r.buildUserRequest(ctx, &planned)
+	updateRequest["user_id"] = userID
+	delete(updateRequest, "teams")
+	// auto_create_key is a Create action. Do not generate an inaccessible new
+	// key while adopting an account whose existing raw keys cannot be read back.
+	delete(updateRequest, "auto_create_key")
+	if err := r.client.DoRequestWithResponse(ctx, "POST", "/user/update", updateRequest, nil); err != nil {
+		return fmt.Errorf("unable to converge the existing user: %w", err)
+	}
+
+	teamsChanged := userTeamMembershipsDiffer(current.Teams, planned.Teams)
+	if teamsChanged {
+		if err := r.reconcileUserTeams(ctx, userID, current.Teams, planned.Teams); err != nil {
+			return fmt.Errorf("unable to converge existing user team membership: %w", err)
+		}
+	}
+
+	*data = planned
+	data.ID = types.StringValue(userID)
+	data.UserID = types.StringValue(userID)
+	data.Key = types.StringNull()
+	if teamsChanged {
+		if err := r.readUserTeamsAfterUpdate(ctx, data, 8); err != nil {
+			return fmt.Errorf("existing user team membership did not converge: %w", err)
+		}
+	} else if err := r.readUser(ctx, data); err != nil {
+		return fmt.Errorf("unable to read the adopted user: %w", err)
+	}
+	if planned.UserAlias.IsNull() {
+		data.UserAlias = planned.UserAlias
+	}
+	return nil
 }
 
 func (r *UserResource) buildUserRequest(ctx context.Context, data *UserResourceModel) map[string]interface{} {

--- a/internal/provider/resource_user_test.go
+++ b/internal/provider/resource_user_test.go
@@ -16,6 +16,199 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
+func TestFindExistingUserByExactEmailPaginatesAndIgnoresPartialMatches(t *testing.T) {
+	t.Parallel()
+
+	const email = "exact+tag@example.com"
+	var pages atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/user/list" || request.URL.Query().Get("user_email") != email || request.URL.Query().Get("page_size") != "100" {
+			http.Error(writer, "unexpected request", http.StatusBadRequest)
+			return
+		}
+		page := request.URL.Query().Get("page")
+		pages.Add(1)
+		writer.Header().Set("Content-Type", "application/json")
+		if page == "1" {
+			_ = json.NewEncoder(writer).Encode(map[string]interface{}{
+				"users":       []interface{}{map[string]interface{}{"user_id": "partial", "user_email": "prefix-" + email}},
+				"total_pages": 2,
+			})
+			return
+		}
+		_ = json.NewEncoder(writer).Encode(map[string]interface{}{
+			"users":       []interface{}{map[string]interface{}{"user_id": "exact-id", "user_email": email}},
+			"total_pages": 2,
+		})
+	}))
+	defer server.Close()
+
+	resource := &UserResource{client: &Client{APIBase: server.URL, APIKey: "test-key", HTTPClient: server.Client()}}
+	userID, err := resource.findExistingUserByExactEmail(context.Background(), email)
+	if err != nil {
+		t.Fatalf("findExistingUserByExactEmail returned error: %v", err)
+	}
+	if userID != "exact-id" || pages.Load() != 2 {
+		t.Fatalf("user_id = %q, pages = %d", userID, pages.Load())
+	}
+}
+
+func TestFindExistingUserByExactEmailRejectsPartialOnly(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(writer).Encode(map[string]interface{}{
+			"users":       []interface{}{map[string]interface{}{"user_id": "partial", "user_email": "prefix-target@example.com"}},
+			"total_pages": 1,
+		})
+	}))
+	defer server.Close()
+
+	resource := &UserResource{client: &Client{APIBase: server.URL, APIKey: "test-key", HTTPClient: server.Client()}}
+	if _, err := resource.findExistingUserByExactEmail(context.Background(), "target@example.com"); err == nil {
+		t.Fatal("partial-only email match was accepted")
+	}
+}
+
+func TestFindExistingUserByExactEmailRejectsAmbiguousMatches(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(writer).Encode(map[string]interface{}{
+			"users": []interface{}{
+				map[string]interface{}{"user_id": "user-a", "user_email": "same@example.com"},
+				map[string]interface{}{"user_id": "user-b", "user_email": "same@example.com"},
+			},
+			"total_pages": 1,
+		})
+	}))
+	defer server.Close()
+
+	resource := &UserResource{client: &Client{APIBase: server.URL, APIKey: "test-key", HTTPClient: server.Client()}}
+	if _, err := resource.findExistingUserByExactEmail(context.Background(), "same@example.com"); err == nil {
+		t.Fatal("ambiguous exact matches were accepted")
+	}
+}
+
+func TestAdoptExistingUserVerifiesAndConvergesWithoutCreatingKey(t *testing.T) {
+	t.Parallel()
+
+	var updated atomic.Bool
+	var membershipUpdated atomic.Bool
+	var memberAdds atomic.Int32
+	var memberDeletes atomic.Int32
+	var updateBody map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		switch {
+		case request.Method == http.MethodGet && request.URL.Path == "/user/list":
+			_ = json.NewEncoder(writer).Encode(map[string]interface{}{
+				"users":       []interface{}{map[string]interface{}{"user_id": "existing-id", "user_email": "existing@example.com"}},
+				"total_pages": 1,
+			})
+		case request.Method == http.MethodGet && request.URL.Path == "/user/info":
+			alias := "old-alias"
+			role := "internal_user"
+			teams := []interface{}{"team-a"}
+			if updated.Load() {
+				alias = "managed-alias"
+				role = "internal_user_viewer"
+			}
+			if membershipUpdated.Load() {
+				teams = []interface{}{"team-b"}
+			}
+			_ = json.NewEncoder(writer).Encode(map[string]interface{}{"user_info": map[string]interface{}{
+				"user_id": "existing-id", "user_email": "existing@example.com", "user_alias": alias,
+				"user_role": role, "teams": teams, "models": []interface{}{}, "metadata": map[string]interface{}{},
+			}})
+		case request.Method == http.MethodPost && request.URL.Path == "/user/update":
+			if err := json.NewDecoder(request.Body).Decode(&updateBody); err != nil {
+				t.Errorf("decode update body: %v", err)
+			}
+			updated.Store(true)
+			_ = json.NewEncoder(writer).Encode(map[string]interface{}{"status": "ok"})
+		case request.Method == http.MethodPost && request.URL.Path == "/team/member_add":
+			memberAdds.Add(1)
+			_ = json.NewEncoder(writer).Encode(map[string]interface{}{"status": "ok"})
+		case request.Method == http.MethodPost && request.URL.Path == "/team/member_delete":
+			memberDeletes.Add(1)
+			membershipUpdated.Store(true)
+			_ = json.NewEncoder(writer).Encode(map[string]interface{}{"status": "ok"})
+		default:
+			http.Error(writer, "unexpected request", http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+
+	resource := &UserResource{client: &Client{APIBase: server.URL, APIKey: "test-key", HTTPClient: server.Client()}}
+	data := UserResourceModel{
+		UserID:        types.StringUnknown(),
+		UserEmail:     types.StringValue("existing@example.com"),
+		UserAlias:     types.StringValue("managed-alias"),
+		UserRole:      types.StringValue("internal_user_viewer"),
+		AutoCreateKey: types.BoolValue(true),
+		Teams:         stringListValue("team-b"),
+		Models:        types.ListNull(types.StringType),
+		Metadata:      types.MapNull(types.StringType),
+		Key:           types.StringUnknown(),
+	}
+
+	if err := resource.adoptExistingUser(context.Background(), &data); err != nil {
+		t.Fatalf("adoptExistingUser returned error: %v", err)
+	}
+	if data.ID.ValueString() != "existing-id" || data.UserID.ValueString() != "existing-id" || data.UserAlias.ValueString() != "managed-alias" {
+		t.Fatalf("unexpected adopted state: %#v", data)
+	}
+	if !data.Key.IsNull() {
+		t.Fatalf("adoption exposed an unexpected key: %v", data.Key)
+	}
+	if updateBody["user_id"] != "existing-id" || updateBody["user_email"] != "existing@example.com" || updateBody["user_alias"] != "managed-alias" {
+		t.Fatalf("unexpected update request: %#v", updateBody)
+	}
+	if _, exists := updateBody["auto_create_key"]; exists {
+		t.Fatalf("adoption update requested an inaccessible key: %#v", updateBody)
+	}
+	if _, exists := updateBody["teams"]; exists {
+		t.Fatalf("adoption sent teams through /user/update: %#v", updateBody)
+	}
+	if memberAdds.Load() != 1 || memberDeletes.Load() != 1 || !userTeamMembershipEqual(data.Teams, []string{"team-b"}) {
+		t.Fatalf("team membership did not converge: adds=%d deletes=%d teams=%v", memberAdds.Load(), memberDeletes.Load(), data.Teams)
+	}
+}
+
+func TestAdoptExistingUserRequiresKnownEmail(t *testing.T) {
+	t.Parallel()
+
+	resource := &UserResource{}
+	for _, email := range []types.String{types.StringNull(), types.StringUnknown(), types.StringValue("")} {
+		data := UserResourceModel{UserEmail: email}
+		if err := resource.adoptExistingUser(context.Background(), &data); err == nil {
+			t.Fatalf("unsafe email %v was accepted for adoption", email)
+		}
+	}
+}
+
+func TestAdoptExistingUserRejectsConfiguredIDMismatch(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(writer).Encode(map[string]interface{}{
+			"users":       []interface{}{map[string]interface{}{"user_id": "existing-id", "user_email": "existing@example.com"}},
+			"total_pages": 1,
+		})
+	}))
+	defer server.Close()
+
+	resource := &UserResource{client: &Client{APIBase: server.URL, APIKey: "test-key", HTTPClient: server.Client()}}
+	data := UserResourceModel{UserID: types.StringValue("different-id"), UserEmail: types.StringValue("existing@example.com")}
+	if err := resource.adoptExistingUser(context.Background(), &data); err == nil {
+		t.Fatal("configured user_id mismatch was accepted")
+	}
+}
+
 func TestReadUserDoesNotSetAPIInjectedDefaultsWhenUnconfigured(t *testing.T) {
 	t.Parallel()
 

--- a/internal/provider/resource_user_test.go
+++ b/internal/provider/resource_user_test.go
@@ -155,8 +155,12 @@ func TestAdoptExistingUserVerifiesAndConvergesWithoutCreatingKey(t *testing.T) {
 		Key:           types.StringUnknown(),
 	}
 
-	if err := resource.adoptExistingUser(context.Background(), &data); err != nil {
+	mutated, err := resource.adoptExistingUser(context.Background(), &data)
+	if err != nil {
 		t.Fatalf("adoptExistingUser returned error: %v", err)
+	}
+	if !mutated {
+		t.Fatal("successful adoption did not report mutation")
 	}
 	if data.ID.ValueString() != "existing-id" || data.UserID.ValueString() != "existing-id" || data.UserAlias.ValueString() != "managed-alias" {
 		t.Fatalf("unexpected adopted state: %#v", data)
@@ -178,13 +182,53 @@ func TestAdoptExistingUserVerifiesAndConvergesWithoutCreatingKey(t *testing.T) {
 	}
 }
 
+func TestAdoptExistingUserRejectsMissingVerifiedIdentity(t *testing.T) {
+	t.Parallel()
+
+	for _, omitted := range []string{"user_id", "user_email"} {
+		omitted := omitted
+		t.Run(omitted, func(t *testing.T) {
+			t.Parallel()
+			var updates atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				writer.Header().Set("Content-Type", "application/json")
+				if request.URL.Path == "/user/list" {
+					_ = json.NewEncoder(writer).Encode(map[string]interface{}{
+						"users":       []interface{}{map[string]interface{}{"user_id": "existing-id", "user_email": "existing@example.com"}},
+						"total_pages": 1,
+					})
+					return
+				}
+				if request.URL.Path == "/user/info" {
+					identity := map[string]interface{}{"user_id": "existing-id", "user_email": "existing@example.com"}
+					delete(identity, omitted)
+					_ = json.NewEncoder(writer).Encode(map[string]interface{}{"user_info": identity})
+					return
+				}
+				updates.Add(1)
+				http.Error(writer, "unexpected mutation", http.StatusInternalServerError)
+			}))
+			defer server.Close()
+
+			resource := &UserResource{client: &Client{APIBase: server.URL, APIKey: "test-key", HTTPClient: server.Client()}}
+			data := UserResourceModel{UserEmail: types.StringValue("existing@example.com")}
+			if mutated, err := resource.adoptExistingUser(context.Background(), &data); err == nil || mutated {
+				t.Fatalf("missing %s was accepted: mutated=%v err=%v", omitted, mutated, err)
+			}
+			if updates.Load() != 0 {
+				t.Fatalf("missing %s triggered mutation", omitted)
+			}
+		})
+	}
+}
+
 func TestAdoptExistingUserRequiresKnownEmail(t *testing.T) {
 	t.Parallel()
 
 	resource := &UserResource{}
 	for _, email := range []types.String{types.StringNull(), types.StringUnknown(), types.StringValue("")} {
 		data := UserResourceModel{UserEmail: email}
-		if err := resource.adoptExistingUser(context.Background(), &data); err == nil {
+		if mutated, err := resource.adoptExistingUser(context.Background(), &data); err == nil || mutated {
 			t.Fatalf("unsafe email %v was accepted for adoption", email)
 		}
 	}
@@ -204,8 +248,106 @@ func TestAdoptExistingUserRejectsConfiguredIDMismatch(t *testing.T) {
 
 	resource := &UserResource{client: &Client{APIBase: server.URL, APIKey: "test-key", HTTPClient: server.Client()}}
 	data := UserResourceModel{UserID: types.StringValue("different-id"), UserEmail: types.StringValue("existing@example.com")}
-	if err := resource.adoptExistingUser(context.Background(), &data); err == nil {
+	if mutated, err := resource.adoptExistingUser(context.Background(), &data); err == nil || mutated {
 		t.Fatal("configured user_id mismatch was accepted")
+	}
+}
+
+func TestAdoptExistingUserRejectsUnsupportedEmptyClearsBeforeMutation(t *testing.T) {
+	t.Parallel()
+
+	var mutations atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		switch request.URL.Path {
+		case "/user/list":
+			_ = json.NewEncoder(writer).Encode(map[string]interface{}{
+				"users":       []interface{}{map[string]interface{}{"user_id": "existing-id", "user_email": "existing@example.com"}},
+				"total_pages": 1,
+			})
+		case "/user/info":
+			_ = json.NewEncoder(writer).Encode(map[string]interface{}{"user_info": map[string]interface{}{
+				"user_id": "existing-id", "user_email": "existing@example.com", "user_alias": "existing-alias",
+				"models": []interface{}{"legacy"}, "metadata": map[string]interface{}{"owner": "external"},
+			}})
+		default:
+			mutations.Add(1)
+			http.Error(writer, "unexpected mutation", http.StatusInternalServerError)
+		}
+	}))
+	defer server.Close()
+
+	resource := &UserResource{client: &Client{APIBase: server.URL, APIKey: "test-key", HTTPClient: server.Client()}}
+	data := UserResourceModel{
+		UserEmail: types.StringValue("existing@example.com"),
+		Models:    stringListValue(),
+		Metadata:  types.MapValueMust(types.StringType, map[string]attr.Value{}),
+	}
+	mutated, err := resource.adoptExistingUser(context.Background(), &data)
+	if err == nil || mutated || mutations.Load() != 0 {
+		t.Fatalf("unsupported clear was not rejected safely: mutated=%v requests=%d err=%v", mutated, mutations.Load(), err)
+	}
+}
+
+func TestAdoptExistingUserFailureAfterMutationKeepsRecoverableState(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		switch request.URL.Path {
+		case "/user/list":
+			_ = json.NewEncoder(writer).Encode(map[string]interface{}{
+				"users":       []interface{}{map[string]interface{}{"user_id": "existing-id", "user_email": "existing@example.com"}},
+				"total_pages": 1,
+			})
+		case "/user/info":
+			_ = json.NewEncoder(writer).Encode(map[string]interface{}{"user_info": map[string]interface{}{
+				"user_id": "existing-id", "user_email": "existing@example.com", "teams": []interface{}{"team-a"},
+				"models": []interface{}{}, "metadata": map[string]interface{}{},
+			}})
+		case "/user/update":
+			_ = json.NewEncoder(writer).Encode(map[string]interface{}{"status": "ok"})
+		case "/team/member_add":
+			http.Error(writer, "injected membership failure", http.StatusInternalServerError)
+		default:
+			http.Error(writer, "unexpected request", http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+
+	resource := &UserResource{client: &Client{APIBase: server.URL, APIKey: "test-key", HTTPClient: server.Client()}}
+	data := UserResourceModel{
+		UserEmail: types.StringValue("existing@example.com"),
+		Teams:     stringListValue("team-b"),
+		Models:    types.ListUnknown(types.StringType),
+		Metadata:  types.MapUnknown(types.StringType),
+		Key:       types.StringUnknown(),
+	}
+	mutated, err := resource.adoptExistingUser(context.Background(), &data)
+	if err == nil || !mutated {
+		t.Fatalf("post-mutation failure = mutated %v, error %v", mutated, err)
+	}
+	if data.ID.ValueString() != "existing-id" || data.UserID.ValueString() != "existing-id" || !data.Key.IsNull() {
+		t.Fatalf("failure did not retain recoverable identity state: %#v", data)
+	}
+	if data.Models.IsUnknown() || data.Metadata.IsUnknown() || data.Teams.IsUnknown() {
+		t.Fatalf("failure retained unknown state: %#v", data)
+	}
+}
+
+func TestBuildUserRequestIncludesExplicitEmptyCollections(t *testing.T) {
+	t.Parallel()
+
+	resource := &UserResource{}
+	data := UserResourceModel{
+		Models:   stringListValue(),
+		Metadata: types.MapValueMust(types.StringType, map[string]attr.Value{}),
+	}
+	request := resource.buildUserRequest(context.Background(), &data)
+	models, modelsOK := request["models"].([]string)
+	metadata, metadataOK := request["metadata"].(map[string]string)
+	if !modelsOK || len(models) != 0 || !metadataOK || len(metadata) != 0 {
+		t.Fatalf("explicit empty collections were omitted: %#v", request)
 	}
 }
 
@@ -254,6 +396,9 @@ func TestReadUserDoesNotSetAPIInjectedDefaultsWhenUnconfigured(t *testing.T) {
 		t.Fatalf("readUser returned error: %v", err)
 	}
 
+	if !data.UserAlias.IsNull() {
+		t.Fatalf("user_alias should remain null when unconfigured, got %q", data.UserAlias.ValueString())
+	}
 	if !data.UserRole.IsNull() {
 		t.Fatalf("user_role should remain null when unconfigured, got %q", data.UserRole.ValueString())
 	}


### PR DESCRIPTION
### Summary

Closes #117. When `/user/new` returns HTTP 409, `litellm_user` can now safely adopt an account that LiteLLM previously created through SSO, UI, or another workflow.

Adoption requires a known email and an exact, unique `/user/list` match across bounded pagination. Partial, missing, or ambiguous matches fail. A configured `user_id` must match, and `/user/info` must explicitly return the same ID and email before mutation. Configured fields and team membership are then reconciled. Teams continue through dedicated add-before-delete endpoints; `auto_create_key` is deliberately omitted because an existing raw key cannot be recovered into state, and the computed key resolves to null. Unsupported empty-value clears fail before mutation, while failures after mutation retain recoverable ID-bearing state.

### Validation

Live v1.98.0 validation precreated an external user and confirmed Terraform adopted the same ID, converged alias/role/budget/metadata, retained a null key, and planned cleanly. A conflicting explicit ID failed without mutation. Real out-of-band alias drift remained visible and was restored. A separate adoption replaced team A with team B and planned cleanly. An unmanaged external alias stayed null through subsequent reads. Unsupported empty clears failed before mutation with the remote account unchanged. An alias update followed by an injected invalid-team failure retained the adopted ID in state and supported recovery through destroy. The ordinary new-user path still generated a key and planned cleanly. Focused identity/adoption/team/recovery tests, `go vet`, full tests, race tests, and the 23-resource real-dev lifecycle suite pass.

### Diff size

**Docs** — 2 files · `+10 / -3`

Documents safe adoption, key behavior, Terraform ownership/destruction, and the Unreleased fix.

**Implementation** — 1 file · `+157 / -8`

Adds exact paginated lookup, explicit identity verification, conflict adoption, safe update behavior, unsupported-clear preflight, recoverable partial-failure state, owned alias reads, and team reconciliation.

**Tests** — 1 file · `+338 / -0`

Covers pagination, partial and ambiguous matches, missing identity fields, ID mismatch, unsupported clears, partial-failure recovery, explicit empties, update side effects, key handling, alias ownership, and team convergence.
