### PR TITLE
feat: add write-only LiteLLM key input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`litellm_key`**: Mark `metadata` sensitive and preserve configured nested secret leaves when LiteLLM reads them back as encrypted values, while continuing to expose unmasked metadata drift. ([#115](https://github.com/ncecere/terraform-provider-litellm/issues/115))
 - **`litellm_mcp_server`**: Fall back to the MCP collection endpoint when individual read-back fails and resolve computed unknowns after successful mutations so backend read errors remain recoverable. ([#116](https://github.com/ncecere/terraform-provider-litellm/issues/116))
 - **`litellm_user`**: Safely adopt an existing exact-email account after an HTTP 409, verify any configured ID, converge managed fields and team membership, and avoid generating an unrecoverable key. ([#117](https://github.com/ncecere/terraform-provider-litellm/issues/117))
+- **`litellm_key`**: Add `key_wo` with a persisted replacement trigger and hash-only lifecycle/import support so predefined keys can remain absent from Terraform plan, state, and private state. ([#86](https://github.com/ncecere/terraform-provider-litellm/issues/86)) — thanks @ripiomatiascalvo
 
 ## [2.0.1] - 2026-06-12
 

--- a/docs/resources/key.md
+++ b/docs/resources/key.md
@@ -51,6 +51,8 @@ resource "litellm_key" "write_only" {
 
 In write-only mode, `key` remains null and `id` contains only `sha256:<key-hash>`. The provider uses this hash for Read, Update, and Delete; plaintext is not stored in Terraform private state.
 
+> **Key entropy:** Use a cryptographically random key with at least 128 bits of entropy. The unsalted SHA256 management identifier does not authenticate to LiteLLM, but it is visible in ordinary Terraform output and lets an observer verify offline guesses of a weak or patterned predefined key.
+
 > **Compatibility:** The optional write-only argument requires Terraform or OpenTofu 1.11+. Older clients can continue using the provider when `key_wo` is omitted, but reject configurations that set it.
 
 ### Key with Budget and Rate Limits
@@ -135,7 +137,7 @@ The following arguments are supported:
 
 * `key` - (Optional) User-defined key value. If not set, LiteLLM generates a 16-digit unique `sk-` key automatically. The key is stored as a sensitive value in state. Conflicts with `key_wo`.
 
-* `key_wo` - (Optional, Sensitive, Write-only) Predefined key sent to LiteLLM but represented only by null in plan and state. Must be configured with `key_wo_version`. Requires Terraform or OpenTofu 1.11+.
+* `key_wo` - (Optional, Sensitive, Write-only) Predefined key sent to LiteLLM but represented only by null in plan and state. Must be configured with `key_wo_version`. Use a cryptographically random, high-entropy value because its SHA256 management identifier is persisted. Requires Terraform or OpenTofu 1.11+.
 
 * `key_wo_version` - (Optional, ForceNew) Persisted version or nonce for `key_wo`. Change this whenever the write-only secret changes. It conflicts with configurations that omit `key_wo`.
 
@@ -207,7 +209,7 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - Non-sensitive unique identifier for this key (SHA256 hash of the key value). This is safe to appear in logs and CI/CD output.
+* `id` - Non-sensitive unique management identifier for this key (SHA256 hash of the key value). LiteLLM prevents this digest from authenticating as a virtual key. It is displayed in logs and CI/CD output, so low-entropy predefined keys remain susceptible to offline guessing.
 
 * `key` - The API key token (sensitive). This is the actual secret used for authentication for generated or stateful predefined keys. It remains null in write-only mode.
 

--- a/docs/resources/key.md
+++ b/docs/resources/key.md
@@ -28,6 +28,31 @@ resource "litellm_key" "predefined" {
 }
 ```
 
+### Write-Only Predefined Key
+
+Terraform or OpenTofu 1.11 and later can send a predefined key without storing it in plan or state through `key_wo`. For end-to-end protection, source the value from an ephemeral resource or variable; a non-ephemeral source can still persist the secret independently of this resource.
+
+```hcl
+variable "litellm_key" {
+  type      = string
+  sensitive = true
+  ephemeral = true
+}
+
+resource "litellm_key" "write_only" {
+  key_wo         = var.litellm_key
+  key_wo_version = "1"
+  key_alias      = "prod-key-1"
+  models         = ["gpt-4o"]
+}
+```
+
+`key_wo_version` is persisted because Terraform cannot compare write-only values. Change both the secret and version to replace the key. Replacement deletes and recreates the LiteLLM key, including its server-side spend history and budget window. The ephemeral source must be available during both plan and apply; applying a saved plan requires supplying the ephemeral input again.
+
+In write-only mode, `key` remains null and `id` contains only `sha256:<key-hash>`. The provider uses this hash for Read, Update, and Delete; plaintext is not stored in Terraform private state.
+
+> **Compatibility:** The optional write-only argument requires Terraform or OpenTofu 1.11+. Older clients can continue using the provider when `key_wo` is omitted, but reject configurations that set it.
+
 ### Key with Budget and Rate Limits
 
 ```hcl
@@ -108,7 +133,11 @@ resource "litellm_key" "with_logging" {
 
 The following arguments are supported:
 
-* `key` - (Optional) User-defined key value. If not set, LiteLLM generates a 16-digit unique `sk-` key automatically. The key is stored as a sensitive value in state.
+* `key` - (Optional) User-defined key value. If not set, LiteLLM generates a 16-digit unique `sk-` key automatically. The key is stored as a sensitive value in state. Conflicts with `key_wo`.
+
+* `key_wo` - (Optional, Sensitive, Write-only) Predefined key sent to LiteLLM but represented only by null in plan and state. Must be configured with `key_wo_version`. Requires Terraform or OpenTofu 1.11+.
+
+* `key_wo_version` - (Optional, ForceNew) Persisted version or nonce for `key_wo`. Change this whenever the write-only secret changes. It conflicts with configurations that omit `key_wo`.
 
 * `key_alias` - (Optional) Human-readable alias for this key.
 
@@ -180,7 +209,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - Non-sensitive unique identifier for this key (SHA256 hash of the key value). This is safe to appear in logs and CI/CD output.
 
-* `key` - The API key token (sensitive). This is the actual secret used for authentication.
+* `key` - The API key token (sensitive). This is the actual secret used for authentication for generated or stateful predefined keys. It remains null in write-only mode.
 
 ## Import
 
@@ -191,6 +220,17 @@ $ terraform import litellm_key.example sk-xxxxxxxxxxxx
 ```
 
 The provider will automatically hash the key for the resource ID and store the raw value in the sensitive `key` attribute.
+
+To import without storing the raw key, configure `key_wo` with `key_wo_version = "1"`, calculate the SHA256 hash outside Terraform, and import the prefixed hash:
+
+```shell
+TF_VAR_litellm_key="$LITELLM_KEY" terraform import \
+  litellm_key.example "sha256:<64-character-sha256>"
+```
+
+Hash import initializes `key_wo_version` to `"1"`; the configuration must initially match it. The ephemeral input must be available during import and subsequent operations. An initial apply may be needed to normalize other Optional+Computed key attributes.
+
+Switching an existing stateful `key` resource to `key_wo` replaces the key and removes plaintext from the current state. Historical local backups or remote-state versions may still contain the old value and must be expired or purged according to the backend's retention controls.
 
 ## Upgrade Notes
 

--- a/internal/provider/resource_key.go
+++ b/internal/provider/resource_key.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -41,8 +42,10 @@ func (r *KeyResource) ConfigValidators(ctx context.Context) []resource.ConfigVal
 	}
 }
 
-// hashKeyForID produces a non-sensitive identifier from a raw API key.
-// Format: "sha256:<hex digest>" so it is self-documenting and non-reversible.
+// hashKeyForID produces the non-sensitive management identifier used by this
+// provider. Because an unsalted digest permits offline guesses, callers should
+// use cryptographically random, high-entropy predefined keys.
+// Format: "sha256:<hex digest>".
 func hashKeyForID(rawKey string) string {
 	h := sha256.Sum256([]byte(rawKey))
 	return fmt.Sprintf("sha256:%x", h)
@@ -72,6 +75,14 @@ func keyLookupIdentifier(data *KeyResourceModel) (string, error) {
 		return "", fmt.Errorf("key value is empty, cannot identify the LiteLLM key")
 	}
 	return key, nil
+}
+
+func writeOnlyKeyCreateError(err error) string {
+	var apiErr *APIError
+	if errors.As(err, &apiErr) {
+		return fmt.Sprintf("LiteLLM returned HTTP %d while creating the write-only key. The response body was omitted because it may contain the submitted secret.", apiErr.StatusCode)
+	}
+	return "The write-only key request failed. Error details were omitted because an intermediary may include the submitted secret."
 }
 
 func NewKeyResource() resource.Resource {
@@ -147,7 +158,7 @@ func (r *KeyResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 				},
 			},
 			"key_wo": schema.StringAttribute{
-				Description: "Write-only predefined API key value. Terraform sends this value to LiteLLM but does not store it in plan or state artifacts. Requires Terraform 1.11 or compatible OpenTofu support.",
+				Description: "Write-only predefined API key value. Terraform sends this value to LiteLLM but does not store it in plan or state artifacts. Use a cryptographically random, high-entropy key because its persisted SHA256 management identifier permits offline guesses of weak values. Requires Terraform 1.11 or compatible OpenTofu support.",
 				Optional:    true,
 				Sensitive:   true,
 				WriteOnly:   true,
@@ -399,7 +410,11 @@ func (r *KeyResource) Create(ctx context.Context, req resource.CreateRequest, re
 
 	var result map[string]interface{}
 	if err := r.client.DoRequestWithResponse(ctx, "POST", endpoint, keyReq, &result); err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create key: %s", err))
+		if writeOnlyMode {
+			resp.Diagnostics.AddError("Write-Only Key Creation Error", writeOnlyKeyCreateError(err))
+		} else {
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create key: %s", err))
+		}
 		return
 	}
 

--- a/internal/provider/resource_key.go
+++ b/internal/provider/resource_key.go
@@ -3,16 +3,21 @@ package provider
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -21,12 +26,52 @@ import (
 var _ resource.Resource = &KeyResource{}
 var _ resource.ResourceWithImportState = &KeyResource{}
 var _ resource.ResourceWithUpgradeState = &KeyResource{}
+var _ resource.ResourceWithConfigValidators = &KeyResource{}
+
+func (r *KeyResource) ConfigValidators(ctx context.Context) []resource.ConfigValidator {
+	return []resource.ConfigValidator{
+		resourcevalidator.RequiredTogether(
+			path.MatchRoot("key_wo"),
+			path.MatchRoot("key_wo_version"),
+		),
+		resourcevalidator.Conflicting(
+			path.MatchRoot("key"),
+			path.MatchRoot("key_wo"),
+		),
+	}
+}
 
 // hashKeyForID produces a non-sensitive identifier from a raw API key.
 // Format: "sha256:<hex digest>" so it is self-documenting and non-reversible.
 func hashKeyForID(rawKey string) string {
 	h := sha256.Sum256([]byte(rawKey))
 	return fmt.Sprintf("sha256:%x", h)
+}
+
+func keyHashFromID(id string) (string, error) {
+	const prefix = "sha256:"
+	if !strings.HasPrefix(id, prefix) {
+		return "", fmt.Errorf("key ID %q does not contain a SHA256 key hash", id)
+	}
+	hash := strings.TrimPrefix(id, prefix)
+	if len(hash) != sha256.Size*2 {
+		return "", fmt.Errorf("key ID contains an invalid SHA256 hash length")
+	}
+	if _, err := hex.DecodeString(hash); err != nil {
+		return "", fmt.Errorf("key ID contains an invalid SHA256 hash: %w", err)
+	}
+	return hash, nil
+}
+
+func keyLookupIdentifier(data *KeyResourceModel) (string, error) {
+	if !data.KeyWOVersion.IsNull() && !data.KeyWOVersion.IsUnknown() {
+		return keyHashFromID(data.ID.ValueString())
+	}
+	key := data.Key.ValueString()
+	if key == "" {
+		return "", fmt.Errorf("key value is empty, cannot identify the LiteLLM key")
+	}
+	return key, nil
 }
 
 func NewKeyResource() resource.Resource {
@@ -40,6 +85,8 @@ type KeyResource struct {
 type KeyResourceModel struct {
 	ID                       types.String  `tfsdk:"id"`
 	Key                      types.String  `tfsdk:"key"`
+	KeyWO                    types.String  `tfsdk:"key_wo"`
+	KeyWOVersion             types.String  `tfsdk:"key_wo_version"`
 	Models                   types.List    `tfsdk:"models"`
 	AllowedRoutes            types.List    `tfsdk:"allowed_routes"`
 	AllowedPassthroughRoutes types.List    `tfsdk:"allowed_passthrough_routes"`
@@ -91,12 +138,31 @@ func (r *KeyResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 				},
 			},
 			"key": schema.StringAttribute{
-				Description: "The API key value. If not specified, a key will be generated.",
+				Description: "The API key value. If not specified, a key will be generated. Use key_wo instead to avoid storing a predefined key in Terraform artifacts.",
 				Optional:    true,
 				Computed:    true,
 				Sensitive:   true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"key_wo": schema.StringAttribute{
+				Description: "Write-only predefined API key value. Terraform sends this value to LiteLLM but does not store it in plan or state artifacts. Requires Terraform 1.11 or compatible OpenTofu support.",
+				Optional:    true,
+				Sensitive:   true,
+				WriteOnly:   true,
+				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(1),
+				},
+			},
+			"key_wo_version": schema.StringAttribute{
+				Description: "Persisted version or nonce for key_wo. Change it when the write-only key changes; changing or removing it replaces the LiteLLM key.",
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(1),
+				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
 				},
 			},
 			"models": schema.ListAttribute{
@@ -297,7 +363,34 @@ func (r *KeyResource) Create(ctx context.Context, req resource.CreateRequest, re
 		return
 	}
 
+	var writeOnlyKey types.String
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("key_wo"), &writeOnlyKey)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if writeOnlyKey.IsUnknown() {
+		resp.Diagnostics.AddError("Invalid Write-Only Key", "key_wo must be known during apply; the provider will not fall back to generating and storing a key.")
+		return
+	}
+	writeOnlyMode := !writeOnlyKey.IsNull()
+	if writeOnlyMode {
+		if writeOnlyKey.ValueString() == "" {
+			resp.Diagnostics.AddError("Invalid Write-Only Key", "key_wo must be non-empty during apply.")
+			return
+		}
+		if data.KeyWOVersion.IsNull() || data.KeyWOVersion.IsUnknown() || data.KeyWOVersion.ValueString() == "" {
+			resp.Diagnostics.AddError("Invalid Write-Only Key Version", "key_wo_version must be known and non-empty whenever key_wo is configured.")
+			return
+		}
+	} else if !data.KeyWOVersion.IsNull() {
+		resp.Diagnostics.AddError("Invalid Write-Only Key Version", "key_wo_version cannot be configured without key_wo.")
+		return
+	}
+
 	keyReq := r.buildKeyRequest(ctx, &data)
+	if writeOnlyMode {
+		keyReq["key"] = writeOnlyKey.ValueString()
+	}
 
 	endpoint := "/key/generate"
 	if !data.ServiceAccountID.IsNull() && data.ServiceAccountID.ValueString() != "" {
@@ -310,7 +403,11 @@ func (r *KeyResource) Create(ctx context.Context, req resource.CreateRequest, re
 		return
 	}
 
-	if keyVal, ok := result["key"].(string); ok {
+	if writeOnlyMode {
+		data.ID = types.StringValue(hashKeyForID(writeOnlyKey.ValueString()))
+		data.Key = types.StringNull()
+		data.KeyWO = types.StringNull()
+	} else if keyVal, ok := result["key"].(string); ok {
 		data.Key = types.StringValue(keyVal)
 		data.ID = types.StringValue(hashKeyForID(keyVal))
 	}
@@ -359,9 +456,15 @@ func (r *KeyResource) Update(ctx context.Context, req resource.UpdateRequest, re
 
 	data.ID = state.ID
 	data.Key = state.Key
+	data.KeyWO = types.StringNull()
 
+	keyIdentifier, err := keyLookupIdentifier(&data)
+	if err != nil {
+		resp.Diagnostics.AddError("Key Identity Error", fmt.Sprintf("Unable to identify key for update: %s", err))
+		return
+	}
 	updateReq := r.buildKeyRequest(ctx, &data)
-	updateReq["key"] = data.Key.ValueString()
+	updateReq["key"] = keyIdentifier
 
 	if err := r.client.DoRequestWithResponse(ctx, "POST", "/key/update", updateReq, nil); err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update key: %s", err))
@@ -383,8 +486,13 @@ func (r *KeyResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 		return
 	}
 
+	keyIdentifier, err := keyLookupIdentifier(&data)
+	if err != nil {
+		resp.Diagnostics.AddError("Key Identity Error", fmt.Sprintf("Unable to identify key for deletion: %s", err))
+		return
+	}
 	deleteReq := map[string]interface{}{
-		"keys": []string{data.Key.ValueString()},
+		"keys": []string{keyIdentifier},
 	}
 
 	if err := r.client.DoRequestWithResponse(ctx, "POST", "/key/delete", deleteReq, nil); err != nil {
@@ -396,8 +504,21 @@ func (r *KeyResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 }
 
 func (r *KeyResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	// The import ID is the raw API key value. Store it in "key" (sensitive)
-	// and use a SHA256 hash as the non-sensitive resource ID.
+	if strings.HasPrefix(req.ID, "sha256:") {
+		if _, err := keyHashFromID(req.ID); err != nil {
+			resp.Diagnostics.AddError("Invalid Write-Only Key Import", err.Error())
+			return
+		}
+		// A hash import avoids placing the raw token in state. Version "1" is
+		// the documented bootstrap value and must match configuration initially.
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("key"), types.StringNull())...)
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("key_wo_version"), "1")...)
+		return
+	}
+
+	// Legacy/stateful import accepts the raw API key and stores it in the
+	// sensitive key attribute so existing workflows remain compatible.
 	rawKey := req.ID
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), hashKeyForID(rawKey))...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("key"), rawKey)...)
@@ -698,15 +819,15 @@ func stringMapMatchesAttrValues(current types.Map, observed map[string]attr.Valu
 }
 
 func (r *KeyResource) readKey(ctx context.Context, data *KeyResourceModel) error {
-	keyVal := data.Key.ValueString()
-	if keyVal == "" {
-		return fmt.Errorf("key value is empty, cannot read key info")
+	keyIdentifier, err := keyLookupIdentifier(data)
+	if err != nil {
+		return err
 	}
 
-	// url.QueryEscape ensures special characters in the key (e.g. '#') are
-	// percent-encoded and not interpreted as a URL fragment, which would
-	// silently truncate the key value before it reaches the server.
-	endpoint := fmt.Sprintf("/key/info?key=%s", url.QueryEscape(keyVal))
+	// url.QueryEscape ensures special characters in a plaintext key (e.g. '#')
+	// are not interpreted as a URL fragment. LiteLLM also accepts the SHA256
+	// token hash used to manage write-only keys without recovering plaintext.
+	endpoint := fmt.Sprintf("/key/info?key=%s", url.QueryEscape(keyIdentifier))
 
 	var result map[string]interface{}
 	if err := r.client.DoRequestWithResponse(ctx, "GET", endpoint, nil, &result); err != nil {
@@ -806,7 +927,7 @@ func (r *KeyResource) readKey(ctx context.Context, data *KeyResourceModel) error
 	// custom key value it is already known and must NOT be overwritten — the
 	// /key/info endpoint returns a hashed token, not the raw key, so
 	// overwriting would cause "inconsistent values for sensitive attribute".
-	if data.Key.IsUnknown() || data.Key.IsNull() {
+	if data.KeyWOVersion.IsNull() && (data.Key.IsUnknown() || data.Key.IsNull()) {
 		if keyValue, ok := result["key"].(string); ok && keyValue != "" {
 			data.Key = types.StringValue(keyValue)
 			data.ID = types.StringValue(hashKeyForID(keyValue))

--- a/internal/provider/resource_key_test.go
+++ b/internal/provider/resource_key_test.go
@@ -14,6 +14,112 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 )
 
+func TestKeyWriteOnlySchemaAndValidators(t *testing.T) {
+	t.Parallel()
+
+	keyResource := &KeyResource{}
+	var response resource.SchemaResponse
+	keyResource.Schema(context.Background(), resource.SchemaRequest{}, &response)
+	if response.Diagnostics.HasError() {
+		t.Fatalf("schema diagnostics: %v", response.Diagnostics)
+	}
+	keyWO, ok := response.Schema.Attributes["key_wo"]
+	if !ok || !keyWO.IsWriteOnly() || !keyWO.IsSensitive() {
+		t.Fatalf("key_wo must be sensitive and write-only: %#v", keyWO)
+	}
+	version, ok := response.Schema.Attributes["key_wo_version"]
+	if !ok || version.IsWriteOnly() || version.IsSensitive() {
+		t.Fatalf("key_wo_version must be persisted and non-sensitive: %#v", version)
+	}
+	if got := len(keyResource.ConfigValidators(context.Background())); got != 2 {
+		t.Fatalf("config validators = %d, want 2", got)
+	}
+}
+
+func TestKeyLookupIdentifier(t *testing.T) {
+	t.Parallel()
+
+	raw := "sk-write-only-test"
+	id := hashKeyForID(raw)
+	hash := strings.TrimPrefix(id, "sha256:")
+	tests := map[string]struct {
+		data    KeyResourceModel
+		want    string
+		wantErr bool
+	}{
+		"stateful plaintext": {
+			data: KeyResourceModel{Key: types.StringValue(raw), KeyWOVersion: types.StringNull()},
+			want: raw,
+		},
+		"write-only hash": {
+			data: KeyResourceModel{ID: types.StringValue(id), Key: types.StringNull(), KeyWOVersion: types.StringValue("1")},
+			want: hash,
+		},
+		"invalid write-only ID": {
+			data:    KeyResourceModel{ID: types.StringValue("sha256:not-a-hash"), KeyWOVersion: types.StringValue("1")},
+			wantErr: true,
+		},
+		"missing stateful key": {
+			data:    KeyResourceModel{Key: types.StringNull(), KeyWOVersion: types.StringNull()},
+			wantErr: true,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got, err := keyLookupIdentifier(&test.data)
+			if test.wantErr {
+				if err == nil {
+					t.Fatalf("keyLookupIdentifier() = %q, want error", got)
+				}
+				return
+			}
+			if err != nil || got != test.want {
+				t.Fatalf("keyLookupIdentifier() = %q, %v; want %q", got, err, test.want)
+			}
+		})
+	}
+}
+
+func TestReadKeyWriteOnlyUsesHashAndKeepsPlaintextNull(t *testing.T) {
+	t.Parallel()
+
+	raw := "sk-write-only-read-test"
+	id := hashKeyForID(raw)
+	hash := strings.TrimPrefix(id, "sha256:")
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/key/info" || request.URL.Query().Get("key") != hash {
+			http.Error(writer, "unexpected key identifier", http.StatusBadRequest)
+			return
+		}
+		writer.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(writer).Encode(map[string]interface{}{
+			"key": hash,
+			"info": map[string]interface{}{
+				"token":     hash,
+				"key_alias": "write-only",
+				"models":    []interface{}{"gpt-4o"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	resource := &KeyResource{client: &Client{APIBase: server.URL, APIKey: "test-key", HTTPClient: server.Client()}}
+	data := KeyResourceModel{
+		ID:           types.StringValue(id),
+		Key:          types.StringNull(),
+		KeyWO:        types.StringNull(),
+		KeyWOVersion: types.StringValue("1"),
+		Models:       stringListValue("gpt-4o"),
+	}
+	if err := resource.readKey(context.Background(), &data); err != nil {
+		t.Fatalf("readKey returned error: %v", err)
+	}
+	if !data.Key.IsNull() || !data.KeyWO.IsNull() || data.ID.ValueString() != id {
+		t.Fatalf("write-only read changed secret state: %#v", data)
+	}
+}
+
 func TestKeyMetadataSchemaIsSensitive(t *testing.T) {
 	t.Parallel()
 

--- a/internal/provider/resource_key_test.go
+++ b/internal/provider/resource_key_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -78,6 +79,40 @@ func TestKeyLookupIdentifier(t *testing.T) {
 				t.Fatalf("keyLookupIdentifier() = %q, %v; want %q", got, err, test.want)
 			}
 		})
+	}
+}
+
+func TestWriteOnlyKeyCreateErrorOmitsEchoedSecret(t *testing.T) {
+	t.Parallel()
+
+	secret := `sk-write-only-echoed-"secret"`
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		body, err := io.ReadAll(request.Body)
+		if err != nil {
+			t.Errorf("read request body: %v", err)
+		}
+		writer.WriteHeader(http.StatusBadRequest)
+		_, _ = writer.Write(body)
+	}))
+	defer server.Close()
+
+	client := &Client{APIBase: server.URL, APIKey: "admin-key", HTTPClient: server.Client()}
+	err := client.DoRequestWithResponse(
+		context.Background(),
+		http.MethodPost,
+		"/key/generate",
+		map[string]interface{}{"key": secret},
+		nil,
+	)
+	if err == nil {
+		t.Fatal("expected echoed API error")
+	}
+	message := writeOnlyKeyCreateError(err)
+	if strings.Contains(message, secret) || strings.Contains(message, `\\\"secret\\\"`) {
+		t.Fatalf("safe diagnostic exposed write-only key: %q", message)
+	}
+	if !strings.Contains(message, "HTTP 400") || !strings.Contains(message, "response body was omitted") {
+		t.Fatalf("safe diagnostic = %q, want status without response body", message)
 	}
 }
 


### PR DESCRIPTION
### Summary

Closes #86. Adds `key_wo`, a sensitive write-only predefined key argument for Terraform and OpenTofu 1.11+, plus persisted `key_wo_version` replacement signaling. The raw key is consumed only from resource configuration during Create and is never placed in normal state, private state, planned state, or the `key` output.

After Create, lifecycle identity uses the existing non-sensitive `sha256:<hash>` ID. LiteLLM v1.98.0 accepts its stored token hash for `/key/info`, `/key/update`, and `/key/delete`, so refresh, in-place metadata changes, replacement, and destroy do not need plaintext. Hash-based import is also supported with bootstrap version `1`; legacy raw imports remain compatible.

This retains the intent and attribution of contributor PR #128 while fixing its refresh/delete gap and adding hash lifecycle, apply-time unknown safeguards, write-only import, compatibility guidance, and end-to-end leak validation.

### Validation

Terraform 1.15 live validation covered write-only Create, refresh, hash-targeted in-place alias Update, `key_wo_version` replacement, and hash-targeted Delete against LiteLLM v1.98.0. `key` and `key_wo` remained null. The plaintext was absent from unzipped saved plans, plan JSON, CLI logs, current/backup state, and import artifacts when sourced from an external ephemeral variable. A fault-injected API response that echoed the submitted secret produced only a body-omitted HTTP-status diagnostic, with no secret in Terraform output or state. Saved-plan apply correctly required the ephemeral input again. Missing-version and stateful/write-only conflict configurations failed validation. Hash import, normalization apply, clean plan, and destroy passed without plaintext. Focused tests, `go vet`, full tests, race tests, and the 23-resource real-dev lifecycle suite pass.

### Diff size

**Docs** — 2 files · `+46 / -3`

Documents ephemeral sourcing, Terraform/OpenTofu 1.11 compatibility, replacement semantics, saved-plan behavior, hash import, migration/backups, and contributor credit.

**Implementation** — 1 file · `+153 / -17`

Adds write-only schema/config validation, strict apply-time handling, hash identity validation, hash-only lifecycle, null secret state, safe import compatibility, and body-omitted write-only failure diagnostics.

**Tests** — 1 file · `+141 / -0`

Covers schema/validator contracts, valid and invalid hash identity selection, hash-only read-back without secret repopulation, and API errors that echo the submitted key.
