### PR TITLE
feat: support custom LiteLLM team IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`litellm_mcp_server`**: Fall back to the MCP collection endpoint when individual read-back fails and resolve computed unknowns after successful mutations so backend read errors remain recoverable. ([#116](https://github.com/ncecere/terraform-provider-litellm/issues/116))
 - **`litellm_user`**: Safely adopt an existing exact-email account after an HTTP 409, verify any configured ID, converge managed fields and team membership, and avoid generating an unrecoverable key. ([#117](https://github.com/ncecere/terraform-provider-litellm/issues/117))
 - **`litellm_key`**: Add `key_wo` with a persisted replacement trigger and hash-only lifecycle/import support so predefined keys can remain absent from Terraform plan, state, and private state. ([#86](https://github.com/ncecere/terraform-provider-litellm/issues/86)) — thanks @ripiomatiascalvo
+- **`litellm_team`**: Allow a stable custom `team_id` for external identity and JWT group mapping while preserving generated IDs by default. ([#122](https://github.com/ncecere/terraform-provider-litellm/issues/122)) — thanks @TheCodingSheikh
 
 ## [2.0.1] - 2026-06-12
 

--- a/docs/resources/team.md
+++ b/docs/resources/team.md
@@ -14,6 +14,20 @@ resource "litellm_team" "minimal" {
 }
 ```
 
+### Custom Team ID
+
+Set `team_id` when an external identity provider or JWT group claim must refer to a stable, predetermined LiteLLM team identity:
+
+```hcl
+resource "litellm_team" "identity_group" {
+  team_id    = "engineering-platform"
+  team_alias = "Engineering Platform"
+  models     = ["gpt-4o"]
+}
+```
+
+If omitted, the provider generates a UUID as before. Changing `team_id` replaces the team.
+
 ### Full
 
 ```hcl
@@ -89,6 +103,7 @@ resource "litellm_team" "with_fallbacks" {
 The following arguments are supported:
 
 * `team_alias` - (Required) A human-readable alias for the team.
+* `team_id` - (Optional, Computed, Forces replacement) Stable LiteLLM team identifier. Supply a predetermined value for external identity or JWT group mapping, or omit it to let the provider generate a UUID.
 * `organization_id` - (Optional) The ID of the organization this team belongs to.
 * `max_budget` - (Optional) Maximum budget allocated to the team.
 * `budget_duration` - (Optional) Duration for the budget cycle (e.g., `"30d"`, `"7d"`, `"1h"`).
@@ -119,7 +134,8 @@ The following arguments are supported:
 
 In addition to the arguments above, the following attributes are exported:
 
-* `id` - The unique identifier of the team.
+* `id` - The Terraform resource identifier. It always matches `team_id`.
+* `team_id` - The configured or generated LiteLLM team identifier.
 
 The following attributes are both Optional and Computed (they are read back from the API if not explicitly set):
 

--- a/internal/provider/resource_team.go
+++ b/internal/provider/resource_team.go
@@ -3,14 +3,17 @@ package provider
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
@@ -28,6 +31,7 @@ type TeamResource struct {
 
 type TeamResourceModel struct {
 	ID                    types.String  `tfsdk:"id"`
+	TeamID                types.String  `tfsdk:"team_id"`
 	TeamAlias             types.String  `tfsdk:"team_alias"`
 	OrganizationID        types.String  `tfsdk:"organization_id"`
 	Metadata              types.Map     `tfsdk:"metadata"`
@@ -62,6 +66,13 @@ type FallbackEntryModel struct {
 	FallbackModels types.List   `tfsdk:"fallback_models"`
 }
 
+func teamIDForCreate(configured types.String) string {
+	if !configured.IsNull() && !configured.IsUnknown() && configured.ValueString() != "" {
+		return configured.ValueString()
+	}
+	return uuid.New().String()
+}
+
 var fallbackEntryAttrTypes = map[string]attr.Type{
 	"model":           types.StringType,
 	"fallback_models": types.ListType{ElemType: types.StringType},
@@ -85,6 +96,18 @@ func (r *TeamResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 				Computed:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"team_id": schema.StringAttribute{
+				Description: "The LiteLLM team ID. If not specified, the provider generates one. Changing it replaces the team.",
+				Optional:    true,
+				Computed:    true,
+				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(1),
+				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+					stringplanmodifier.RequiresReplace(),
 				},
 			},
 			"team_alias": schema.StringAttribute{
@@ -261,7 +284,8 @@ func (r *TeamResource) Create(ctx context.Context, req resource.CreateRequest, r
 		return
 	}
 
-	teamID := uuid.New().String()
+	teamID := teamIDForCreate(data.TeamID)
+	data.TeamID = types.StringValue(teamID)
 	teamReq := r.buildTeamRequest(ctx, &data, teamID)
 
 	if err := r.client.DoRequestWithResponse(ctx, "POST", "/team/new", teamReq, nil); err != nil {
@@ -314,6 +338,10 @@ func (r *TeamResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	}
 
 	data.ID = state.ID
+	data.TeamID = state.TeamID
+	if data.TeamID.IsNull() || data.TeamID.IsUnknown() {
+		data.TeamID = state.ID
+	}
 	teamReq := r.buildTeamRequest(ctx, &data, data.ID.ValueString())
 	applyTeamNullableClears(teamReq, &state, &data)
 
@@ -363,7 +391,8 @@ func (r *TeamResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 }
 
 func (r *TeamResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("team_id"), req.ID)...)
 }
 
 func (r *TeamResource) buildTeamRequest(ctx context.Context, data *TeamResourceModel, teamID string) map[string]interface{} {
@@ -560,7 +589,7 @@ func fallbackEntriesToAPIFormat(ctx context.Context, list types.List) []map[stri
 }
 
 func (r *TeamResource) readTeam(ctx context.Context, data *TeamResourceModel) error {
-	endpoint := fmt.Sprintf("/team/info?team_id=%s", data.ID.ValueString())
+	endpoint := fmt.Sprintf("/team/info?team_id=%s", url.QueryEscape(data.ID.ValueString()))
 
 	var result map[string]interface{}
 	if err := r.client.DoRequestWithResponse(ctx, "GET", endpoint, nil, &result); err != nil {
@@ -572,6 +601,13 @@ func (r *TeamResource) readTeam(ctx context.Context, data *TeamResourceModel) er
 	if nested, ok := result["team_info"].(map[string]interface{}); ok {
 		teamInfo = nested
 	}
+
+	// Keep the configurable team_id and Terraform id tied to the same remote
+	// identity. Imports and legacy state learn team_id from the resource ID.
+	if observedTeamID, ok := teamInfo["team_id"].(string); ok && observedTeamID != "" && observedTeamID != data.ID.ValueString() {
+		return fmt.Errorf("LiteLLM returned team_id %q while reading team %q", observedTeamID, data.ID.ValueString())
+	}
+	data.TeamID = data.ID
 
 	// Update fields from response
 	if teamAlias, ok := teamInfo["team_alias"].(string); ok && teamAlias != "" {
@@ -791,7 +827,7 @@ func (r *TeamResource) readTeam(ctx context.Context, data *TeamResourceModel) er
 	}
 
 	// Fetch permissions separately - preserve null when API returns empty and config didn't specify permissions
-	permEndpoint := fmt.Sprintf("/team/permissions_list?team_id=%s", data.ID.ValueString())
+	permEndpoint := fmt.Sprintf("/team/permissions_list?team_id=%s", url.QueryEscape(data.ID.ValueString()))
 	var permResult map[string]interface{}
 	if err := r.client.DoRequestWithResponse(ctx, "GET", permEndpoint, nil, &permResult); err == nil {
 		if perms, ok := permResult["team_member_permissions"].([]interface{}); ok && len(perms) > 0 {

--- a/internal/provider/resource_team_test.go
+++ b/internal/provider/resource_team_test.go
@@ -8,11 +8,148 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	resourceschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
+
+func TestTeamIDSchemaSupportsConfiguredOrGeneratedIdentity(t *testing.T) {
+	t.Parallel()
+
+	var response resource.SchemaResponse
+	(&TeamResource{}).Schema(context.Background(), resource.SchemaRequest{}, &response)
+	if response.Diagnostics.HasError() {
+		t.Fatalf("schema diagnostics: %v", response.Diagnostics)
+	}
+	attribute, ok := response.Schema.Attributes["team_id"].(resourceschema.StringAttribute)
+	if !ok {
+		t.Fatalf("team_id schema type = %T, want schema.StringAttribute", response.Schema.Attributes["team_id"])
+	}
+	if !attribute.Optional || !attribute.Computed || attribute.Required {
+		t.Fatalf("team_id must be Optional+Computed: %#v", attribute)
+	}
+	if len(attribute.Validators) != 1 {
+		t.Fatalf("team_id validators = %d, want 1", len(attribute.Validators))
+	}
+	if len(attribute.PlanModifiers) != 2 {
+		t.Fatalf("team_id plan modifiers = %d, want state preservation and replacement", len(attribute.PlanModifiers))
+	}
+}
+
+func TestTeamImportMirrorsIDAndTeamID(t *testing.T) {
+	t.Parallel()
+
+	teamResource := &TeamResource{}
+	var schemaResponse resource.SchemaResponse
+	teamResource.Schema(context.Background(), resource.SchemaRequest{}, &schemaResponse)
+	state, err := nullStateFor(schemaResponse.Schema)
+	if err != nil {
+		t.Fatalf("build import state: %v", err)
+	}
+	response := &resource.ImportStateResponse{State: state}
+	teamResource.ImportState(
+		context.Background(),
+		resource.ImportStateRequest{ID: "external-team"},
+		response,
+	)
+	if response.Diagnostics.HasError() {
+		t.Fatalf("import diagnostics: %v", response.Diagnostics)
+	}
+	var data TeamResourceModel
+	response.Diagnostics.Append(response.State.Get(context.Background(), &data)...)
+	if response.Diagnostics.HasError() {
+		t.Fatalf("decode imported state: %v", response.Diagnostics)
+	}
+	if data.ID.ValueString() != "external-team" || data.TeamID.ValueString() != "external-team" {
+		t.Fatalf("imported identity: id=%q team_id=%q", data.ID.ValueString(), data.TeamID.ValueString())
+	}
+}
+
+func TestTeamIDForCreatePreservesCustomOrGeneratesUUID(t *testing.T) {
+	t.Parallel()
+
+	if got := teamIDForCreate(types.StringValue("engineering-platform")); got != "engineering-platform" {
+		t.Fatalf("configured team ID = %q, want engineering-platform", got)
+	}
+	for name, value := range map[string]types.String{
+		"null":    types.StringNull(),
+		"unknown": types.StringUnknown(),
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := teamIDForCreate(value)
+			if _, err := uuid.Parse(got); err != nil {
+				t.Fatalf("generated team ID %q is not a UUID: %v", got, err)
+			}
+		})
+	}
+}
+
+func TestReadTeamCustomIDIsEscapedAndMirrored(t *testing.T) {
+	t.Parallel()
+
+	const teamID = "engineering/group #1&ops"
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if got := request.URL.Query().Get("team_id"); got != teamID {
+			http.Error(writer, "unexpected team ID: "+got, http.StatusBadRequest)
+			return
+		}
+		writer.Header().Set("Content-Type", "application/json")
+		switch request.URL.Path {
+		case "/team/info":
+			_ = json.NewEncoder(writer).Encode(map[string]interface{}{
+				"team_info": map[string]interface{}{
+					"team_id":    teamID,
+					"team_alias": "Engineering Platform",
+				},
+			})
+		case "/team/permissions_list":
+			_ = json.NewEncoder(writer).Encode(map[string]interface{}{
+				"team_member_permissions": []interface{}{},
+			})
+		default:
+			http.NotFound(writer, request)
+		}
+	}))
+	defer server.Close()
+
+	teamResource := &TeamResource{client: &Client{APIBase: server.URL, APIKey: "test-key", HTTPClient: server.Client()}}
+	data := TeamResourceModel{
+		ID:                    types.StringValue(teamID),
+		TeamID:                types.StringNull(),
+		TeamAlias:             types.StringValue("Engineering Platform"),
+		TeamMemberPermissions: types.ListUnknown(types.StringType),
+	}
+	if err := teamResource.readTeam(context.Background(), &data); err != nil {
+		t.Fatalf("readTeam returned error: %v", err)
+	}
+	if data.TeamID.ValueString() != teamID || data.ID.ValueString() != teamID {
+		t.Fatalf("team identity not mirrored: id=%q team_id=%q", data.ID.ValueString(), data.TeamID.ValueString())
+	}
+}
+
+func TestReadTeamRejectsMismatchedRemoteIdentity(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(writer).Encode(map[string]interface{}{
+			"team_info": map[string]interface{}{
+				"team_id":    "different-team",
+				"team_alias": "Different",
+			},
+		})
+	}))
+	defer server.Close()
+
+	teamResource := &TeamResource{client: &Client{APIBase: server.URL, APIKey: "test-key", HTTPClient: server.Client()}}
+	data := TeamResourceModel{ID: types.StringValue("expected-team")}
+	if err := teamResource.readTeam(context.Background(), &data); err == nil || !strings.Contains(err.Error(), "different-team") {
+		t.Fatalf("readTeam mismatch error = %v, want remote identity diagnostic", err)
+	}
+}
 
 func TestReadTeamResolvesUnknownOptionalComputedCollections(t *testing.T) {
 	t.Parallel()

--- a/internal_testing/resources/team_custom_id.tf
+++ b/internal_testing/resources/team_custom_id.tf
@@ -1,0 +1,19 @@
+# litellm_team - Custom team_id
+#
+# Exercises user-specified identity: both id and team_id must reflect the exact
+# value sent to /team/new instead of a provider-generated UUID.
+#
+# Run with: make smoke resources=team_custom_id.tf
+
+resource "litellm_team" "custom_id" {
+  team_alias = "test-team-custom-id"
+  team_id    = "test-team-custom-id-smoke"
+}
+
+output "team_custom_id_id" {
+  value = litellm_team.custom_id.id
+}
+
+output "team_custom_id_team_id" {
+  value = litellm_team.custom_id.team_id
+}


### PR DESCRIPTION
### Summary

Closes #122. Adds an optional, computed `team_id` to `litellm_team`, allowing external identity providers and JWT `groups` claims to target a stable predetermined LiteLLM team identity. If omitted, the provider continues generating and sending a UUID exactly as before. `id` and `team_id` always represent the same remote team, and changing `team_id` replaces the resource.

Imports populate both identity fields. Read-back verifies LiteLLM did not return a different identity, migrates existing state from `id`, and URL-encodes custom IDs for both team information and permissions reads. This retains the active Plugin Framework design and contributor PR #123's intent without modifying the repository's unused legacy SDKv2 implementation.

### Validation

Live LiteLLM v1.98.0 validation used a custom ID containing slash, space, `#`, and `&`. Create, no-drift plan, in-place alias Update, no-drift plan, team-ID replacement, no-drift plan, Delete, and remote absence checks passed. Hash-safe query encoding worked for both read endpoints. A separately created custom-ID team imported with matching `id`/`team_id`, planned cleanly, and destroyed successfully. Focused tests, `go vet`, full tests, race tests, and the generated-ID 23-resource real-dev lifecycle suite pass.

### Diff size

**Docs** — 2 files · `+18 / -1`

Documents custom IDs, external identity/JWT usage, generated defaults, replacement, and contributor attribution.

**Implementation** — 1 file · `+40 / -4`

Adds active Framework schema/state lifecycle support, migration/import mirroring, identity verification, and query escaping.

**Tests** — 2 files · `+156 / -0`

Covers schema contracts, configured/generated selection, import identity, special-character read paths, mismatch rejection, and destructive acceptance configuration.
