### PR TITLE
feat: manage team access group IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`litellm_user`**: Safely adopt an existing exact-email account after an HTTP 409, verify any configured ID, converge managed fields and team membership, and avoid generating an unrecoverable key. ([#117](https://github.com/ncecere/terraform-provider-litellm/issues/117))
 - **`litellm_key`**: Add `key_wo` with a persisted replacement trigger and hash-only lifecycle/import support so predefined keys can remain absent from Terraform plan, state, and private state. ([#86](https://github.com/ncecere/terraform-provider-litellm/issues/86)) — thanks @ripiomatiascalvo
 - **`litellm_team`**: Allow a stable custom `team_id` for external identity and JWT group mapping while preserving generated IDs by default. ([#122](https://github.com/ncecere/terraform-provider-litellm/issues/122)) — thanks @TheCodingSheikh
+- **`litellm_team`**: Add unordered `access_group_ids` management and expose team access groups through the data source. ([#149](https://github.com/ncecere/terraform-provider-litellm/issues/149))
 
 ## [2.0.1] - 2026-06-12
 

--- a/docs/data-sources/team.md
+++ b/docs/data-sources/team.md
@@ -36,6 +36,7 @@ resource "litellm_key" "team_key" {
 * `team_id` - The team ID.
 * `team_alias` - The human-readable alias for the team.
 * `organization_id` - The organization this team belongs to.
+* `access_group_ids` - Unordered set of access group IDs associated with the team.
 * `models` - List of models the team can access.
 * `max_budget` - Maximum budget for the team.
 * `spend` - Current spend for the team.

--- a/docs/resources/team.md
+++ b/docs/resources/team.md
@@ -28,6 +28,26 @@ resource "litellm_team" "identity_group" {
 
 If omitted, the provider generates a UUID as before. Changing `team_id` replaces the team.
 
+### With Access Groups
+
+Associate access groups with a team to grant their grouped model access:
+
+```hcl
+resource "litellm_access_group" "engineering" {
+  access_group = "engineering-models"
+  model_names  = ["gpt-4o", "gpt-4o-mini"]
+}
+
+resource "litellm_team" "engineering" {
+  team_alias = "Engineering"
+  access_group_ids = [
+    litellm_access_group.engineering.id,
+  ]
+}
+```
+
+`access_group_ids` is unordered. Set it to `[]` to detach all access groups; omitting it allows the provider to read the current API associations.
+
 ### Full
 
 ```hcl
@@ -105,6 +125,7 @@ The following arguments are supported:
 * `team_alias` - (Required) A human-readable alias for the team.
 * `team_id` - (Optional, Computed, Forces replacement) Stable LiteLLM team identifier. Supply a predetermined value for external identity or JWT group mapping, or omit it to let the provider generate a UUID.
 * `organization_id` - (Optional) The ID of the organization this team belongs to.
+* `access_group_ids` - (Optional, Computed) Unordered set of access group IDs associated with the team. Use `[]` to detach all groups.
 * `max_budget` - (Optional) Maximum budget allocated to the team.
 * `budget_duration` - (Optional) Duration for the budget cycle (e.g., `"30d"`, `"7d"`, `"1h"`).
 * `tpm_limit` - (Optional) Tokens per minute limit for the team.
@@ -140,6 +161,7 @@ In addition to the arguments above, the following attributes are exported:
 The following attributes are both Optional and Computed (they are read back from the API if not explicitly set):
 
 * `metadata`
+* `access_group_ids`
 * `models`
 * `model_aliases`
 * `model_rpm_limit`

--- a/internal/provider/datasource_team.go
+++ b/internal/provider/datasource_team.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -25,6 +26,7 @@ type TeamDataSourceModel struct {
 	TeamID                types.String  `tfsdk:"team_id"`
 	TeamAlias             types.String  `tfsdk:"team_alias"`
 	OrganizationID        types.String  `tfsdk:"organization_id"`
+	AccessGroupIDs        types.Set     `tfsdk:"access_group_ids"`
 	Models                types.List    `tfsdk:"models"`
 	MaxBudget             types.Float64 `tfsdk:"max_budget"`
 	Spend                 types.Float64 `tfsdk:"spend"`
@@ -59,6 +61,11 @@ func (d *TeamDataSource) Schema(ctx context.Context, req datasource.SchemaReques
 			"organization_id": schema.StringAttribute{
 				Description: "Organization ID for the team.",
 				Computed:    true,
+			},
+			"access_group_ids": schema.SetAttribute{
+				Description: "Access group IDs associated with this team.",
+				Computed:    true,
+				ElementType: types.StringType,
 			},
 			"models": schema.ListAttribute{
 				Description: "List of models the team can access.",
@@ -129,7 +136,7 @@ func (d *TeamDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 	}
 
 	teamID := data.TeamID.ValueString()
-	endpoint := fmt.Sprintf("/team/info?team_id=%s", teamID)
+	endpoint := fmt.Sprintf("/team/info?team_id=%s", url.QueryEscape(teamID))
 
 	var result map[string]interface{}
 	if err := d.client.DoRequestWithResponse(ctx, "GET", endpoint, nil, &result); err != nil {
@@ -191,6 +198,13 @@ func (d *TeamDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 		data.Models, _ = types.ListValue(types.StringType, []attr.Value{})
 	}
 
+	accessGroupIDs, err := stringSetFromAPI(ctx, teamInfo["access_group_ids"])
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid Team Response", fmt.Sprintf("Unable to decode access_group_ids for team '%s': %s", teamID, err))
+		return
+	}
+	data.AccessGroupIDs = accessGroupIDs
+
 	// Handle metadata map
 	if metadata, ok := teamInfo["metadata"].(map[string]interface{}); ok {
 		metaMap := make(map[string]attr.Value)
@@ -205,7 +219,7 @@ func (d *TeamDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 	}
 
 	// Fetch permissions separately
-	permEndpoint := fmt.Sprintf("/team/permissions_list?team_id=%s", teamID)
+	permEndpoint := fmt.Sprintf("/team/permissions_list?team_id=%s", url.QueryEscape(teamID))
 	var permResult map[string]interface{}
 	if err := d.client.DoRequestWithResponse(ctx, "GET", permEndpoint, nil, &permResult); err == nil {
 		if perms, ok := permResult["team_member_permissions"].([]interface{}); ok {

--- a/internal/provider/datasource_team_test.go
+++ b/internal/provider/datasource_team_test.go
@@ -1,0 +1,26 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	datasourceschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+)
+
+func TestTeamDataSourceAccessGroupIDsAreComputedUnordered(t *testing.T) {
+	t.Parallel()
+
+	var response datasource.SchemaResponse
+	(&TeamDataSource{}).Schema(context.Background(), datasource.SchemaRequest{}, &response)
+	if response.Diagnostics.HasError() {
+		t.Fatalf("schema diagnostics: %v", response.Diagnostics)
+	}
+	attribute, ok := response.Schema.Attributes["access_group_ids"].(datasourceschema.SetAttribute)
+	if !ok {
+		t.Fatalf("access_group_ids schema type = %T, want schema.SetAttribute", response.Schema.Attributes["access_group_ids"])
+	}
+	if !attribute.Computed || attribute.Optional || attribute.Required {
+		t.Fatalf("data source access_group_ids must be Computed-only: %#v", attribute)
+	}
+}

--- a/internal/provider/resource_team.go
+++ b/internal/provider/resource_team.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -34,6 +35,7 @@ type TeamResourceModel struct {
 	TeamID                types.String  `tfsdk:"team_id"`
 	TeamAlias             types.String  `tfsdk:"team_alias"`
 	OrganizationID        types.String  `tfsdk:"organization_id"`
+	AccessGroupIDs        types.Set     `tfsdk:"access_group_ids"`
 	Metadata              types.Map     `tfsdk:"metadata"`
 	TPMLimit              types.Int64   `tfsdk:"tpm_limit"`
 	RPMLimit              types.Int64   `tfsdk:"rpm_limit"`
@@ -71,6 +73,32 @@ func teamIDForCreate(configured types.String) string {
 		return configured.ValueString()
 	}
 	return uuid.New().String()
+}
+
+func stringSetFromAPI(ctx context.Context, value interface{}) (types.Set, error) {
+	values := []string{}
+	switch typed := value.(type) {
+	case nil:
+	case []string:
+		values = typed
+	case []interface{}:
+		values = make([]string, 0, len(typed))
+		for _, item := range typed {
+			stringValue, ok := item.(string)
+			if !ok {
+				return types.SetNull(types.StringType), fmt.Errorf("expected a string, got %T", item)
+			}
+			values = append(values, stringValue)
+		}
+	default:
+		return types.SetNull(types.StringType), fmt.Errorf("expected a list of strings, got %T", value)
+	}
+
+	set, diagnostics := types.SetValueFrom(ctx, types.StringType, values)
+	if diagnostics.HasError() {
+		return types.SetNull(types.StringType), fmt.Errorf("failed to convert string set: %v", diagnostics.Errors())
+	}
+	return set, nil
 }
 
 var fallbackEntryAttrTypes = map[string]attr.Type{
@@ -117,6 +145,15 @@ func (r *TeamResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 			"organization_id": schema.StringAttribute{
 				Description: "Organization ID for the team.",
 				Optional:    true,
+			},
+			"access_group_ids": schema.SetAttribute{
+				Description: "Access group IDs associated with this team. Order is ignored. Set an empty collection to detach all access groups.",
+				Optional:    true,
+				Computed:    true,
+				ElementType: types.StringType,
+				Validators: []validator.Set{
+					setvalidator.ValueStringsAre(stringvalidator.LengthAtLeast(1)),
+				},
 			},
 			"metadata": schema.MapAttribute{
 				Description: "Arbitrary metadata for the team.",
@@ -415,6 +452,12 @@ func (r *TeamResource) buildTeamRequest(ctx context.Context, data *TeamResourceM
 		teamReq["budget_duration"] = data.BudgetDuration.ValueString()
 	}
 
+	if !data.AccessGroupIDs.IsNull() && !data.AccessGroupIDs.IsUnknown() {
+		var accessGroupIDs []string
+		data.AccessGroupIDs.ElementsAs(ctx, &accessGroupIDs, false)
+		teamReq["access_group_ids"] = accessGroupIDs
+	}
+
 	// Numeric fields - check IsNull and IsUnknown
 	if !data.TPMLimit.IsNull() && !data.TPMLimit.IsUnknown() {
 		teamReq["tpm_limit"] = data.TPMLimit.ValueInt64()
@@ -616,6 +659,11 @@ func (r *TeamResource) readTeam(ctx context.Context, data *TeamResourceModel) er
 	if orgID, ok := teamInfo["organization_id"].(string); ok && orgID != "" {
 		data.OrganizationID = types.StringValue(orgID)
 	}
+	accessGroupIDs, err := stringSetFromAPI(ctx, teamInfo["access_group_ids"])
+	if err != nil {
+		return fmt.Errorf("invalid access_group_ids in team response: %w", err)
+	}
+	data.AccessGroupIDs = accessGroupIDs
 	if v, exists := teamInfo["tpm_limit"]; exists {
 		if tpm, ok := v.(float64); ok {
 			data.TPMLimit = types.Int64Value(int64(tpm))

--- a/internal/provider/resource_team_test.go
+++ b/internal/provider/resource_team_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 
@@ -68,6 +69,53 @@ func TestTeamImportMirrorsIDAndTeamID(t *testing.T) {
 	}
 }
 
+func TestTeamAccessGroupIDsSchemaIsOptionalUnordered(t *testing.T) {
+	t.Parallel()
+
+	var response resource.SchemaResponse
+	(&TeamResource{}).Schema(context.Background(), resource.SchemaRequest{}, &response)
+	if response.Diagnostics.HasError() {
+		t.Fatalf("schema diagnostics: %v", response.Diagnostics)
+	}
+	attribute, ok := response.Schema.Attributes["access_group_ids"].(resourceschema.SetAttribute)
+	if !ok {
+		t.Fatalf("access_group_ids schema type = %T, want schema.SetAttribute", response.Schema.Attributes["access_group_ids"])
+	}
+	if !attribute.Optional || !attribute.Computed || attribute.Required {
+		t.Fatalf("access_group_ids must be Optional+Computed: %#v", attribute)
+	}
+	if len(attribute.Validators) != 1 {
+		t.Fatalf("access_group_ids validators = %d, want 1", len(attribute.Validators))
+	}
+}
+
+func TestBuildTeamRequestIncludesManagedAccessGroupIDs(t *testing.T) {
+	t.Parallel()
+
+	data := &TeamResourceModel{
+		TeamAlias: types.StringValue("access-group-team"),
+		AccessGroupIDs: types.SetValueMust(types.StringType, []attr.Value{
+			types.StringValue("group-b"),
+			types.StringValue("group-a"),
+		}),
+	}
+	request := (&TeamResource{}).buildTeamRequest(context.Background(), data, "team-123")
+	got, ok := request["access_group_ids"].([]string)
+	if !ok {
+		t.Fatalf("access_group_ids request type = %T, want []string", request["access_group_ids"])
+	}
+	if len(got) != 2 || !slices.Contains(got, "group-a") || !slices.Contains(got, "group-b") {
+		t.Fatalf("access_group_ids request = %v", got)
+	}
+
+	data.AccessGroupIDs = types.SetValueMust(types.StringType, []attr.Value{})
+	request = (&TeamResource{}).buildTeamRequest(context.Background(), data, "team-123")
+	got, ok = request["access_group_ids"].([]string)
+	if !ok || len(got) != 0 {
+		t.Fatalf("empty access_group_ids request = %#v, want []string{}", request["access_group_ids"])
+	}
+}
+
 func TestTeamIDForCreatePreservesCustomOrGeneratesUUID(t *testing.T) {
 	t.Parallel()
 
@@ -101,8 +149,9 @@ func TestReadTeamCustomIDIsEscapedAndMirrored(t *testing.T) {
 		case "/team/info":
 			_ = json.NewEncoder(writer).Encode(map[string]interface{}{
 				"team_info": map[string]interface{}{
-					"team_id":    teamID,
-					"team_alias": "Engineering Platform",
+					"team_id":          teamID,
+					"team_alias":       "Engineering Platform",
+					"access_group_ids": []interface{}{"group-b", "group-a"},
 				},
 			})
 		case "/team/permissions_list":
@@ -117,9 +166,13 @@ func TestReadTeamCustomIDIsEscapedAndMirrored(t *testing.T) {
 
 	teamResource := &TeamResource{client: &Client{APIBase: server.URL, APIKey: "test-key", HTTPClient: server.Client()}}
 	data := TeamResourceModel{
-		ID:                    types.StringValue(teamID),
-		TeamID:                types.StringNull(),
-		TeamAlias:             types.StringValue("Engineering Platform"),
+		ID:        types.StringValue(teamID),
+		TeamID:    types.StringNull(),
+		TeamAlias: types.StringValue("Engineering Platform"),
+		AccessGroupIDs: types.SetValueMust(types.StringType, []attr.Value{
+			types.StringValue("group-a"),
+			types.StringValue("group-b"),
+		}),
 		TeamMemberPermissions: types.ListUnknown(types.StringType),
 	}
 	if err := teamResource.readTeam(context.Background(), &data); err != nil {
@@ -127,6 +180,13 @@ func TestReadTeamCustomIDIsEscapedAndMirrored(t *testing.T) {
 	}
 	if data.TeamID.ValueString() != teamID || data.ID.ValueString() != teamID {
 		t.Fatalf("team identity not mirrored: id=%q team_id=%q", data.ID.ValueString(), data.TeamID.ValueString())
+	}
+	expectedGroups := types.SetValueMust(types.StringType, []attr.Value{
+		types.StringValue("group-a"),
+		types.StringValue("group-b"),
+	})
+	if !data.AccessGroupIDs.Equal(expectedGroups) {
+		t.Fatalf("access_group_ids = %v, want %v", data.AccessGroupIDs, expectedGroups)
 	}
 }
 
@@ -261,10 +321,11 @@ func TestReadTeamIgnoresUnconfiguredServerBudgetDefaults(t *testing.T) {
 		case "/team/info":
 			_ = json.NewEncoder(w).Encode(map[string]interface{}{
 				"team_info": map[string]interface{}{
-					"team_id":         "team-defaults",
-					"team_alias":      "defaults-team",
-					"max_budget":      500.0,
-					"budget_duration": "30d",
+					"team_id":          "team-defaults",
+					"team_alias":       "defaults-team",
+					"max_budget":       500.0,
+					"budget_duration":  "30d",
+					"access_group_ids": []interface{}{"externally-managed"},
 				},
 			})
 		case "/team/permissions_list":
@@ -290,6 +351,7 @@ func TestReadTeamIgnoresUnconfiguredServerBudgetDefaults(t *testing.T) {
 		TeamAlias:      types.StringValue("defaults-team"),
 		MaxBudget:      types.Float64Null(),
 		BudgetDuration: types.StringNull(),
+		AccessGroupIDs: types.SetNull(types.StringType),
 	}
 
 	if err := r.readTeam(context.Background(), &data); err != nil {
@@ -300,6 +362,10 @@ func TestReadTeamIgnoresUnconfiguredServerBudgetDefaults(t *testing.T) {
 	}
 	if !data.BudgetDuration.IsNull() {
 		t.Errorf("unconfigured budget_duration should remain null, got %v", data.BudgetDuration)
+	}
+	expectedAccessGroups := types.SetValueMust(types.StringType, []attr.Value{types.StringValue("externally-managed")})
+	if !data.AccessGroupIDs.Equal(expectedAccessGroups) {
+		t.Errorf("access_group_ids = %v, want API value %v", data.AccessGroupIDs, expectedAccessGroups)
 	}
 }
 

--- a/internal_testing/resources/team_access_groups.tf
+++ b/internal_testing/resources/team_access_groups.tf
@@ -1,0 +1,16 @@
+# litellm_team - Access group association
+# Pair with model_minimal.tf and access_group_minimal.tf.
+#
+# Run with:
+#   make smoke resources=model_minimal.tf,access_group_minimal.tf,team_access_groups.tf
+
+resource "litellm_team" "access_groups" {
+  team_alias = "test-team-access-groups"
+  access_group_ids = [
+    litellm_access_group.minimal.id,
+  ]
+}
+
+output "team_access_group_ids" {
+  value = litellm_team.access_groups.access_group_ids
+}


### PR DESCRIPTION
### Summary

Closes #149. Adds `access_group_ids` to `litellm_team` as an Optional+Computed set, so association order does not produce drift. Known values are sent during Create/Update, including an explicit empty set to detach every access group. Read and import adopt API associations, and out-of-band changes remain visible as Terraform drift.

The `litellm_team` data source now exposes the same unordered set. Its information and permissions requests also URL-encode team IDs, allowing the custom external-identity IDs introduced by #122 to work through the data source.

### Validation

Live LiteLLM v1.98.0 validation created an access group and attached it to a team whose custom ID contained slash, space, `#`, and `&`. Both the resource and data source read the association and planned cleanly. An out-of-band API detach produced an in-place Terraform drift plan; apply restored the group and returned to no drift. Configuring `[]` detached all associations, both resource and data source read empty sets, and the plan was clean. Omitting the argument after the empty state remained clean. Destroy and remote-absence checks passed. Two-ID ordering is covered by mocked API tests because LiteLLM's access-group model assignment displaced one live group when both test groups referenced the same model. Focused tests, `go vet`, full tests, race tests, and the 23-resource real-dev lifecycle suite pass.

### Diff size

**Docs** — 3 files · `+24 / -0`

Documents association, unordered semantics, explicit detach behavior, and data-source output.

**Implementation** — 2 files · `+64 / -2`

Adds resource/data-source schema and conversion, API request/read-back support, and custom-ID query escaping in the data source.

**Tests** — 3 files · `+117 / -9`

Covers schemas, unordered read-back, API adoption, known and empty request payloads, and destructive acceptance composition.
