### PR TITLE
feat: add recurring team-member budgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`litellm_key`**: Add `key_wo` with a persisted replacement trigger and hash-only lifecycle/import support so predefined keys can remain absent from Terraform plan, state, and private state. ([#86](https://github.com/ncecere/terraform-provider-litellm/issues/86)) — thanks @ripiomatiascalvo
 - **`litellm_team`**: Allow a stable custom `team_id` for external identity and JWT group mapping while preserving generated IDs by default. ([#122](https://github.com/ncecere/terraform-provider-litellm/issues/122)) — thanks @TheCodingSheikh
 - **`litellm_team`**: Add unordered `access_group_ids` management and expose team access groups through the data source. ([#149](https://github.com/ncecere/terraform-provider-litellm/issues/149))
+- **`litellm_team_member` / `litellm_team`**: Add recurring member budget durations through LiteLLM v1.98.0's native member and team APIs. ([#112](https://github.com/ncecere/terraform-provider-litellm/issues/112)) — thanks @obervinov
 
 ## [2.0.1] - 2026-06-12
 

--- a/docs/resources/team.md
+++ b/docs/resources/team.md
@@ -66,7 +66,8 @@ resource "litellm_team" "full" {
   prompts    = []
 
   team_member_permissions = []
-  team_member_budget      = 50.0
+  team_member_budget          = 50.0
+  team_member_budget_duration = "30d"
   team_member_rpm_limit   = 100
   team_member_tpm_limit   = 10000
 
@@ -138,6 +139,7 @@ The following arguments are supported:
 * `prompts` - (Optional) List of prompt identifiers associated with the team.
 * `team_member_permissions` - (Optional) List of permissions granted to team members.
 * `team_member_budget` - (Optional) Default budget for each team member.
+* `team_member_budget_duration` - (Optional) Recurring reset interval for the default member budget, such as `30d`, `24h`, `1mo`, or `monthly`. LiteLLM applies it to new/default membership budgets and may backfill memberships without a budget; private member overrides are preserved. Configure `litellm_team_member.budget_duration` for per-member control.
 * `team_member_rpm_limit` - (Optional) Default requests per minute limit for each team member.
 * `team_member_tpm_limit` - (Optional) Default tokens per minute limit for each team member.
 * `metadata` - (Optional) A map of metadata pairs for the team. Values are strings; use `jsonencode()` for complex values (objects, arrays) — they will be sent as native JSON to the API.

--- a/docs/resources/team_member.md
+++ b/docs/resources/team_member.md
@@ -24,7 +24,7 @@ resource "litellm_team_member" "developer" {
 - `team_id` - (Required) The ID of the team.
 - `user_id` - (Required) The ID of the user to add to the team.
 - `user_email` - (Required) The email address of the user.
-- `role` - (Required) The role of the user within the team. Valid values: `org_admin`, `internal_user`, `internal_user_viewer`, `admin`, `user`.
+- `role` - (Required) The role of the user within the team. LiteLLM v1.98 supports `admin` or `user`.
 - `max_budget_in_team` - (Optional) The maximum budget allocated to this user within the team.
 - `budget_duration` - (Optional) Recurring reset interval for this member's budget, such as `30d`, `24h`, `1mo`, or `monthly`. It may be set without an explicit `max_budget_in_team` to override an inherited/default interval. LiteLLM manages `budget_reset_at` and subsequent resets; the provider sends this value directly through the native team-member API.
 

--- a/docs/resources/team_member.md
+++ b/docs/resources/team_member.md
@@ -13,7 +13,9 @@ resource "litellm_team_member" "developer" {
   team_id    = litellm_team.engineering.id
   user_id    = "developer-1"
   user_email = "developer@example.com"
-  role       = "user"
+  role               = "user"
+  max_budget_in_team = 50
+  budget_duration    = "30d"
 }
 ```
 
@@ -24,6 +26,7 @@ resource "litellm_team_member" "developer" {
 - `user_email` - (Required) The email address of the user.
 - `role` - (Required) The role of the user within the team. Valid values: `org_admin`, `internal_user`, `internal_user_viewer`, `admin`, `user`.
 - `max_budget_in_team` - (Optional) The maximum budget allocated to this user within the team.
+- `budget_duration` - (Optional) Recurring reset interval for this member's budget, such as `30d`, `24h`, `1mo`, or `monthly`. It may be set without an explicit `max_budget_in_team` to override an inherited/default interval. LiteLLM manages `budget_reset_at` and subsequent resets; the provider sends this value directly through the native team-member API.
 
 ## Attribute Reference
 

--- a/internal/provider/resource_team.go
+++ b/internal/provider/resource_team.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"regexp"
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
@@ -21,6 +22,8 @@ import (
 
 var _ resource.Resource = &TeamResource{}
 var _ resource.ResourceWithImportState = &TeamResource{}
+
+var budgetDurationPattern = regexp.MustCompile(`^([1-9][0-9]*(s|m|h|d|w)|1mo|hourly|daily|weekly|monthly)$`)
 
 func NewTeamResource() resource.Resource {
 	return &TeamResource{}
@@ -53,6 +56,7 @@ type TeamResourceModel struct {
 	Blocked               types.Bool    `tfsdk:"blocked"`
 	TeamMemberPermissions types.List    `tfsdk:"team_member_permissions"`
 	TeamMemberBudget      types.Float64 `tfsdk:"team_member_budget"`
+	MemberBudgetDuration  types.String  `tfsdk:"team_member_budget_duration"`
 	TeamMemberRPMLimit    types.Int64   `tfsdk:"team_member_rpm_limit"`
 	TeamMemberTPMLimit    types.Int64   `tfsdk:"team_member_tpm_limit"`
 	RouterSettings        types.Object  `tfsdk:"router_settings"`
@@ -242,6 +246,16 @@ func (r *TeamResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 				Description: "Default budget for team members.",
 				Optional:    true,
 			},
+			"team_member_budget_duration": schema.StringAttribute{
+				Description: "Default recurring budget reset interval for team memberships (for example, 30d or 24h). LiteLLM applies it to new/default memberships and may backfill memberships without a budget; private member overrides are preserved.",
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(
+						budgetDurationPattern,
+						`must be hourly, daily, weekly, monthly, 1mo, or a positive integer with unit s, m, h, d, or w`,
+					),
+				},
+			},
 			"team_member_rpm_limit": schema.Int64Attribute{
 				Description: "Default RPM limit for team members.",
 				Optional:    true,
@@ -382,6 +396,16 @@ func (r *TeamResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	teamReq := r.buildTeamRequest(ctx, &data, data.ID.ValueString())
 	applyTeamNullableClears(teamReq, &state, &data)
 
+	// LiteLLM's team-default budget handler ignores explicit nulls whenever the
+	// same request also contains another non-null member-budget field. Split
+	// clears into their own merge-patch before applying the remaining changes.
+	if clearReq := extractTeamMemberBudgetClears(teamReq, data.ID.ValueString()); clearReq != nil {
+		if err := r.client.DoRequestWithResponse(ctx, "POST", "/team/update", clearReq, nil); err != nil {
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to clear team member budget defaults: %s", err))
+			return
+		}
+	}
+
 	if err := r.client.DoRequestWithResponse(ctx, "POST", "/team/update", teamReq, nil); err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update team: %s", err))
 		return
@@ -470,6 +494,9 @@ func (r *TeamResource) buildTeamRequest(ctx context.Context, data *TeamResourceM
 	}
 	if !data.TeamMemberBudget.IsNull() && !data.TeamMemberBudget.IsUnknown() {
 		teamReq["team_member_budget"] = data.TeamMemberBudget.ValueFloat64()
+	}
+	if !data.MemberBudgetDuration.IsNull() && !data.MemberBudgetDuration.IsUnknown() {
+		teamReq["team_member_budget_duration"] = data.MemberBudgetDuration.ValueString()
 	}
 	if !data.TeamMemberRPMLimit.IsNull() && !data.TeamMemberRPMLimit.IsUnknown() {
 		teamReq["team_member_rpm_limit"] = data.TeamMemberRPMLimit.ValueInt64()
@@ -566,6 +593,25 @@ func (r *TeamResource) buildTeamRequest(ctx context.Context, data *TeamResourceM
 	return teamReq
 }
 
+func extractTeamMemberBudgetClears(teamReq map[string]interface{}, teamID string) map[string]interface{} {
+	clearReq := map[string]interface{}{"team_id": teamID}
+	for _, field := range []string{
+		"team_member_budget",
+		"team_member_budget_duration",
+		"team_member_rpm_limit",
+		"team_member_tpm_limit",
+	} {
+		if value, exists := teamReq[field]; exists && value == nil {
+			clearReq[field] = nil
+			delete(teamReq, field)
+		}
+	}
+	if len(clearReq) == 1 {
+		return nil
+	}
+	return clearReq
+}
+
 // applyTeamNullableClears mutates teamReq to send explicit JSON null for nullable
 // fields that transition from set (non-null in state) to cleared (null in plan).
 // Without this, json.Marshal omits the field entirely; the LiteLLM API uses Pydantic
@@ -586,6 +632,9 @@ func applyTeamNullableClears(teamReq map[string]interface{}, state, plan *TeamRe
 	}
 	if !state.TeamMemberBudget.IsNull() && plan.TeamMemberBudget.IsNull() {
 		teamReq["team_member_budget"] = nil
+	}
+	if !state.MemberBudgetDuration.IsNull() && plan.MemberBudgetDuration.IsNull() {
+		teamReq["team_member_budget_duration"] = nil
 	}
 	if !state.TeamMemberRPMLimit.IsNull() && plan.TeamMemberRPMLimit.IsNull() {
 		teamReq["team_member_rpm_limit"] = nil
@@ -715,32 +764,77 @@ func (r *TeamResource) readTeam(ctx context.Context, data *TeamResourceModel) er
 	if rpmLimitType, ok := teamInfo["rpm_limit_type"].(string); ok && rpmLimitType != "" {
 		data.RPMLimitType = types.StringValue(rpmLimitType)
 	}
-	if v, exists := teamInfo["team_member_budget"]; exists {
-		if teamMemberBudget, ok := v.(float64); ok {
-			data.TeamMemberBudget = types.Float64Value(teamMemberBudget)
-		} else if v == nil {
+	teamMemberBudgetInfo := teamInfo
+	if nestedBudget, ok := teamInfo["team_member_budget_table"].(map[string]interface{}); ok {
+		teamMemberBudgetInfo = nestedBudget
+	}
+	if !data.TeamMemberBudget.IsNull() || data.TeamMemberBudget.IsUnknown() {
+		if v, exists := teamMemberBudgetInfo["team_member_budget"]; exists {
+			if teamMemberBudget, ok := v.(float64); ok {
+				data.TeamMemberBudget = types.Float64Value(teamMemberBudget)
+			} else if v == nil {
+				data.TeamMemberBudget = types.Float64Null()
+			}
+		} else if v, exists := teamMemberBudgetInfo["max_budget"]; exists {
+			if teamMemberBudget, ok := v.(float64); ok {
+				data.TeamMemberBudget = types.Float64Value(teamMemberBudget)
+			} else if v == nil {
+				data.TeamMemberBudget = types.Float64Null()
+			}
+		} else if data.TeamMemberBudget.IsUnknown() {
 			data.TeamMemberBudget = types.Float64Null()
 		}
-	} else if data.TeamMemberBudget.IsUnknown() {
-		data.TeamMemberBudget = types.Float64Null()
 	}
-	if v, exists := teamInfo["team_member_rpm_limit"]; exists {
-		if teamMemberRPMLimit, ok := v.(float64); ok {
-			data.TeamMemberRPMLimit = types.Int64Value(int64(teamMemberRPMLimit))
-		} else if v == nil {
+	if !data.MemberBudgetDuration.IsNull() || data.MemberBudgetDuration.IsUnknown() {
+		if v, exists := teamMemberBudgetInfo["team_member_budget_duration"]; exists {
+			if duration, ok := v.(string); ok && duration != "" {
+				data.MemberBudgetDuration = types.StringValue(duration)
+			} else if v == nil || v == "" {
+				data.MemberBudgetDuration = types.StringNull()
+			}
+		} else if v, exists := teamMemberBudgetInfo["budget_duration"]; exists {
+			if duration, ok := v.(string); ok && duration != "" {
+				data.MemberBudgetDuration = types.StringValue(duration)
+			} else if v == nil || v == "" {
+				data.MemberBudgetDuration = types.StringNull()
+			}
+		} else if data.MemberBudgetDuration.IsUnknown() {
+			data.MemberBudgetDuration = types.StringNull()
+		}
+	}
+	if !data.TeamMemberRPMLimit.IsNull() || data.TeamMemberRPMLimit.IsUnknown() {
+		if v, exists := teamMemberBudgetInfo["team_member_rpm_limit"]; exists {
+			if teamMemberRPMLimit, ok := v.(float64); ok {
+				data.TeamMemberRPMLimit = types.Int64Value(int64(teamMemberRPMLimit))
+			} else if v == nil {
+				data.TeamMemberRPMLimit = types.Int64Null()
+			}
+		} else if v, exists := teamMemberBudgetInfo["rpm_limit"]; exists {
+			if teamMemberRPMLimit, ok := v.(float64); ok {
+				data.TeamMemberRPMLimit = types.Int64Value(int64(teamMemberRPMLimit))
+			} else if v == nil {
+				data.TeamMemberRPMLimit = types.Int64Null()
+			}
+		} else if data.TeamMemberRPMLimit.IsUnknown() {
 			data.TeamMemberRPMLimit = types.Int64Null()
 		}
-	} else if data.TeamMemberRPMLimit.IsUnknown() {
-		data.TeamMemberRPMLimit = types.Int64Null()
 	}
-	if v, exists := teamInfo["team_member_tpm_limit"]; exists {
-		if teamMemberTPMLimit, ok := v.(float64); ok {
-			data.TeamMemberTPMLimit = types.Int64Value(int64(teamMemberTPMLimit))
-		} else if v == nil {
+	if !data.TeamMemberTPMLimit.IsNull() || data.TeamMemberTPMLimit.IsUnknown() {
+		if v, exists := teamMemberBudgetInfo["team_member_tpm_limit"]; exists {
+			if teamMemberTPMLimit, ok := v.(float64); ok {
+				data.TeamMemberTPMLimit = types.Int64Value(int64(teamMemberTPMLimit))
+			} else if v == nil {
+				data.TeamMemberTPMLimit = types.Int64Null()
+			}
+		} else if v, exists := teamMemberBudgetInfo["tpm_limit"]; exists {
+			if teamMemberTPMLimit, ok := v.(float64); ok {
+				data.TeamMemberTPMLimit = types.Int64Value(int64(teamMemberTPMLimit))
+			} else if v == nil {
+				data.TeamMemberTPMLimit = types.Int64Null()
+			}
+		} else if data.TeamMemberTPMLimit.IsUnknown() {
 			data.TeamMemberTPMLimit = types.Int64Null()
 		}
-	} else if data.TeamMemberTPMLimit.IsUnknown() {
-		data.TeamMemberTPMLimit = types.Int64Null()
 	}
 
 	// Handle models list - preserve null when API returns empty and config didn't specify models

--- a/internal/provider/resource_team_member.go
+++ b/internal/provider/resource_team_member.go
@@ -166,19 +166,20 @@ func (r *TeamMemberResource) Create(ctx context.Context, req resource.CreateRequ
 
 	memberReq := buildTeamMemberAddRequest(&data)
 	if err := r.client.DoRequestWithResponse(ctx, "POST", "/team/member_add", memberReq, nil); err != nil {
-		// If the exact roster entry appeared after a preflight that proved it was
-		// absent, recover a partially successful/ambiguous add through the native
-		// update endpoint. Budget rows alone are not membership proof.
+		// A roster entry that appears after preflight might be a partial success or
+		// a concurrent external add. Without backend operation identity, ownership
+		// is ambiguous: never mutate or silently adopt it.
 		postAdd := data
 		exists, verifyErr := r.readTeamMember(ctx, &postAdd)
-		if verifyErr != nil || !exists {
-			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to add team member: %s", err))
+		if verifyErr == nil && exists {
+			resp.Diagnostics.AddError(
+				"Ambiguous Team Member Creation",
+				"The add request failed, but the user is now present in the team roster. The provider cannot prove who created it and did not reconcile or adopt it. Import the membership after verifying ownership.",
+			)
 			return
 		}
-		if updateErr := r.client.DoRequestWithResponse(ctx, "POST", "/team/member_update", buildTeamMemberUpdateRequest(&data), nil); updateErr != nil {
-			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Team member appeared after add failed but could not be reconciled: %s", updateErr))
-			return
-		}
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to add team member: %s", err))
+		return
 	}
 
 	data.ID = types.StringValue(fmt.Sprintf("%s:%s", data.TeamID.ValueString(), data.UserID.ValueString()))

--- a/internal/provider/resource_team_member.go
+++ b/internal/provider/resource_team_member.go
@@ -65,10 +65,10 @@ func (r *TeamMemberResource) Schema(ctx context.Context, req resource.SchemaRequ
 				Required:    true,
 			},
 			"role": schema.StringAttribute{
-				Description: "Role in the team (org_admin, internal_user, internal_user_viewer, admin, user).",
+				Description: "Role in the team (admin or user).",
 				Required:    true,
 				Validators: []validator.String{
-					stringvalidator.OneOf("org_admin", "internal_user", "internal_user_viewer", "admin", "user"),
+					stringvalidator.OneOf("admin", "user"),
 				},
 			},
 			"max_budget_in_team": schema.Float64Attribute{
@@ -150,30 +150,48 @@ func (r *TeamMemberResource) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
-	memberReq := buildTeamMemberAddRequest(&data)
+	// Refuse implicit adoption. This preflight distinguishes an account that
+	// existed before Create from a membership that appears only after an
+	// ambiguous/partially successful add request.
+	observed := data
+	preexisting, err := r.readTeamMember(ctx, &observed)
+	if err != nil {
+		resp.Diagnostics.AddError("Team Member Preflight Error", fmt.Sprintf("Unable to verify that the team member does not already exist: %s", err))
+		return
+	}
+	if preexisting {
+		resp.Diagnostics.AddError("Team Member Already Exists", "The user is already in this team. Import the membership before managing it with Terraform.")
+		return
+	}
 
+	memberReq := buildTeamMemberAddRequest(&data)
 	if err := r.client.DoRequestWithResponse(ctx, "POST", "/team/member_add", memberReq, nil); err != nil {
-		// LiteLLM can report duplicate/partially-created memberships through
-		// several status/body shapes. Verify the exact team+user identity before
-		// deciding whether Create can safely continue as reconciliation.
-		observed := data
-		exists, verifyErr := r.readTeamMember(ctx, &observed)
+		// If the exact roster entry appeared after a preflight that proved it was
+		// absent, recover a partially successful/ambiguous add through the native
+		// update endpoint. Budget rows alone are not membership proof.
+		postAdd := data
+		exists, verifyErr := r.readTeamMember(ctx, &postAdd)
 		if verifyErr != nil || !exists {
 			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to add team member: %s", err))
 			return
 		}
 		if updateErr := r.client.DoRequestWithResponse(ctx, "POST", "/team/member_update", buildTeamMemberUpdateRequest(&data), nil); updateErr != nil {
-			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Team member exists after add failed but could not be reconciled: %s", updateErr))
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Team member appeared after add failed but could not be reconciled: %s", updateErr))
 			return
 		}
 	}
 
 	data.ID = types.StringValue(fmt.Sprintf("%s:%s", data.TeamID.ValueString(), data.UserID.ValueString()))
 
-	if exists, err := r.readTeamMember(ctx, &data); err != nil {
-		resp.Diagnostics.AddWarning("Read Error", fmt.Sprintf("Team member was created but could not be read back: %s", err))
-	} else if !exists {
-		resp.Diagnostics.AddWarning("Read Error", "Team member was created but was not present in the immediate team read-back.")
+	exists, readErr := r.readTeamMember(ctx, &data)
+	if readErr != nil {
+		resp.Diagnostics.AddError("Team Member Read-Back Error", fmt.Sprintf("The membership may have been created, but it could not be verified: %s", readErr))
+		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		return
+	}
+	if !exists {
+		resp.Diagnostics.AddError("Team Member Missing After Create", "LiteLLM accepted the create request but the user is not present in the team's member roster.")
+		return
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -186,7 +204,7 @@ func (r *TeamMemberResource) readTeamMember(ctx context.Context, data *TeamMembe
 		return false, err
 	}
 
-	memberFound := false
+	rosterFound := false
 	teamInfo := result
 	if nested, ok := result["team_info"].(map[string]interface{}); ok {
 		teamInfo = nested
@@ -197,7 +215,7 @@ func (r *TeamMemberResource) readTeamMember(ctx context.Context, data *TeamMembe
 			if !ok || member["user_id"] != data.UserID.ValueString() {
 				continue
 			}
-			memberFound = true
+			rosterFound = true
 			if role, ok := member["role"].(string); ok && role != "" {
 				data.Role = types.StringValue(role)
 			}
@@ -215,12 +233,11 @@ func (r *TeamMemberResource) readTeamMember(ctx context.Context, data *TeamMembe
 			if !ok || membership["user_id"] != data.UserID.ValueString() {
 				continue
 			}
-			memberFound = true
 			budget, _ = membership["litellm_budget_table"].(map[string]interface{})
 			break
 		}
 	}
-	if !memberFound {
+	if !rosterFound {
 		return false, nil
 	}
 
@@ -292,10 +309,14 @@ func (r *TeamMemberResource) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
-	if exists, err := r.readTeamMember(ctx, &data); err != nil {
-		resp.Diagnostics.AddWarning("Read Error", fmt.Sprintf("Team member was updated but could not be read back: %s", err))
-	} else if !exists {
-		resp.Diagnostics.AddWarning("Read Error", "Team member was updated but was not present in the immediate team read-back.")
+	exists, readErr := r.readTeamMember(ctx, &data)
+	if readErr != nil {
+		resp.Diagnostics.AddError("Team Member Read-Back Error", fmt.Sprintf("The membership was updated but could not be verified: %s", readErr))
+		return
+	}
+	if !exists {
+		resp.Diagnostics.AddError("Team Member Missing After Update", "LiteLLM accepted the update request but the user is not present in the team's member roster.")
+		return
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/provider/resource_team_member.go
+++ b/internal/provider/resource_team_member.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -33,6 +34,7 @@ type TeamMemberResourceModel struct {
 	UserEmail       types.String  `tfsdk:"user_email"`
 	Role            types.String  `tfsdk:"role"`
 	MaxBudgetInTeam types.Float64 `tfsdk:"max_budget_in_team"`
+	BudgetDuration  types.String  `tfsdk:"budget_duration"`
 }
 
 func (r *TeamMemberResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -73,6 +75,16 @@ func (r *TeamMemberResource) Schema(ctx context.Context, req resource.SchemaRequ
 				Description: "Maximum budget for this member in the team.",
 				Optional:    true,
 			},
+			"budget_duration": schema.StringAttribute{
+				Description: "Recurring reset interval for this member's budget (for example, 30d or 24h). It may be configured without an explicit max to override an inherited/default interval. LiteLLM manages the reset schedule.",
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(
+						budgetDurationPattern,
+						`must be hourly, daily, weekly, monthly, 1mo, or a positive integer with unit s, m, h, d, or w`,
+					),
+				},
+			},
 		},
 	}
 }
@@ -94,14 +106,7 @@ func (r *TeamMemberResource) Configure(ctx context.Context, req resource.Configu
 	r.client = client
 }
 
-func (r *TeamMemberResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var data TeamMemberResourceModel
-
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
+func buildTeamMemberAddRequest(data *TeamMemberResourceModel) map[string]interface{} {
 	memberReq := map[string]interface{}{
 		"member": []map[string]interface{}{
 			{
@@ -112,21 +117,129 @@ func (r *TeamMemberResource) Create(ctx context.Context, req resource.CreateRequ
 		},
 		"team_id": data.TeamID.ValueString(),
 	}
-
 	if !data.MaxBudgetInTeam.IsNull() && !data.MaxBudgetInTeam.IsUnknown() {
 		memberReq["max_budget_in_team"] = data.MaxBudgetInTeam.ValueFloat64()
 	}
+	if !data.BudgetDuration.IsNull() && !data.BudgetDuration.IsUnknown() {
+		memberReq["budget_duration"] = data.BudgetDuration.ValueString()
+	}
+	return memberReq
+}
+
+func buildTeamMemberUpdateRequest(data *TeamMemberResourceModel) map[string]interface{} {
+	updateReq := map[string]interface{}{
+		"user_id":    data.UserID.ValueString(),
+		"user_email": data.UserEmail.ValueString(),
+		"team_id":    data.TeamID.ValueString(),
+		"role":       data.Role.ValueString(),
+	}
+	if !data.MaxBudgetInTeam.IsNull() && !data.MaxBudgetInTeam.IsUnknown() {
+		updateReq["max_budget_in_team"] = data.MaxBudgetInTeam.ValueFloat64()
+	}
+	if !data.BudgetDuration.IsNull() && !data.BudgetDuration.IsUnknown() {
+		updateReq["budget_duration"] = data.BudgetDuration.ValueString()
+	}
+	return updateReq
+}
+
+func (r *TeamMemberResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data TeamMemberResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	memberReq := buildTeamMemberAddRequest(&data)
 
 	if err := r.client.DoRequestWithResponse(ctx, "POST", "/team/member_add", memberReq, nil); err != nil {
-		if !isTeamMemberAlreadyInTeamError(err) {
+		// LiteLLM can report duplicate/partially-created memberships through
+		// several status/body shapes. Verify the exact team+user identity before
+		// deciding whether Create can safely continue as reconciliation.
+		observed := data
+		exists, verifyErr := r.readTeamMember(ctx, &observed)
+		if verifyErr != nil || !exists {
 			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to add team member: %s", err))
+			return
+		}
+		if updateErr := r.client.DoRequestWithResponse(ctx, "POST", "/team/member_update", buildTeamMemberUpdateRequest(&data), nil); updateErr != nil {
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Team member exists after add failed but could not be reconciled: %s", updateErr))
 			return
 		}
 	}
 
 	data.ID = types.StringValue(fmt.Sprintf("%s:%s", data.TeamID.ValueString(), data.UserID.ValueString()))
 
+	if exists, err := r.readTeamMember(ctx, &data); err != nil {
+		resp.Diagnostics.AddWarning("Read Error", fmt.Sprintf("Team member was created but could not be read back: %s", err))
+	} else if !exists {
+		resp.Diagnostics.AddWarning("Read Error", "Team member was created but was not present in the immediate team read-back.")
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *TeamMemberResource) readTeamMember(ctx context.Context, data *TeamMemberResourceModel) (bool, error) {
+	endpoint := fmt.Sprintf("/team/info?team_id=%s", url.QueryEscape(data.TeamID.ValueString()))
+	var result map[string]interface{}
+	if err := r.client.DoRequestWithResponse(ctx, "GET", endpoint, nil, &result); err != nil {
+		return false, err
+	}
+
+	memberFound := false
+	teamInfo := result
+	if nested, ok := result["team_info"].(map[string]interface{}); ok {
+		teamInfo = nested
+	}
+	if members, ok := teamInfo["members_with_roles"].([]interface{}); ok {
+		for _, rawMember := range members {
+			member, ok := rawMember.(map[string]interface{})
+			if !ok || member["user_id"] != data.UserID.ValueString() {
+				continue
+			}
+			memberFound = true
+			if role, ok := member["role"].(string); ok && role != "" {
+				data.Role = types.StringValue(role)
+			}
+			if email, ok := member["user_email"].(string); ok && email != "" {
+				data.UserEmail = types.StringValue(email)
+			}
+			break
+		}
+	}
+
+	var budget map[string]interface{}
+	if memberships, ok := result["team_memberships"].([]interface{}); ok {
+		for _, rawMembership := range memberships {
+			membership, ok := rawMembership.(map[string]interface{})
+			if !ok || membership["user_id"] != data.UserID.ValueString() {
+				continue
+			}
+			memberFound = true
+			budget, _ = membership["litellm_budget_table"].(map[string]interface{})
+			break
+		}
+	}
+	if !memberFound {
+		return false, nil
+	}
+
+	if !data.MaxBudgetInTeam.IsNull() || data.MaxBudgetInTeam.IsUnknown() {
+		if value, ok := budget["max_budget"].(float64); ok {
+			data.MaxBudgetInTeam = types.Float64Value(value)
+		} else {
+			data.MaxBudgetInTeam = types.Float64Null()
+		}
+	}
+	if !data.BudgetDuration.IsNull() || data.BudgetDuration.IsUnknown() {
+		if value, ok := budget["budget_duration"].(string); ok && value != "" {
+			data.BudgetDuration = types.StringValue(value)
+		} else {
+			data.BudgetDuration = types.StringNull()
+		}
+	}
+
+	return true, nil
 }
 
 func (r *TeamMemberResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -137,8 +250,20 @@ func (r *TeamMemberResource) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 
-	// No specific endpoint to read a single team member
-	// Maintain state as-is
+	exists, err := r.readTeamMember(ctx, &data)
+	if err != nil {
+		if IsNotFoundError(err) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read team member: %s", err))
+		return
+	}
+	if !exists {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -158,21 +283,19 @@ func (r *TeamMemberResource) Update(ctx context.Context, req resource.UpdateRequ
 
 	data.ID = state.ID
 
-	updateReq := map[string]interface{}{
-		"user_id":    data.UserID.ValueString(),
-		"user_email": data.UserEmail.ValueString(),
-		"team_id":    data.TeamID.ValueString(),
-	}
-
-	if !data.MaxBudgetInTeam.IsNull() && !data.MaxBudgetInTeam.IsUnknown() {
-		updateReq["max_budget_in_team"] = data.MaxBudgetInTeam.ValueFloat64()
-	}
+	updateReq := buildTeamMemberUpdateRequest(&data)
 
 	applyTeamMemberNullableClears(updateReq, &state, &data)
 
 	if err := r.client.DoRequestWithResponse(ctx, "POST", "/team/member_update", updateReq, nil); err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update team member: %s", err))
 		return
+	}
+
+	if exists, err := r.readTeamMember(ctx, &data); err != nil {
+		resp.Diagnostics.AddWarning("Read Error", fmt.Sprintf("Team member was updated but could not be read back: %s", err))
+	} else if !exists {
+		resp.Diagnostics.AddWarning("Read Error", "Team member was updated but was not present in the immediate team read-back.")
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -220,12 +343,7 @@ func applyTeamMemberNullableClears(updateReq map[string]interface{}, state, plan
 	if !state.MaxBudgetInTeam.IsNull() && plan.MaxBudgetInTeam.IsNull() {
 		updateReq["max_budget_in_team"] = nil
 	}
-}
-
-func isTeamMemberAlreadyInTeamError(err error) bool {
-	if err == nil {
-		return false
+	if !state.BudgetDuration.IsNull() && plan.BudgetDuration.IsNull() {
+		updateReq["budget_duration"] = nil
 	}
-	errStr := err.Error()
-	return contains(errStr, "status 400") && contains(errStr, "team_member_already_in_team")
 }

--- a/internal/provider/resource_team_member_test.go
+++ b/internal/provider/resource_team_member_test.go
@@ -1,34 +1,155 @@
 package provider
 
 import (
+	"context"
 	"encoding/json"
-	"errors"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	resourceschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-// TestApplyTeamMemberNullableClears_TransitionToNull verifies that clearing
-// max_budget_in_team in plan (was set in state) results in explicit JSON null
-// on the wire — required because the LiteLLM API ignores omitted fields under
-// Pydantic exclude_unset=True.
-func TestIsTeamMemberAlreadyInTeamError(t *testing.T) {
+func TestTeamMemberBudgetDurationSchema(t *testing.T) {
 	t.Parallel()
 
-	alreadyErr := errors.New(`API request failed with status 400: {"type":"team_member_already_in_team","message":"User is already in team"}`)
-	if !isTeamMemberAlreadyInTeamError(alreadyErr) {
-		t.Fatal("expected team_member_already_in_team status 400 error to be idempotent")
+	var response resource.SchemaResponse
+	(&TeamMemberResource{}).Schema(context.Background(), resource.SchemaRequest{}, &response)
+	if response.Diagnostics.HasError() {
+		t.Fatalf("schema diagnostics: %v", response.Diagnostics)
 	}
-
-	wrongStatus := errors.New(`API request failed with status 500: {"type":"team_member_already_in_team"}`)
-	if isTeamMemberAlreadyInTeamError(wrongStatus) {
-		t.Fatal("status 500 should not be treated as idempotent already-in-team")
+	attribute, ok := response.Schema.Attributes["budget_duration"].(resourceschema.StringAttribute)
+	if !ok {
+		t.Fatalf("budget_duration schema type = %T", response.Schema.Attributes["budget_duration"])
 	}
+	if !attribute.Optional || attribute.Computed || attribute.Required {
+		t.Fatalf("budget_duration must be Optional-only: %#v", attribute)
+	}
+	if len(attribute.Validators) != 1 {
+		t.Fatalf("budget_duration validators = %d, want duration format validator", len(attribute.Validators))
+	}
+}
 
-	wrongType := errors.New(`API request failed with status 400: {"type":"other_error"}`)
-	if isTeamMemberAlreadyInTeamError(wrongType) {
-		t.Fatal("other status 400 errors should not be treated as idempotent already-in-team")
+func TestTeamMemberMutationRequestsUseNativeBudgetDuration(t *testing.T) {
+	t.Parallel()
+
+	data := &TeamMemberResourceModel{
+		TeamID:          types.StringValue("team-1"),
+		UserID:          types.StringValue("user-1"),
+		UserEmail:       types.StringValue("user@example.com"),
+		Role:            types.StringValue("user"),
+		MaxBudgetInTeam: types.Float64Value(50),
+		BudgetDuration:  types.StringValue("30d"),
+	}
+	for name, request := range map[string]map[string]interface{}{
+		"member_add":    buildTeamMemberAddRequest(data),
+		"member_update": buildTeamMemberUpdateRequest(data),
+	} {
+		if got := request["budget_duration"]; got != "30d" {
+			t.Errorf("%s budget_duration = %#v, want 30d", name, got)
+		}
+		if got := request["max_budget_in_team"]; got != float64(50) {
+			t.Errorf("%s max_budget_in_team = %#v, want 50", name, got)
+		}
+	}
+	if got := buildTeamMemberUpdateRequest(data)["role"]; got != "user" {
+		t.Errorf("member_update role = %#v, want user", got)
+	}
+}
+
+// TestApplyTeamMemberNullableClears_TransitionToNull verifies that clearing
+// managed nullable fields results in explicit JSON null on the wire — required
+// because the LiteLLM API ignores omitted fields under Pydantic
+// exclude_unset=True.
+func TestReadTeamMemberUsesMembershipBudgetAndEscapedTeamID(t *testing.T) {
+	t.Parallel()
+
+	const teamID = "team/group #1&ops"
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/team/info" || request.URL.Query().Get("team_id") != teamID {
+			http.Error(writer, "unexpected team query", http.StatusBadRequest)
+			return
+		}
+		writer.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(writer).Encode(map[string]interface{}{
+			"team_info": map[string]interface{}{
+				"members_with_roles": []interface{}{
+					map[string]interface{}{
+						"user_id":    "user-1",
+						"user_email": "observed@example.com",
+						"role":       "admin",
+					},
+				},
+			},
+			"team_memberships": []interface{}{
+				map[string]interface{}{
+					"user_id": "user-1",
+					"litellm_budget_table": map[string]interface{}{
+						"max_budget":      75.0,
+						"budget_duration": "7d",
+					},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	teamMemberResource := &TeamMemberResource{client: &Client{APIBase: server.URL, APIKey: "test-key", HTTPClient: server.Client()}}
+	data := TeamMemberResourceModel{
+		TeamID:          types.StringValue(teamID),
+		UserID:          types.StringValue("user-1"),
+		UserEmail:       types.StringValue("configured@example.com"),
+		Role:            types.StringValue("user"),
+		MaxBudgetInTeam: types.Float64Value(50),
+		BudgetDuration:  types.StringValue("30d"),
+	}
+	exists, err := teamMemberResource.readTeamMember(context.Background(), &data)
+	if err != nil || !exists {
+		t.Fatalf("readTeamMember() exists=%v err=%v", exists, err)
+	}
+	if data.UserEmail.ValueString() != "observed@example.com" || data.Role.ValueString() != "admin" {
+		t.Fatalf("member identity read-back email=%q role=%q", data.UserEmail.ValueString(), data.Role.ValueString())
+	}
+	if data.MaxBudgetInTeam.ValueFloat64() != 75 || data.BudgetDuration.ValueString() != "7d" {
+		t.Fatalf("member budget read-back max=%v duration=%q", data.MaxBudgetInTeam.ValueFloat64(), data.BudgetDuration.ValueString())
+	}
+}
+
+func TestReadTeamMemberPreservesUnmanagedBudgetFields(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(writer).Encode(map[string]interface{}{
+			"team_memberships": []interface{}{
+				map[string]interface{}{
+					"user_id": "user-1",
+					"litellm_budget_table": map[string]interface{}{
+						"max_budget":      75.0,
+						"budget_duration": "7d",
+					},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	teamMemberResource := &TeamMemberResource{client: &Client{APIBase: server.URL, APIKey: "test-key", HTTPClient: server.Client()}}
+	data := TeamMemberResourceModel{
+		TeamID:          types.StringValue("team-1"),
+		UserID:          types.StringValue("user-1"),
+		MaxBudgetInTeam: types.Float64Null(),
+		BudgetDuration:  types.StringNull(),
+	}
+	exists, err := teamMemberResource.readTeamMember(context.Background(), &data)
+	if err != nil || !exists {
+		t.Fatalf("readTeamMember() exists=%v err=%v", exists, err)
+	}
+	if !data.MaxBudgetInTeam.IsNull() || !data.BudgetDuration.IsNull() {
+		t.Fatalf("unmanaged member budget was adopted: max=%v duration=%v", data.MaxBudgetInTeam, data.BudgetDuration)
 	}
 }
 
@@ -37,9 +158,11 @@ func TestApplyTeamMemberNullableClears_TransitionToNull(t *testing.T) {
 
 	state := &TeamMemberResourceModel{
 		MaxBudgetInTeam: types.Float64Value(50),
+		BudgetDuration:  types.StringValue("30d"),
 	}
 	plan := &TeamMemberResourceModel{
 		MaxBudgetInTeam: types.Float64Null(),
+		BudgetDuration:  types.StringNull(),
 	}
 
 	updateReq := map[string]interface{}{"team_id": "team-1", "user_id": "user-1"}
@@ -52,6 +175,9 @@ func TestApplyTeamMemberNullableClears_TransitionToNull(t *testing.T) {
 	if v != nil {
 		t.Errorf("updateReq[max_budget_in_team] = %v, want nil", v)
 	}
+	if v, ok := updateReq["budget_duration"]; !ok || v != nil {
+		t.Errorf("updateReq[budget_duration] = %#v, want explicit nil", v)
+	}
 
 	body, err := json.Marshal(updateReq)
 	if err != nil {
@@ -59,6 +185,9 @@ func TestApplyTeamMemberNullableClears_TransitionToNull(t *testing.T) {
 	}
 	if !strings.Contains(string(body), `"max_budget_in_team":null`) {
 		t.Errorf("request body missing \"max_budget_in_team\":null; got %s", string(body))
+	}
+	if !strings.Contains(string(body), `"budget_duration":null`) {
+		t.Errorf("request body missing \"budget_duration\":null; got %s", string(body))
 	}
 }
 
@@ -68,8 +197,14 @@ func TestApplyTeamMemberNullableClears_NoTransition_NoOp(t *testing.T) {
 	t.Parallel()
 
 	// Both null: no key injected.
-	state := &TeamMemberResourceModel{MaxBudgetInTeam: types.Float64Null()}
-	plan := &TeamMemberResourceModel{MaxBudgetInTeam: types.Float64Null()}
+	state := &TeamMemberResourceModel{
+		MaxBudgetInTeam: types.Float64Null(),
+		BudgetDuration:  types.StringNull(),
+	}
+	plan := &TeamMemberResourceModel{
+		MaxBudgetInTeam: types.Float64Null(),
+		BudgetDuration:  types.StringNull(),
+	}
 
 	updateReq := map[string]interface{}{}
 	applyTeamMemberNullableClears(updateReq, state, plan)
@@ -77,15 +212,30 @@ func TestApplyTeamMemberNullableClears_NoTransition_NoOp(t *testing.T) {
 	if _, ok := updateReq["max_budget_in_team"]; ok {
 		t.Errorf("helper added max_budget_in_team when no transition; got %v", updateReq)
 	}
+	if _, ok := updateReq["budget_duration"]; ok {
+		t.Errorf("helper added budget_duration when no transition; got %v", updateReq)
+	}
 
-	// Both set (stable value): existing value preserved.
-	state = &TeamMemberResourceModel{MaxBudgetInTeam: types.Float64Value(50)}
-	plan = &TeamMemberResourceModel{MaxBudgetInTeam: types.Float64Value(75)}
+	// Both set (stable value): existing values are preserved.
+	state = &TeamMemberResourceModel{
+		MaxBudgetInTeam: types.Float64Value(50),
+		BudgetDuration:  types.StringValue("30d"),
+	}
+	plan = &TeamMemberResourceModel{
+		MaxBudgetInTeam: types.Float64Value(75),
+		BudgetDuration:  types.StringValue("7d"),
+	}
 
-	updateReq = map[string]interface{}{"max_budget_in_team": float64(75)}
+	updateReq = map[string]interface{}{
+		"max_budget_in_team": float64(75),
+		"budget_duration":    "7d",
+	}
 	applyTeamMemberNullableClears(updateReq, state, plan)
 
 	if v := updateReq["max_budget_in_team"]; v != float64(75) {
 		t.Errorf("helper overwrote stable max_budget_in_team; got %v, want 75", v)
+	}
+	if v := updateReq["budget_duration"]; v != "7d" {
+		t.Errorf("helper overwrote stable budget_duration; got %v, want 7d", v)
 	}
 }

--- a/internal/provider/resource_team_member_test.go
+++ b/internal/provider/resource_team_member_test.go
@@ -124,6 +124,11 @@ func TestReadTeamMemberPreservesUnmanagedBudgetFields(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		writer.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(writer).Encode(map[string]interface{}{
+			"team_info": map[string]interface{}{
+				"members_with_roles": []interface{}{
+					map[string]interface{}{"user_id": "user-1", "role": "user"},
+				},
+			},
 			"team_memberships": []interface{}{
 				map[string]interface{}{
 					"user_id": "user-1",
@@ -150,6 +155,39 @@ func TestReadTeamMemberPreservesUnmanagedBudgetFields(t *testing.T) {
 	}
 	if !data.MaxBudgetInTeam.IsNull() || !data.BudgetDuration.IsNull() {
 		t.Fatalf("unmanaged member budget was adopted: max=%v duration=%v", data.MaxBudgetInTeam, data.BudgetDuration)
+	}
+}
+
+func TestReadTeamMemberRejectsOrphanBudgetMembership(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(writer).Encode(map[string]interface{}{
+			"team_info": map[string]interface{}{
+				"members_with_roles": []interface{}{},
+			},
+			"team_memberships": []interface{}{
+				map[string]interface{}{
+					"user_id": "user-1",
+					"litellm_budget_table": map[string]interface{}{
+						"max_budget":      75.0,
+						"budget_duration": "7d",
+					},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	teamMemberResource := &TeamMemberResource{client: &Client{APIBase: server.URL, APIKey: "test-key", HTTPClient: server.Client()}}
+	data := TeamMemberResourceModel{TeamID: types.StringValue("team-1"), UserID: types.StringValue("user-1")}
+	exists, err := teamMemberResource.readTeamMember(context.Background(), &data)
+	if err != nil {
+		t.Fatalf("readTeamMember() error = %v", err)
+	}
+	if exists {
+		t.Fatal("budget membership without members_with_roles roster entry must not count as a team member")
 	}
 }
 

--- a/internal/provider/resource_team_test.go
+++ b/internal/provider/resource_team_test.go
@@ -288,6 +288,39 @@ func TestReadTeamResolvesUnknownOptionalComputedCollections(t *testing.T) {
 	}
 }
 
+func TestTeamDefaultMemberBudgetDurationSchema(t *testing.T) {
+	t.Parallel()
+
+	var response resource.SchemaResponse
+	(&TeamResource{}).Schema(context.Background(), resource.SchemaRequest{}, &response)
+	if response.Diagnostics.HasError() {
+		t.Fatalf("schema diagnostics: %v", response.Diagnostics)
+	}
+	attribute, ok := response.Schema.Attributes["team_member_budget_duration"].(resourceschema.StringAttribute)
+	if !ok {
+		t.Fatalf("team_member_budget_duration schema type = %T", response.Schema.Attributes["team_member_budget_duration"])
+	}
+	if !attribute.Optional || attribute.Computed || attribute.Required {
+		t.Fatalf("team_member_budget_duration must be Optional-only: %#v", attribute)
+	}
+	if len(attribute.Validators) != 1 {
+		t.Fatalf("team_member_budget_duration validators = %d, want duration format validator", len(attribute.Validators))
+	}
+}
+
+func TestBuildTeamRequestIncludesMemberBudgetDuration(t *testing.T) {
+	t.Parallel()
+
+	request := (&TeamResource{}).buildTeamRequest(context.Background(), &TeamResourceModel{
+		TeamAlias:            types.StringValue("budget-team"),
+		TeamMemberBudget:     types.Float64Value(50),
+		MemberBudgetDuration: types.StringValue("30d"),
+	}, "team-1")
+	if got := request["team_member_budget_duration"]; got != "30d" {
+		t.Fatalf("team_member_budget_duration = %#v, want 30d", got)
+	}
+}
+
 func TestTeamBudgetInputsRemainOptionalOnly(t *testing.T) {
 	t.Parallel()
 
@@ -326,6 +359,12 @@ func TestReadTeamIgnoresUnconfiguredServerBudgetDefaults(t *testing.T) {
 					"max_budget":       500.0,
 					"budget_duration":  "30d",
 					"access_group_ids": []interface{}{"externally-managed"},
+					"team_member_budget_table": map[string]interface{}{
+						"max_budget":      25.0,
+						"budget_duration": "30d",
+						"rpm_limit":       10.0,
+						"tpm_limit":       1000.0,
+					},
 				},
 			})
 		case "/team/permissions_list":
@@ -347,11 +386,15 @@ func TestReadTeamIgnoresUnconfiguredServerBudgetDefaults(t *testing.T) {
 	}
 
 	data := TeamResourceModel{
-		ID:             types.StringValue("team-defaults"),
-		TeamAlias:      types.StringValue("defaults-team"),
-		MaxBudget:      types.Float64Null(),
-		BudgetDuration: types.StringNull(),
-		AccessGroupIDs: types.SetNull(types.StringType),
+		ID:                   types.StringValue("team-defaults"),
+		TeamAlias:            types.StringValue("defaults-team"),
+		MaxBudget:            types.Float64Null(),
+		BudgetDuration:       types.StringNull(),
+		AccessGroupIDs:       types.SetNull(types.StringType),
+		TeamMemberBudget:     types.Float64Null(),
+		MemberBudgetDuration: types.StringNull(),
+		TeamMemberRPMLimit:   types.Int64Null(),
+		TeamMemberTPMLimit:   types.Int64Null(),
 	}
 
 	if err := r.readTeam(context.Background(), &data); err != nil {
@@ -362,6 +405,9 @@ func TestReadTeamIgnoresUnconfiguredServerBudgetDefaults(t *testing.T) {
 	}
 	if !data.BudgetDuration.IsNull() {
 		t.Errorf("unconfigured budget_duration should remain null, got %v", data.BudgetDuration)
+	}
+	if !data.TeamMemberBudget.IsNull() || !data.MemberBudgetDuration.IsNull() || !data.TeamMemberRPMLimit.IsNull() || !data.TeamMemberTPMLimit.IsNull() {
+		t.Errorf("unconfigured team member defaults should remain null: budget=%v duration=%v rpm=%v tpm=%v", data.TeamMemberBudget, data.MemberBudgetDuration, data.TeamMemberRPMLimit, data.TeamMemberTPMLimit)
 	}
 	expectedAccessGroups := types.SetValueMust(types.StringType, []attr.Value{types.StringValue("externally-managed")})
 	if !data.AccessGroupIDs.Equal(expectedAccessGroups) {
@@ -380,25 +426,28 @@ func TestReadTeamWithNestedTeamInfoResponse(t *testing.T) {
 		case "/team/info":
 			_ = json.NewEncoder(w).Encode(map[string]interface{}{
 				"team_info": map[string]interface{}{
-					"team_id":            "team-abc-123",
-					"team_alias":         "production-team",
-					"organization_id":    "org-1",
-					"max_budget":         500.0,
-					"tpm_limit":          10000.0,
-					"rpm_limit":          1000.0,
-					"budget_duration":    "monthly",
-					"blocked":            false,
-					"tpm_limit_type":     "team",
-					"rpm_limit_type":     "team",
-					"models":             []interface{}{"gpt-4", "claude-3"},
-					"tags":               []interface{}{"prod", "high-priority"},
-					"guardrails":         []interface{}{"content-filter"},
-					"prompts":            []interface{}{},
-					"metadata":           map[string]interface{}{"env": "production"},
-					"model_aliases":      map[string]interface{}{"fast": "gpt-3.5-turbo"},
-					"model_rpm_limit":    map[string]interface{}{"gpt-4": 100.0},
-					"model_tpm_limit":    map[string]interface{}{"gpt-4": 5000.0},
-					"team_member_budget": 50.0,
+					"team_id":         "team-abc-123",
+					"team_alias":      "production-team",
+					"organization_id": "org-1",
+					"max_budget":      500.0,
+					"tpm_limit":       10000.0,
+					"rpm_limit":       1000.0,
+					"budget_duration": "monthly",
+					"blocked":         false,
+					"tpm_limit_type":  "team",
+					"rpm_limit_type":  "team",
+					"models":          []interface{}{"gpt-4", "claude-3"},
+					"tags":            []interface{}{"prod", "high-priority"},
+					"guardrails":      []interface{}{"content-filter"},
+					"prompts":         []interface{}{},
+					"metadata":        map[string]interface{}{"env": "production"},
+					"model_aliases":   map[string]interface{}{"fast": "gpt-3.5-turbo"},
+					"model_rpm_limit": map[string]interface{}{"gpt-4": 100.0},
+					"model_tpm_limit": map[string]interface{}{"gpt-4": 5000.0},
+					"team_member_budget_table": map[string]interface{}{
+						"max_budget":      50.0,
+						"budget_duration": "30d",
+					},
 				},
 			})
 		case "/team/permissions_list":
@@ -424,6 +473,8 @@ func TestReadTeamWithNestedTeamInfoResponse(t *testing.T) {
 		TeamAlias:             types.StringValue("production-team"),
 		MaxBudget:             types.Float64Value(500),
 		BudgetDuration:        types.StringValue("monthly"),
+		TeamMemberBudget:      types.Float64Value(50),
+		MemberBudgetDuration:  types.StringValue("30d"),
 		Models:                types.ListUnknown(types.StringType),
 		Tags:                  types.ListUnknown(types.StringType),
 		Guardrails:            types.ListUnknown(types.StringType),
@@ -460,6 +511,9 @@ func TestReadTeamWithNestedTeamInfoResponse(t *testing.T) {
 	}
 	if data.TeamMemberBudget.ValueFloat64() != 50.0 {
 		t.Fatalf("expected team_member_budget 50.0, got %f", data.TeamMemberBudget.ValueFloat64())
+	}
+	if data.MemberBudgetDuration.ValueString() != "30d" {
+		t.Fatalf("expected team_member_budget_duration 30d, got %q", data.MemberBudgetDuration.ValueString())
 	}
 
 	// Verify lists were populated from nested response
@@ -795,22 +849,24 @@ func TestApplyTeamNullableClears_AllTransitionsEmitNull(t *testing.T) {
 	t.Parallel()
 
 	state := &TeamResourceModel{
-		MaxBudget:          types.Float64Value(100),
-		BudgetDuration:     types.StringValue("30d"),
-		TPMLimit:           types.Int64Value(1000),
-		RPMLimit:           types.Int64Value(60),
-		TeamMemberBudget:   types.Float64Value(50),
-		TeamMemberRPMLimit: types.Int64Value(10),
-		TeamMemberTPMLimit: types.Int64Value(500),
+		MaxBudget:            types.Float64Value(100),
+		BudgetDuration:       types.StringValue("30d"),
+		TPMLimit:             types.Int64Value(1000),
+		RPMLimit:             types.Int64Value(60),
+		TeamMemberBudget:     types.Float64Value(50),
+		MemberBudgetDuration: types.StringValue("30d"),
+		TeamMemberRPMLimit:   types.Int64Value(10),
+		TeamMemberTPMLimit:   types.Int64Value(500),
 	}
 	plan := &TeamResourceModel{
-		MaxBudget:          types.Float64Null(),
-		BudgetDuration:     types.StringNull(),
-		TPMLimit:           types.Int64Null(),
-		RPMLimit:           types.Int64Null(),
-		TeamMemberBudget:   types.Float64Null(),
-		TeamMemberRPMLimit: types.Int64Null(),
-		TeamMemberTPMLimit: types.Int64Null(),
+		MaxBudget:            types.Float64Null(),
+		BudgetDuration:       types.StringNull(),
+		TPMLimit:             types.Int64Null(),
+		RPMLimit:             types.Int64Null(),
+		TeamMemberBudget:     types.Float64Null(),
+		MemberBudgetDuration: types.StringNull(),
+		TeamMemberRPMLimit:   types.Int64Null(),
+		TeamMemberTPMLimit:   types.Int64Null(),
 	}
 
 	teamReq := map[string]interface{}{"team_id": "team-123"}
@@ -818,7 +874,7 @@ func TestApplyTeamNullableClears_AllTransitionsEmitNull(t *testing.T) {
 
 	expectedNullKeys := []string{
 		"max_budget", "budget_duration", "tpm_limit", "rpm_limit",
-		"team_member_budget", "team_member_rpm_limit", "team_member_tpm_limit",
+		"team_member_budget", "team_member_budget_duration", "team_member_rpm_limit", "team_member_tpm_limit",
 	}
 	for _, k := range expectedNullKeys {
 		v, ok := teamReq[k]
@@ -840,6 +896,24 @@ func TestApplyTeamNullableClears_AllTransitionsEmitNull(t *testing.T) {
 		needle := `"` + k + `":null`
 		if !strings.Contains(bodyStr, needle) {
 			t.Errorf("request body missing %s; got %s", needle, bodyStr)
+		}
+	}
+
+	clearReq := extractTeamMemberBudgetClears(teamReq, "team-123")
+	if clearReq == nil || clearReq["team_id"] != "team-123" {
+		t.Fatalf("team member budget clear request = %#v", clearReq)
+	}
+	for _, key := range []string{
+		"team_member_budget",
+		"team_member_budget_duration",
+		"team_member_rpm_limit",
+		"team_member_tpm_limit",
+	} {
+		if value, exists := clearReq[key]; !exists || value != nil {
+			t.Errorf("clearReq[%q] = %#v, want explicit nil", key, value)
+		}
+		if _, exists := teamReq[key]; exists {
+			t.Errorf("main team request retained extracted clear %q", key)
 		}
 	}
 }
@@ -880,5 +954,8 @@ func TestApplyTeamNullableClears_NoTransition_NoOp(t *testing.T) {
 
 	if v := teamReq["max_budget"]; v != float64(200) {
 		t.Errorf("helper overwrote stable max_budget; got %v, want 200", v)
+	}
+	if clearReq := extractTeamMemberBudgetClears(teamReq, "team-123"); clearReq != nil {
+		t.Errorf("unexpected team member budget clear request: %#v", clearReq)
 	}
 }

--- a/internal_testing/resources/team_member_budget_duration.tf
+++ b/internal_testing/resources/team_member_budget_duration.tf
@@ -1,0 +1,20 @@
+# litellm_team - Default recurring team-member budget
+#
+# Exercises team_member_budget_duration for memberships created after the team
+# default is configured.
+#
+# Run with: make smoke resources=team_member_budget_duration.tf
+
+resource "litellm_team" "member_budget_duration" {
+  team_alias                  = "test-team-member-budget-duration"
+  team_member_budget          = 25.0
+  team_member_budget_duration = "30d"
+}
+
+output "team_member_budget_duration_id" {
+  value = litellm_team.member_budget_duration.id
+}
+
+output "team_member_budget_duration_value" {
+  value = litellm_team.member_budget_duration.team_member_budget_duration
+}

--- a/internal_testing/resources/team_member_full.tf
+++ b/internal_testing/resources/team_member_full.tf
@@ -7,6 +7,7 @@ resource "litellm_team_member" "full" {
   user_email         = "teammemberfull@example.com"
   role               = "admin"
   max_budget_in_team = 100.0
+  budget_duration    = "30d"
 }
 
 output "team_member_full_id" {


### PR DESCRIPTION
### Summary

Closes #112. Adds recurring member-budget durations to `litellm_team_member` and team defaults to `litellm_team`.

This keeps contributor PR #113's user-facing design and attribution but targets the pinned LiteLLM v1.98.0 API rather than its v1.80.15 workaround. v1.98 natively accepts `budget_duration` on `/team/member_add` and `/team/member_update`, including duration-only inherited/default overrides and merge-patch clears, so the provider does not perform a second `/budget/update` mutation. Strict validation permits the safe backend-supported forms and rejects values such as invalid multi-month durations.

Team-member Read now joins `/team/info` membership/role data with `team_memberships[].litellm_budget_table`, detects remote deletion and managed budget drift, and recovers import identity. Create performs an exact roster preflight and refuses implicit adoption of an existing member. If an add fails and a roster entry then appears, ownership remains ambiguous; the provider neither mutates nor adopts it and instead requires verification plus import. Budget rows alone are never treated as membership proof.

Team defaults use the nested `team_member_budget_table` as authoritative read-back while leaving unconfigured defaults unmanaged. A dedicated clear merge-patch works around LiteLLM v1.98 ignoring null member-default fields when another non-null sibling is in the same request.

### Validation

Live LiteLLM v1.98.0 validation covered default/member Create, Update, explicit clears, duration-only budgets, future reset timestamps, nested read-back, out-of-band duration drift detection/repair, remote member deletion/recreation, safe rejection of state-loss duplicates followed by import normalization, strict duration/role validation, TOCTOU ownership rejection, no-drift plans, and destroy/absence. In particular, the backend combined-clear defect and HTTP 500 duplicate shape were reproduced; final preflight behavior rejected the pre-existing roster entry without mutation and directed import. A fault-injected TOCTOU sequence hid that entry during preflight, exposed it after the failed add, and likewise produced an empty-state `Ambiguous Team Member Creation` error while preserving the remote 5/7d settings. Focused tests, `go vet`, full tests, race tests, and the 23-resource real-dev lifecycle suite pass.

### Diff size

**Docs** — 3 files · `+9 / -3`

Documents native recurring member/default budgets, supported duration semantics, reset ownership, inheritance/backfill, private overrides, and contributor credit.

**Implementation** — 2 files · `+283 / -49`

Adds native mutation fields, authoritative member/default read-back, deletion/import recovery, roster preflight and ambiguity-safe ownership rejection, strict role/duration validation, and split default clears.

**Tests** — 4 files · `+345 / -59`

Covers schemas, native payloads, selective nested reads, URL encoding, managed/unmanaged drift, orphan-row rejection, nullable clears, split patches, and destructive acceptance configurations.
