### PR TITLE
feat: add key router settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`litellm_key` resource and data source**: Add complete LiteLLM v1.98.0 `router_settings` support with ordered fallback JSON, retry policies, model-group aliases, routing groups, affinity, tag routing, whole-document ownership, and explicit removal semantics. Key data-source lookups now URL-escape raw tokens and expose only a SHA256 management ID instead of copying the token into a non-sensitive ID. ([#97](https://github.com/ncecere/terraform-provider-litellm/issues/97), [#98](https://github.com/ncecere/terraform-provider-litellm/pull/98), [#147](https://github.com/ncecere/terraform-provider-litellm/pull/147)) — thanks @orolega for #98 and @alexeishtakal for #147
+
 ### Changed
 - **Development and CI**: Add read-only build/vet/format/race-test CI with coverage and JUnit artifacts, broaden provider unit coverage, make local provider installation architecture-aware, and add an isolated, failure-preserving LiteLLM v1.98.0 smoke/acceptance harness covering 22 non-enterprise resources. ([#145](https://github.com/ncecere/terraform-provider-litellm/issues/145)) — thanks @msabramo
 

--- a/docs/data-sources/key.md
+++ b/docs/data-sources/key.md
@@ -19,13 +19,24 @@ output "key_info" {
 }
 ```
 
+For a write-only key, use its non-sensitive management ID instead of reintroducing the token into data-source state:
+
+```hcl
+data "litellm_key" "write_only" {
+  key_hash = litellm_key.write_only.id
+}
+```
+
 ## Argument Reference
 
-* `key` - (Required, Sensitive) The API key value to look up.
+Exactly one lookup argument is required:
+
+* `key` - (Optional, Sensitive) Raw API key value to look up.
+* `key_hash` - (Optional) A `sha256:<64-hex>` management identifier, such as the `id` exported by a `litellm_key` using `key_wo`. The provider sends only the bare hash accepted by LiteLLM and does not require the raw token.
 
 ## Attribute Reference
 
-* `id` - The unique identifier of the key.
+* `id` - Non-sensitive SHA256 management identifier for the key; the raw token is never copied into this attribute.
 * `key_alias` - The human-readable alias for the key.
 * `team_id` - The team ID associated with this key.
 * `project_id` - The project ID associated with this key.
@@ -41,8 +52,9 @@ output "key_info" {
 * `metadata` - Map of metadata for the key.
 * `tags` - List of tags for the key.
 * `blocked` - Whether the key is blocked.
+* `router_settings` - Complete key-specific LiteLLM v1.98.0 router-settings document. Scalar fields are typed; heterogeneous objects and ordered arrays are returned as canonical JSON strings. See the `litellm_key` resource documentation for the nested fields.
 
 ## Notes
 
-- The `key` argument is marked as sensitive and will not appear in plan output.
+- The `key` argument is marked as sensitive and will not appear in plan output. It is still an input stored in data-source state; use `key_hash` for write-only keys.
 - Use this data source to check key status and budget information.

--- a/docs/resources/key.md
+++ b/docs/resources/key.md
@@ -49,7 +49,7 @@ resource "litellm_key" "write_only" {
 
 `key_wo_version` is persisted because Terraform cannot compare write-only values. Change both the secret and version to replace the key. Replacement deletes and recreates the LiteLLM key, including its server-side spend history and budget window. The ephemeral source must be available during both plan and apply; applying a saved plan requires supplying the ephemeral input again.
 
-In write-only mode, `key` remains null and `id` contains only `sha256:<key-hash>`. The provider uses this hash for Read, Update, and Delete; plaintext is not stored in Terraform private state.
+In write-only mode, `key` remains null and `id` contains only `sha256:<key-hash>`. The provider uses this hash for Read, Update, and Delete; plaintext is not stored in Terraform private state. The same `id` can be passed to the `litellm_key` data source's `key_hash` argument for hash-only lookup.
 
 > **Key entropy:** Use a cryptographically random key with at least 128 bits of entropy. The unsalted SHA256 management identifier does not authenticate to LiteLLM, but it is visible in ordinary Terraform output and lets an observer verify offline guesses of a weak or patterned predefined key.
 
@@ -89,6 +89,44 @@ resource "litellm_key" "example" {
   }
 }
 ```
+
+### Key-Specific Router Settings
+
+`router_settings` is a complete key-level override. When present, it takes precedence over team router settings; Terraform owns and replaces the complete document. Ordered or heterogeneous fields use `jsonencode()` so their JSON semantics round-trip without losing order or object-valued aliases.
+
+```hcl
+resource "litellm_key" "routed" {
+  key_alias = "routed-key"
+  models    = ["gpt-4o", "gpt-4o-mini"]
+
+  router_settings = {
+    routing_strategy = "usage-based-routing-v2"
+    num_retries      = 3
+    timeout          = 30.5
+    retry_after      = 0.25
+
+    fallbacks = jsonencode([
+      { "gpt-4o" = ["gpt-4o-mini"] },
+      { "*" = ["emergency-model"] }
+    ])
+
+    model_group_alias = jsonencode({
+      fast = "gpt-4o-mini"
+      primary = {
+        model  = "gpt-4o"
+        hidden = true
+      }
+    })
+
+    retry_policy = {
+      rate_limit_error_retries      = 5
+      internal_server_error_retries = 2
+    }
+  }
+}
+```
+
+Removing the entire block sends an explicit empty object to clear the key-level override and restores team/global inheritance. Setting `fallbacks = jsonencode([])` retains a non-empty key-level settings document and intentionally suppresses inherited fallbacks.
 
 ### Service Account Key
 
@@ -204,6 +242,27 @@ The following arguments are supported:
 * `tags` - (Optional) List of tags. **Note:** Requires LiteLLM Enterprise license.
 
 * `blocked` - (Optional) Whether this key is blocked.
+
+* `router_settings` - (Optional) Complete key-specific router-settings document. Omitting the block leaves remote settings unmanaged. A configured block replaces the complete document on update rather than merging individual fields. Supported LiteLLM v1.98.0 fields:
+  * `routing_strategy_args` - (Optional) JSON object passed to the routing strategy.
+  * `routing_strategy` - (Optional) Routing strategy name.
+  * `routing_groups` - (Optional) JSON array of routing groups.
+  * `retry_policy` - (Optional) Typed retry counts: `bad_request_error_retries`, `authentication_error_retries`, `timeout_error_retries`, `rate_limit_error_retries`, `content_policy_violation_error_retries`, and `internal_server_error_retries`.
+  * `model_group_retry_policy` - (Optional) JSON object mapping model groups to retry policies. Nested retry keys use LiteLLM's PascalCase names, such as `RateLimitErrorRetries`.
+  * `model_group_affinity_config` - (Optional) JSON object mapping affinity groups to lists of model groups.
+  * `allowed_fails` - (Optional) Failures allowed before cooldown.
+  * `cooldown_time` - (Optional) Cooldown duration in seconds.
+  * `num_retries` - (Optional) Number of request retries.
+  * `timeout` - (Optional) Request timeout in seconds.
+  * `max_retries` - (Optional) Maximum retries.
+  * `retry_after` - (Optional) Retry delay in seconds; decimal values are supported.
+  * `fallbacks` - (Optional) Ordered JSON array of model fallback mappings.
+  * `context_window_fallbacks` - (Optional) Ordered JSON array of context-window fallback mappings.
+  * `model_group_alias` - (Optional) JSON object mapping aliases to model groups or alias configuration objects.
+  * `enable_tag_filtering` - (Optional) Enables request-tag routing.
+  * `tag_routing_prefix` - (Optional) Prefix for tag-based routing.
+
+  LiteLLM v1.98.0 accepts and stores all fields above, but its per-key request path currently applies only `fallbacks`, `context_window_fallbacks`, `num_retries`, `timeout`, `model_group_retry_policy`, `routing_strategy`, `enable_tag_filtering`, and `model_group_alias`. Other accepted fields are exposed for API fidelity and future LiteLLM behavior.
 
 ## Attribute Reference
 

--- a/internal/provider/datasource_key.go
+++ b/internal/provider/datasource_key.go
@@ -2,15 +2,24 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/datasourcevalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 var _ datasource.DataSource = &KeyDataSource{}
+var _ datasource.DataSourceWithConfigValidators = &KeyDataSource{}
 
 func NewKeyDataSource() datasource.DataSource {
 	return &KeyDataSource{}
@@ -23,6 +32,7 @@ type KeyDataSource struct {
 type KeyDataSourceModel struct {
 	ID                  types.String  `tfsdk:"id"`
 	Key                 types.String  `tfsdk:"key"`
+	KeyHash             types.String  `tfsdk:"key_hash"`
 	KeyAlias            types.String  `tfsdk:"key_alias"`
 	Models              types.List    `tfsdk:"models"`
 	MaxBudget           types.Float64 `tfsdk:"max_budget"`
@@ -38,6 +48,16 @@ type KeyDataSourceModel struct {
 	Metadata            types.Map     `tfsdk:"metadata"`
 	Tags                types.List    `tfsdk:"tags"`
 	Blocked             types.Bool    `tfsdk:"blocked"`
+	RouterSettings      types.Object  `tfsdk:"router_settings"`
+}
+
+func (d *KeyDataSource) ConfigValidators(ctx context.Context) []datasource.ConfigValidator {
+	return []datasource.ConfigValidator{
+		datasourcevalidator.ExactlyOneOf(
+			path.MatchRoot("key"),
+			path.MatchRoot("key_hash"),
+		),
+	}
 }
 
 func (d *KeyDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -49,13 +69,20 @@ func (d *KeyDataSource) Schema(ctx context.Context, req datasource.SchemaRequest
 		Description: "Retrieves information about a LiteLLM API key.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
-				Description: "The unique identifier for this key.",
+				Description: "Non-sensitive SHA256 management identifier for this key.",
 				Computed:    true,
 			},
 			"key": schema.StringAttribute{
-				Description: "The API key value to look up.",
-				Required:    true,
+				Description: "The raw API key value to look up. Conflicts with key_hash.",
+				Optional:    true,
 				Sensitive:   true,
+			},
+			"key_hash": schema.StringAttribute{
+				Description: "A sha256:<64-hex> management identifier used to look up a write-only key without reintroducing the raw token into Terraform state. Conflicts with key.",
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`^sha256:[0-9a-fA-F]{64}$`), "must use the sha256:<64-hex> management identifier format"),
+				},
 			},
 			"key_alias": schema.StringAttribute{
 				Description: "User-friendly alias for the key.",
@@ -120,6 +147,7 @@ func (d *KeyDataSource) Schema(ctx context.Context, req datasource.SchemaRequest
 				Description: "Whether the key is blocked.",
 				Computed:    true,
 			},
+			"router_settings": keyRouterSettingsDataSourceAttribute(),
 		},
 	}
 }
@@ -141,6 +169,31 @@ func (d *KeyDataSource) Configure(ctx context.Context, req datasource.ConfigureR
 	d.client = client
 }
 
+func keyDataSourceLookup(data *KeyDataSourceModel) (string, string, error) {
+	if !data.KeyHash.IsNull() && !data.KeyHash.IsUnknown() {
+		hash, err := keyHashFromID(data.KeyHash.ValueString())
+		if err != nil {
+			return "", "", err
+		}
+		hash = strings.ToLower(hash)
+		return hash, "sha256:" + hash, nil
+	}
+	if data.Key.IsNull() || data.Key.IsUnknown() || data.Key.ValueString() == "" {
+		return "", "", fmt.Errorf("exactly one of key or key_hash must be known and non-empty")
+	}
+	key := data.Key.ValueString()
+	return key, hashKeyForID(key), nil
+}
+
+func keyDataSourceReadError(err error) string {
+	var apiErr *APIError
+	if errors.As(err, &apiErr) {
+		return fmt.Sprintf("LiteLLM returned HTTP %d while reading the key. The response body was omitted because it may contain the lookup token.", apiErr.StatusCode)
+	}
+	// Go transport errors can embed the complete query URL, including a raw key.
+	return "The key read request failed at the transport layer. Error details were omitted because they may contain the lookup token."
+}
+
 func (d *KeyDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	var data KeyDataSourceModel
 
@@ -149,12 +202,16 @@ func (d *KeyDataSource) Read(ctx context.Context, req datasource.ReadRequest, re
 		return
 	}
 
-	keyValue := data.Key.ValueString()
-	endpoint := fmt.Sprintf("/key/info?key=%s", keyValue)
+	lookupValue, managementID, err := keyDataSourceLookup(&data)
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid Key Lookup", err.Error())
+		return
+	}
+	endpoint := fmt.Sprintf("/key/info?key=%s", url.QueryEscape(lookupValue))
 
 	var result map[string]interface{}
 	if err := d.client.DoRequestWithResponse(ctx, "GET", endpoint, nil, &result); err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read key: %s", err))
+		resp.Diagnostics.AddError("Key Read Error", keyDataSourceReadError(err))
 		return
 	}
 
@@ -164,8 +221,8 @@ func (d *KeyDataSource) Read(ctx context.Context, req datasource.ReadRequest, re
 		info = nested
 	}
 
-	// Set ID
-	data.ID = data.Key
+	// Never copy the sensitive raw key into the non-sensitive data source ID.
+	data.ID = types.StringValue(managementID)
 
 	// Update fields from response
 	if keyAlias, ok := info["key_alias"].(string); ok {
@@ -245,6 +302,15 @@ func (d *KeyDataSource) Read(ctx context.Context, req datasource.ReadRequest, re
 		data.Tags, _ = types.ListValue(types.StringType, tagsList)
 	} else {
 		data.Tags, _ = types.ListValue(types.StringType, []attr.Value{})
+	}
+
+	if routerSettings, present, err := keyRouterSettingsFromAPI(info["router_settings"], types.ObjectNull(keyRouterSettingsAttrTypes)); err != nil {
+		resp.Diagnostics.AddError("Router Settings Read Error", err.Error())
+		return
+	} else if present {
+		data.RouterSettings = routerSettings
+	} else {
+		data.RouterSettings = types.ObjectNull(keyRouterSettingsAttrTypes)
 	}
 
 	// Handle metadata map

--- a/internal/provider/resource_key.go
+++ b/internal/provider/resource_key.go
@@ -7,8 +7,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -130,6 +132,7 @@ type KeyResourceModel struct {
 	EnforcedParams           types.List    `tfsdk:"enforced_params"`
 	Tags                     types.List    `tfsdk:"tags"`
 	Blocked                  types.Bool    `tfsdk:"blocked"`
+	RouterSettings           types.Object  `tfsdk:"router_settings"`
 }
 
 func (r *KeyResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -345,6 +348,7 @@ func (r *KeyResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 				Optional:    true,
 				Computed:    true,
 			},
+			"router_settings": keyRouterSettingsResourceAttribute(),
 		},
 	}
 }
@@ -398,7 +402,11 @@ func (r *KeyResource) Create(ctx context.Context, req resource.CreateRequest, re
 		return
 	}
 
-	keyReq := r.buildKeyRequest(ctx, &data)
+	keyReq, err := r.buildKeyRequest(ctx, &data)
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid Key Request", err.Error())
+		return
+	}
 	if writeOnlyMode {
 		keyReq["key"] = writeOnlyKey.ValueString()
 	}
@@ -425,6 +433,12 @@ func (r *KeyResource) Create(ctx context.Context, req resource.CreateRequest, re
 	} else if keyVal, ok := result["key"].(string); ok {
 		data.Key = types.StringValue(keyVal)
 		data.ID = types.StringValue(hashKeyForID(keyVal))
+	}
+
+	if !data.RouterSettings.IsNull() {
+		if err := r.waitForKeyRouterSettings(ctx, &data); err != nil {
+			resp.Diagnostics.AddError("Router Settings Did Not Converge", "The key was created, but "+err.Error()+". Terraform retained the key identity for recovery.")
+		}
 	}
 
 	// Read back for full state
@@ -478,12 +492,23 @@ func (r *KeyResource) Update(ctx context.Context, req resource.UpdateRequest, re
 		resp.Diagnostics.AddError("Key Identity Error", fmt.Sprintf("Unable to identify key for update: %s", err))
 		return
 	}
-	updateReq := r.buildKeyRequest(ctx, &data)
+	updateReq, err := r.buildKeyRequest(ctx, &data)
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid Key Request", err.Error())
+		return
+	}
 	updateReq["key"] = keyIdentifier
+	applyKeyRouterSettingsUpdateSemantics(updateReq, data.RouterSettings, state.RouterSettings)
 
 	if err := r.client.DoRequestWithResponse(ctx, "POST", "/key/update", updateReq, nil); err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update key: %s", err))
 		return
+	}
+
+	if !data.RouterSettings.IsNull() || !state.RouterSettings.IsNull() {
+		if err := r.waitForKeyRouterSettings(ctx, &data); err != nil {
+			resp.Diagnostics.AddError("Router Settings Did Not Converge", err.Error()+". The remote key may have changed; run Terraform again after reviewing the key.")
+		}
 	}
 
 	if err := r.readKey(ctx, &data); err != nil {
@@ -612,7 +637,7 @@ func (r *KeyResource) UpgradeState(ctx context.Context) map[int64]resource.State
 	}
 }
 
-func (r *KeyResource) buildKeyRequest(ctx context.Context, data *KeyResourceModel) map[string]interface{} {
+func (r *KeyResource) buildKeyRequest(ctx context.Context, data *KeyResourceModel) (map[string]interface{}, error) {
 	keyReq := make(map[string]interface{})
 
 	// String fields - check IsNull, IsUnknown, and empty string
@@ -803,6 +828,14 @@ func (r *KeyResource) buildKeyRequest(ctx context.Context, data *KeyResourceMode
 		}
 	}
 
+	if !data.RouterSettings.IsNull() && !data.RouterSettings.IsUnknown() {
+		routerSettings, err := keyRouterSettingsPayload(data.RouterSettings)
+		if err != nil {
+			return nil, err
+		}
+		keyReq["router_settings"] = routerSettings
+	}
+
 	// Handle service account
 	if !data.ServiceAccountID.IsNull() && !data.ServiceAccountID.IsUnknown() && data.ServiceAccountID.ValueString() != "" {
 		saID := data.ServiceAccountID.ValueString()
@@ -817,7 +850,7 @@ func (r *KeyResource) buildKeyRequest(ctx context.Context, data *KeyResourceMode
 		}
 	}
 
-	return keyReq
+	return keyReq, nil
 }
 
 func stringMapMatchesAttrValues(current types.Map, observed map[string]attr.Value) bool {
@@ -833,26 +866,91 @@ func stringMapMatchesAttrValues(current types.Map, observed map[string]attr.Valu
 	return true
 }
 
-func (r *KeyResource) readKey(ctx context.Context, data *KeyResourceModel) error {
+func (r *KeyResource) getKeyInfo(ctx context.Context, data *KeyResourceModel) (map[string]interface{}, map[string]interface{}, error) {
 	keyIdentifier, err := keyLookupIdentifier(data)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 
 	// url.QueryEscape ensures special characters in a plaintext key (e.g. '#')
 	// are not interpreted as a URL fragment. LiteLLM also accepts the SHA256
 	// token hash used to manage write-only keys without recovering plaintext.
 	endpoint := fmt.Sprintf("/key/info?key=%s", url.QueryEscape(keyIdentifier))
-
 	var result map[string]interface{}
 	if err := r.client.DoRequestWithResponse(ctx, "GET", endpoint, nil, &result); err != nil {
-		return err
+		return nil, nil, err
 	}
-
-	// The /key/info endpoint may return key data nested inside "info"
 	info := result
 	if nested, ok := result["info"].(map[string]interface{}); ok {
 		info = nested
+	}
+	return result, info, nil
+}
+
+func isTransientRouterSettingsReadStatus(status int) bool {
+	return status == http.StatusNotFound || status == http.StatusRequestTimeout || status == http.StatusTooManyRequests || status >= 500
+}
+
+func (r *KeyResource) waitForKeyRouterSettings(ctx context.Context, data *KeyResourceModel) error {
+	var wanted map[string]interface{}
+	if !data.RouterSettings.IsNull() {
+		var err error
+		wanted, err = keyRouterSettingsPayload(data.RouterSettings)
+		if err != nil {
+			return fmt.Errorf("build planned router settings")
+		}
+	}
+
+	const attempts = 6
+	stableMatches := 0
+	lastDetail := "the read-back document did not match the planned document"
+	for attempt := 0; attempt < attempts; attempt++ {
+		_, info, err := r.getKeyInfo(ctx, data)
+		if err == nil {
+			matches, comparisonErr := keyRouterSettingsMatchAPI(wanted, info["router_settings"])
+			if comparisonErr != nil {
+				// Do not include response values because arbitrary router settings
+				// can contain sensitive data.
+				return fmt.Errorf("LiteLLM returned malformed or unsupported router settings during read-back")
+			}
+			if matches {
+				stableMatches++
+				if stableMatches >= 2 {
+					return nil
+				}
+			} else {
+				stableMatches = 0
+				lastDetail = "the read-back document did not match the planned document"
+			}
+		} else {
+			stableMatches = 0
+			var apiErr *APIError
+			if errors.As(err, &apiErr) {
+				lastDetail = fmt.Sprintf("the read-back request returned HTTP %d", apiErr.StatusCode)
+				if !isTransientRouterSettingsReadStatus(apiErr.StatusCode) {
+					return fmt.Errorf("LiteLLM router-settings read-back returned HTTP %d", apiErr.StatusCode)
+				}
+			} else {
+				// Transport errors can embed the request URL and therefore a raw
+				// stateful key. Keep the convergence diagnostic deliberately generic.
+				lastDetail = "the read-back transport request failed"
+			}
+		}
+		if attempt+1 < attempts {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(250 * time.Millisecond):
+			}
+		}
+	}
+	return fmt.Errorf("LiteLLM did not return the complete planned router settings after the key mutation: %s", lastDetail)
+}
+
+func (r *KeyResource) readKey(ctx context.Context, data *KeyResourceModel) error {
+	result, info, err := r.getKeyInfo(ctx, data)
+	if err != nil {
+		return err
 	}
 
 	// Update computed fields from response.
@@ -1170,6 +1268,17 @@ func (r *KeyResource) readKey(ctx context.Context, data *KeyResourceModel) error
 		data.ModelRPMLimit, _ = types.MapValue(types.Int64Type, rpmMap)
 	} else if data.ModelRPMLimit.IsUnknown() {
 		data.ModelRPMLimit, _ = types.MapValue(types.Int64Type, map[string]attr.Value{})
+	}
+
+	// router_settings is Optional rather than Optional+Computed. An absent block
+	// intentionally leaves remote key settings unmanaged; a present block owns
+	// the complete LiteLLM router-settings document.
+	if !data.RouterSettings.IsNull() {
+		routerSettings, _, err := keyRouterSettingsFromAPI(info["router_settings"], data.RouterSettings)
+		if err != nil {
+			return err
+		}
+		data.RouterSettings = routerSettings
 	}
 
 	// Handle model_tpm_limit map

--- a/internal/provider/resource_key_router_settings.go
+++ b/internal/provider/resource_key_router_settings.go
@@ -1,0 +1,467 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	datasourceschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	resourceschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// LiteLLM v1.98.0 accepts these fields in UpdateRouterConfig. Complex values
+// remain JSON strings in Terraform so heterogeneous objects and ordered arrays
+// can round-trip without lossy schema coercion.
+var keyRetryPolicyAttrTypes = map[string]attr.Type{
+	"bad_request_error_retries":              types.Int64Type,
+	"authentication_error_retries":           types.Int64Type,
+	"timeout_error_retries":                  types.Int64Type,
+	"rate_limit_error_retries":               types.Int64Type,
+	"content_policy_violation_error_retries": types.Int64Type,
+	"internal_server_error_retries":          types.Int64Type,
+}
+
+var keyRouterSettingsAttrTypes = map[string]attr.Type{
+	"routing_strategy_args":       types.StringType,
+	"routing_strategy":            types.StringType,
+	"routing_groups":              types.StringType,
+	"retry_policy":                types.ObjectType{AttrTypes: keyRetryPolicyAttrTypes},
+	"model_group_retry_policy":    types.StringType,
+	"model_group_affinity_config": types.StringType,
+	"allowed_fails":               types.Int64Type,
+	"cooldown_time":               types.Float64Type,
+	"num_retries":                 types.Int64Type,
+	"timeout":                     types.Float64Type,
+	"max_retries":                 types.Int64Type,
+	"retry_after":                 types.Float64Type,
+	"fallbacks":                   types.StringType,
+	"context_window_fallbacks":    types.StringType,
+	"model_group_alias":           types.StringType,
+	"enable_tag_filtering":        types.BoolType,
+	"tag_routing_prefix":          types.StringType,
+}
+
+func keyRouterSettingsDataSourceAttribute() datasourceschema.SingleNestedAttribute {
+	return datasourceschema.SingleNestedAttribute{
+		Description: "The complete key-specific LiteLLM v1.98.0 router-settings document. Complex heterogeneous fields are canonical JSON strings.",
+		Computed:    true,
+		Attributes: map[string]datasourceschema.Attribute{
+			"routing_strategy_args": datasourceschema.StringAttribute{Computed: true},
+			"routing_strategy":      datasourceschema.StringAttribute{Computed: true},
+			"routing_groups":        datasourceschema.StringAttribute{Computed: true},
+			"retry_policy": datasourceschema.SingleNestedAttribute{
+				Computed: true,
+				Attributes: map[string]datasourceschema.Attribute{
+					"bad_request_error_retries":              datasourceschema.Int64Attribute{Computed: true},
+					"authentication_error_retries":           datasourceschema.Int64Attribute{Computed: true},
+					"timeout_error_retries":                  datasourceschema.Int64Attribute{Computed: true},
+					"rate_limit_error_retries":               datasourceschema.Int64Attribute{Computed: true},
+					"content_policy_violation_error_retries": datasourceschema.Int64Attribute{Computed: true},
+					"internal_server_error_retries":          datasourceschema.Int64Attribute{Computed: true},
+				},
+			},
+			"model_group_retry_policy":    datasourceschema.StringAttribute{Computed: true},
+			"model_group_affinity_config": datasourceschema.StringAttribute{Computed: true},
+			"allowed_fails":               datasourceschema.Int64Attribute{Computed: true},
+			"cooldown_time":               datasourceschema.Float64Attribute{Computed: true},
+			"num_retries":                 datasourceschema.Int64Attribute{Computed: true},
+			"timeout":                     datasourceschema.Float64Attribute{Computed: true},
+			"max_retries":                 datasourceschema.Int64Attribute{Computed: true},
+			"retry_after":                 datasourceschema.Float64Attribute{Computed: true},
+			"fallbacks":                   datasourceschema.StringAttribute{Computed: true},
+			"context_window_fallbacks":    datasourceschema.StringAttribute{Computed: true},
+			"model_group_alias":           datasourceschema.StringAttribute{Computed: true},
+			"enable_tag_filtering":        datasourceschema.BoolAttribute{Computed: true},
+			"tag_routing_prefix":          datasourceschema.StringAttribute{Computed: true},
+		},
+	}
+}
+
+func keyRouterSettingsResourceAttribute() resourceschema.SingleNestedAttribute {
+	jsonObject := []validator.String{jsonShapeStringValidator{shape: '{'}}
+	jsonArray := []validator.String{jsonShapeStringValidator{shape: '['}}
+	return resourceschema.SingleNestedAttribute{
+		Description: "Key-specific LiteLLM v1.98.0 router settings. When configured, Terraform owns and replaces the complete router-settings document. Complex heterogeneous fields are JSON strings.",
+		Optional:    true,
+		Attributes: map[string]resourceschema.Attribute{
+			"routing_strategy_args": resourceschema.StringAttribute{Description: "JSON object passed to the routing strategy.", Optional: true, Validators: jsonObject},
+			"routing_strategy":      resourceschema.StringAttribute{Description: "Routing strategy name.", Optional: true},
+			"routing_groups":        resourceschema.StringAttribute{Description: "JSON array of routing groups.", Optional: true, Validators: jsonArray},
+			"retry_policy": resourceschema.SingleNestedAttribute{
+				Description: "Default retry counts by LiteLLM exception type.",
+				Optional:    true,
+				Attributes: map[string]resourceschema.Attribute{
+					"bad_request_error_retries":              resourceschema.Int64Attribute{Optional: true},
+					"authentication_error_retries":           resourceschema.Int64Attribute{Optional: true},
+					"timeout_error_retries":                  resourceschema.Int64Attribute{Optional: true},
+					"rate_limit_error_retries":               resourceschema.Int64Attribute{Optional: true},
+					"content_policy_violation_error_retries": resourceschema.Int64Attribute{Optional: true},
+					"internal_server_error_retries":          resourceschema.Int64Attribute{Optional: true},
+				},
+			},
+			"model_group_retry_policy":    resourceschema.StringAttribute{Description: "JSON object mapping model groups to retry-policy objects. Retry-policy keys use LiteLLM's PascalCase wire names.", Optional: true, Validators: jsonObject},
+			"model_group_affinity_config": resourceschema.StringAttribute{Description: "JSON object mapping affinity groups to arrays of model groups.", Optional: true, Validators: jsonObject},
+			"allowed_fails":               resourceschema.Int64Attribute{Description: "Failures allowed before a deployment enters cooldown.", Optional: true},
+			"cooldown_time":               resourceschema.Float64Attribute{Description: "Cooldown duration in seconds.", Optional: true},
+			"num_retries":                 resourceschema.Int64Attribute{Description: "Number of request retries.", Optional: true},
+			"timeout":                     resourceschema.Float64Attribute{Description: "Request timeout in seconds.", Optional: true},
+			"max_retries":                 resourceschema.Int64Attribute{Description: "Maximum retries.", Optional: true},
+			"retry_after":                 resourceschema.Float64Attribute{Description: "Retry delay in seconds; decimal values are supported.", Optional: true},
+			"fallbacks":                   resourceschema.StringAttribute{Description: "Ordered JSON array of model fallback mappings.", Optional: true, Validators: jsonArray},
+			"context_window_fallbacks":    resourceschema.StringAttribute{Description: "Ordered JSON array of context-window fallback mappings.", Optional: true, Validators: jsonArray},
+			"model_group_alias":           resourceschema.StringAttribute{Description: "JSON object mapping aliases to model groups or alias configuration objects.", Optional: true, Validators: jsonObject},
+			"enable_tag_filtering":        resourceschema.BoolAttribute{Description: "Enable routing by request tags.", Optional: true},
+			"tag_routing_prefix":          resourceschema.StringAttribute{Description: "Prefix used for tag-based routing.", Optional: true},
+		},
+	}
+}
+
+var keyRetryPolicyWireNames = map[string]string{
+	"bad_request_error_retries":              "BadRequestErrorRetries",
+	"authentication_error_retries":           "AuthenticationErrorRetries",
+	"timeout_error_retries":                  "TimeoutErrorRetries",
+	"rate_limit_error_retries":               "RateLimitErrorRetries",
+	"content_policy_violation_error_retries": "ContentPolicyViolationErrorRetries",
+	"internal_server_error_retries":          "InternalServerErrorRetries",
+}
+
+type jsonShapeStringValidator struct {
+	shape byte
+}
+
+var _ validator.String = jsonShapeStringValidator{}
+
+func (v jsonShapeStringValidator) Description(context.Context) string {
+	if v.shape == '{' {
+		return "Value must be a JSON object."
+	}
+	return "Value must be a JSON array."
+}
+
+func (v jsonShapeStringValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v jsonShapeStringValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+	var decoded interface{}
+	if err := json.Unmarshal([]byte(req.ConfigValue.ValueString()), &decoded); err != nil {
+		resp.Diagnostics.AddAttributeError(req.Path, "Invalid Router Settings JSON", fmt.Sprintf("Value must be valid JSON: %s", err))
+		return
+	}
+	valid := false
+	if v.shape == '{' {
+		_, valid = decoded.(map[string]interface{})
+	} else {
+		_, valid = decoded.([]interface{})
+	}
+	if !valid {
+		resp.Diagnostics.AddAttributeError(req.Path, "Invalid Router Settings JSON Shape", v.Description(ctx))
+	}
+}
+
+func decodeRouterSettingsJSON(value types.String) (interface{}, error) {
+	var decoded interface{}
+	if err := json.Unmarshal([]byte(value.ValueString()), &decoded); err != nil {
+		return nil, err
+	}
+	return decoded, nil
+}
+
+func applyKeyRouterSettingsUpdateSemantics(request map[string]interface{}, planned, prior types.Object) {
+	// LiteLLM distinguishes an omitted router_settings field (leave unchanged)
+	// from an explicit empty object (clear the complete stored document). The
+	// v1.98.0 request/auth validation path rejects JSON null for this field.
+	if planned.IsNull() && !prior.IsNull() {
+		request["router_settings"] = map[string]interface{}{}
+	}
+}
+
+func keyRouterSettingsPayload(obj types.Object) (map[string]interface{}, error) {
+	if obj.IsNull() || obj.IsUnknown() {
+		return nil, nil
+	}
+	attrs := obj.Attributes()
+	payload := make(map[string]interface{})
+
+	for _, name := range []string{"routing_strategy", "tag_routing_prefix"} {
+		value := attrs[name].(types.String)
+		if !value.IsNull() && !value.IsUnknown() {
+			payload[name] = value.ValueString()
+		}
+	}
+	for _, name := range []string{"allowed_fails", "num_retries", "max_retries"} {
+		value := attrs[name].(types.Int64)
+		if !value.IsNull() && !value.IsUnknown() {
+			payload[name] = value.ValueInt64()
+		}
+	}
+	for _, name := range []string{"cooldown_time", "timeout", "retry_after"} {
+		value := attrs[name].(types.Float64)
+		if !value.IsNull() && !value.IsUnknown() {
+			payload[name] = value.ValueFloat64()
+		}
+	}
+	if value := attrs["enable_tag_filtering"].(types.Bool); !value.IsNull() && !value.IsUnknown() {
+		payload["enable_tag_filtering"] = value.ValueBool()
+	}
+
+	for _, name := range []string{
+		"routing_strategy_args",
+		"routing_groups",
+		"model_group_retry_policy",
+		"model_group_affinity_config",
+		"fallbacks",
+		"context_window_fallbacks",
+		"model_group_alias",
+	} {
+		value := attrs[name].(types.String)
+		if value.IsNull() || value.IsUnknown() {
+			continue
+		}
+		decoded, err := decodeRouterSettingsJSON(value)
+		if err != nil {
+			return nil, fmt.Errorf("decode router_settings.%s: %w", name, err)
+		}
+		payload[name] = decoded
+	}
+
+	if retryPolicy := attrs["retry_policy"].(types.Object); !retryPolicy.IsNull() && !retryPolicy.IsUnknown() {
+		policy := make(map[string]interface{})
+		for terraformName, wireName := range keyRetryPolicyWireNames {
+			value := retryPolicy.Attributes()[terraformName].(types.Int64)
+			if !value.IsNull() && !value.IsUnknown() {
+				policy[wireName] = value.ValueInt64()
+			}
+		}
+		payload["retry_policy"] = policy
+	}
+
+	return payload, nil
+}
+
+func normalizedRouterSettingsJSON(value interface{}) (interface{}, error) {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	var normalized interface{}
+	if err := json.Unmarshal(encoded, &normalized); err != nil {
+		return nil, err
+	}
+	return normalized, nil
+}
+
+// keyRouterSettingsMatchAPI compares the complete owned document. A nil or
+// empty API object both mean there is no key-level override and inheritance is
+// restored. JSON normalization removes Go int64/float64 representation noise.
+func keyRouterSettingsMatchAPI(wanted map[string]interface{}, raw interface{}) (bool, error) {
+	observed, present, err := routerSettingsMapFromAPI(raw)
+	if err != nil {
+		return false, err
+	}
+	if wanted == nil {
+		return !present || len(observed) == 0, nil
+	}
+	if !present {
+		return false, nil
+	}
+	normalizedWanted, err := normalizedRouterSettingsJSON(wanted)
+	if err != nil {
+		return false, err
+	}
+	normalizedObserved, err := normalizedRouterSettingsJSON(observed)
+	if err != nil {
+		return false, err
+	}
+	return reflect.DeepEqual(normalizedWanted, normalizedObserved), nil
+}
+
+func routerSettingsMapFromAPI(raw interface{}) (map[string]interface{}, bool, error) {
+	if raw == nil {
+		return nil, false, nil
+	}
+	if value, ok := raw.(string); ok {
+		if value == "" || value == "null" {
+			return nil, false, nil
+		}
+		var decoded interface{}
+		if err := json.Unmarshal([]byte(value), &decoded); err != nil {
+			return nil, false, fmt.Errorf("decode router_settings response: %w", err)
+		}
+		raw = decoded
+	}
+	settings, ok := raw.(map[string]interface{})
+	if !ok {
+		return nil, false, fmt.Errorf("expected router_settings to be an object, got %T", raw)
+	}
+	return settings, true, nil
+}
+
+func jsonStringFromRouterSettingsAPI(raw interface{}, current attr.Value) (types.String, error) {
+	canonical, err := json.Marshal(raw)
+	if err != nil {
+		return types.StringNull(), err
+	}
+	if existing, ok := current.(types.String); ok && !existing.IsNull() && !existing.IsUnknown() {
+		var configured interface{}
+		if json.Unmarshal([]byte(existing.ValueString()), &configured) == nil && reflect.DeepEqual(configured, raw) {
+			return existing, nil
+		}
+	}
+	return types.StringValue(string(canonical)), nil
+}
+
+func int64FromRouterSettingsAPI(raw interface{}) (types.Int64, error) {
+	switch value := raw.(type) {
+	case float64:
+		if value != float64(int64(value)) {
+			return types.Int64Null(), fmt.Errorf("expected an integer, got %v", value)
+		}
+		return types.Int64Value(int64(value)), nil
+	case int:
+		return types.Int64Value(int64(value)), nil
+	case int64:
+		return types.Int64Value(value), nil
+	default:
+		return types.Int64Null(), fmt.Errorf("expected an integer, got %T", raw)
+	}
+}
+
+func float64FromRouterSettingsAPI(raw interface{}) (types.Float64, error) {
+	switch value := raw.(type) {
+	case float64:
+		return types.Float64Value(value), nil
+	case int:
+		return types.Float64Value(float64(value)), nil
+	case int64:
+		return types.Float64Value(float64(value)), nil
+	default:
+		return types.Float64Null(), fmt.Errorf("expected a number, got %T", raw)
+	}
+}
+
+func retryPolicyFromAPI(raw interface{}) (types.Object, error) {
+	policy, ok := raw.(map[string]interface{})
+	if !ok {
+		return types.ObjectNull(keyRetryPolicyAttrTypes), fmt.Errorf("expected retry_policy to be an object, got %T", raw)
+	}
+	knownWireNames := make(map[string]struct{}, len(keyRetryPolicyWireNames))
+	for _, wireName := range keyRetryPolicyWireNames {
+		knownWireNames[wireName] = struct{}{}
+	}
+	for wireName := range policy {
+		if _, known := knownWireNames[wireName]; !known {
+			return types.ObjectNull(keyRetryPolicyAttrTypes), fmt.Errorf("retry_policy contains unsupported LiteLLM v1.98.0 field %q", wireName)
+		}
+	}
+	values := make(map[string]attr.Value, len(keyRetryPolicyAttrTypes))
+	for terraformName, wireName := range keyRetryPolicyWireNames {
+		values[terraformName] = types.Int64Null()
+		if rawValue, exists := policy[wireName]; exists && rawValue != nil {
+			value, err := int64FromRouterSettingsAPI(rawValue)
+			if err != nil {
+				return types.ObjectNull(keyRetryPolicyAttrTypes), fmt.Errorf("retry_policy.%s: %w", wireName, err)
+			}
+			values[terraformName] = value
+		}
+	}
+	value, diagnostics := types.ObjectValue(keyRetryPolicyAttrTypes, values)
+	if diagnostics.HasError() {
+		return types.ObjectNull(keyRetryPolicyAttrTypes), fmt.Errorf("build retry_policy state: %v", diagnostics.Errors())
+	}
+	return value, nil
+}
+
+func keyRouterSettingsFromAPI(raw interface{}, current types.Object) (types.Object, bool, error) {
+	settings, present, err := routerSettingsMapFromAPI(raw)
+	if err != nil || !present {
+		return types.ObjectNull(keyRouterSettingsAttrTypes), present, err
+	}
+	for name := range settings {
+		if _, known := keyRouterSettingsAttrTypes[name]; !known {
+			return types.ObjectNull(keyRouterSettingsAttrTypes), true, fmt.Errorf("router_settings contains unsupported LiteLLM v1.98.0 field %q", name)
+		}
+	}
+
+	values := make(map[string]attr.Value, len(keyRouterSettingsAttrTypes))
+	// Initialize the finite v1.98.0 schema explicitly with typed nulls.
+	for _, name := range []string{"routing_strategy_args", "routing_strategy", "routing_groups", "model_group_retry_policy", "model_group_affinity_config", "fallbacks", "context_window_fallbacks", "model_group_alias", "tag_routing_prefix"} {
+		values[name] = types.StringNull()
+	}
+	values["retry_policy"] = types.ObjectNull(keyRetryPolicyAttrTypes)
+	for _, name := range []string{"allowed_fails", "num_retries", "max_retries"} {
+		values[name] = types.Int64Null()
+	}
+	for _, name := range []string{"cooldown_time", "timeout", "retry_after"} {
+		values[name] = types.Float64Null()
+	}
+	values["enable_tag_filtering"] = types.BoolNull()
+
+	currentAttrs := map[string]attr.Value{}
+	if !current.IsNull() && !current.IsUnknown() {
+		currentAttrs = current.Attributes()
+	}
+	for _, name := range []string{"routing_strategy_args", "routing_groups", "model_group_retry_policy", "model_group_affinity_config", "fallbacks", "context_window_fallbacks", "model_group_alias"} {
+		if rawValue, exists := settings[name]; exists && rawValue != nil {
+			value, err := jsonStringFromRouterSettingsAPI(rawValue, currentAttrs[name])
+			if err != nil {
+				return types.ObjectNull(keyRouterSettingsAttrTypes), true, fmt.Errorf("router_settings.%s: %w", name, err)
+			}
+			values[name] = value
+		}
+	}
+	for _, name := range []string{"routing_strategy", "tag_routing_prefix"} {
+		if rawValue, exists := settings[name]; exists && rawValue != nil {
+			value, ok := rawValue.(string)
+			if !ok {
+				return types.ObjectNull(keyRouterSettingsAttrTypes), true, fmt.Errorf("router_settings.%s: expected string, got %T", name, rawValue)
+			}
+			values[name] = types.StringValue(value)
+		}
+	}
+	for _, name := range []string{"allowed_fails", "num_retries", "max_retries"} {
+		if rawValue, exists := settings[name]; exists && rawValue != nil {
+			value, err := int64FromRouterSettingsAPI(rawValue)
+			if err != nil {
+				return types.ObjectNull(keyRouterSettingsAttrTypes), true, fmt.Errorf("router_settings.%s: %w", name, err)
+			}
+			values[name] = value
+		}
+	}
+	for _, name := range []string{"cooldown_time", "timeout", "retry_after"} {
+		if rawValue, exists := settings[name]; exists && rawValue != nil {
+			value, err := float64FromRouterSettingsAPI(rawValue)
+			if err != nil {
+				return types.ObjectNull(keyRouterSettingsAttrTypes), true, fmt.Errorf("router_settings.%s: %w", name, err)
+			}
+			values[name] = value
+		}
+	}
+	if rawValue, exists := settings["enable_tag_filtering"]; exists && rawValue != nil {
+		value, ok := rawValue.(bool)
+		if !ok {
+			return types.ObjectNull(keyRouterSettingsAttrTypes), true, fmt.Errorf("router_settings.enable_tag_filtering: expected boolean, got %T", rawValue)
+		}
+		values["enable_tag_filtering"] = types.BoolValue(value)
+	}
+	if rawValue, exists := settings["retry_policy"]; exists && rawValue != nil {
+		value, err := retryPolicyFromAPI(rawValue)
+		if err != nil {
+			return types.ObjectNull(keyRouterSettingsAttrTypes), true, err
+		}
+		values["retry_policy"] = value
+	}
+
+	value, diagnostics := types.ObjectValue(keyRouterSettingsAttrTypes, values)
+	if diagnostics.HasError() {
+		return types.ObjectNull(keyRouterSettingsAttrTypes), true, fmt.Errorf("build router_settings state: %v", diagnostics.Errors())
+	}
+	return value, true, nil
+}

--- a/internal/provider/resource_key_router_settings_test.go
+++ b/internal/provider/resource_key_router_settings_test.go
@@ -1,0 +1,450 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestKeyRouterSettingsOwnershipSchema(t *testing.T) {
+	t.Parallel()
+
+	var resourceResponse resource.SchemaResponse
+	(&KeyResource{}).Schema(context.Background(), resource.SchemaRequest{}, &resourceResponse)
+	if resourceResponse.Diagnostics.HasError() {
+		t.Fatalf("resource schema diagnostics: %v", resourceResponse.Diagnostics)
+	}
+	resourceAttribute := resourceResponse.Schema.Attributes["router_settings"]
+	if !resourceAttribute.IsOptional() || resourceAttribute.IsComputed() {
+		t.Fatalf("resource router_settings must be Optional-only for selective ownership: %#v", resourceAttribute)
+	}
+
+	var dataSourceResponse datasource.SchemaResponse
+	(&KeyDataSource{}).Schema(context.Background(), datasource.SchemaRequest{}, &dataSourceResponse)
+	if dataSourceResponse.Diagnostics.HasError() {
+		t.Fatalf("data source schema diagnostics: %v", dataSourceResponse.Diagnostics)
+	}
+	dataSourceAttribute := dataSourceResponse.Schema.Attributes["router_settings"]
+	if !dataSourceAttribute.IsComputed() || dataSourceAttribute.IsOptional() {
+		t.Fatalf("data source router_settings must expose the complete computed document: %#v", dataSourceAttribute)
+	}
+	if got := len((&KeyDataSource{}).ConfigValidators(context.Background())); got != 1 {
+		t.Fatalf("key data source config validators = %d, want exactly-one lookup validator", got)
+	}
+	if key := dataSourceResponse.Schema.Attributes["key"]; !key.IsOptional() || !key.IsSensitive() {
+		t.Fatalf("key lookup must be optional and sensitive: %#v", key)
+	}
+	if keyHash := dataSourceResponse.Schema.Attributes["key_hash"]; !keyHash.IsOptional() || keyHash.IsSensitive() {
+		t.Fatalf("key_hash lookup must be optional and non-sensitive: %#v", keyHash)
+	}
+}
+
+func TestKeyDataSourceLookupSupportsRawAndWriteOnlyHash(t *testing.T) {
+	t.Parallel()
+
+	raw := "sk-data-source-lookup-test"
+	managementID := hashKeyForID(raw)
+	bareHash, err := keyHashFromID(managementID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tests := map[string]struct {
+		data       KeyDataSourceModel
+		wantLookup string
+		wantID     string
+		wantError  bool
+	}{
+		"raw key": {
+			data:       KeyDataSourceModel{Key: types.StringValue(raw), KeyHash: types.StringNull()},
+			wantLookup: raw,
+			wantID:     managementID,
+		},
+		"write-only hash": {
+			data:       KeyDataSourceModel{Key: types.StringNull(), KeyHash: types.StringValue(managementID)},
+			wantLookup: bareHash,
+			wantID:     managementID,
+		},
+		"uppercase write-only hash normalizes": {
+			data:       KeyDataSourceModel{Key: types.StringNull(), KeyHash: types.StringValue("sha256:" + strings.ToUpper(bareHash))},
+			wantLookup: bareHash,
+			wantID:     managementID,
+		},
+		"invalid hash": {
+			data:      KeyDataSourceModel{Key: types.StringNull(), KeyHash: types.StringValue("sha256:not-a-hash")},
+			wantError: true,
+		},
+		"missing lookup": {
+			data:      KeyDataSourceModel{Key: types.StringNull(), KeyHash: types.StringNull()},
+			wantError: true,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			lookup, id, err := keyDataSourceLookup(&test.data)
+			if test.wantError {
+				if err == nil {
+					t.Fatalf("lookup = %q, id = %q, want error", lookup, id)
+				}
+				return
+			}
+			if err != nil || lookup != test.wantLookup || id != test.wantID {
+				t.Fatalf("keyDataSourceLookup = (%q, %q, %v), want (%q, %q, nil)", lookup, id, err, test.wantLookup, test.wantID)
+			}
+		})
+	}
+}
+
+func TestKeyDataSourceReadErrorOmitsLookupToken(t *testing.T) {
+	t.Parallel()
+
+	secret := "sk-sensitive-data-source-lookup-token"
+	for name, err := range map[string]error{
+		"transport": fmt.Errorf("Get https://proxy.example/key/info?key=%s: connection reset", secret),
+		"api":       &APIError{StatusCode: http.StatusBadRequest, Body: `{"echo":"` + secret + `"}`},
+	} {
+		t.Run(name, func(t *testing.T) {
+			message := keyDataSourceReadError(err)
+			if strings.Contains(message, secret) {
+				t.Fatalf("safe data-source diagnostic exposed lookup token: %q", message)
+			}
+		})
+	}
+}
+
+func TestRouterSettingsReadStatusClassification(t *testing.T) {
+	t.Parallel()
+
+	for _, status := range []int{http.StatusNotFound, http.StatusRequestTimeout, http.StatusTooManyRequests, http.StatusInternalServerError, http.StatusBadGateway} {
+		if !isTransientRouterSettingsReadStatus(status) {
+			t.Errorf("HTTP %d must be retried", status)
+		}
+	}
+	for _, status := range []int{http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden, http.StatusUnprocessableEntity} {
+		if isTransientRouterSettingsReadStatus(status) {
+			t.Errorf("HTTP %d must fail fast", status)
+		}
+	}
+}
+
+func keyRouterSettingsTestValue(t *testing.T, overrides map[string]attr.Value) types.Object {
+	t.Helper()
+	values := map[string]attr.Value{}
+	for _, name := range []string{"routing_strategy_args", "routing_strategy", "routing_groups", "model_group_retry_policy", "model_group_affinity_config", "fallbacks", "context_window_fallbacks", "model_group_alias", "tag_routing_prefix"} {
+		values[name] = types.StringNull()
+	}
+	values["retry_policy"] = types.ObjectNull(keyRetryPolicyAttrTypes)
+	for _, name := range []string{"allowed_fails", "num_retries", "max_retries"} {
+		values[name] = types.Int64Null()
+	}
+	for _, name := range []string{"cooldown_time", "timeout", "retry_after"} {
+		values[name] = types.Float64Null()
+	}
+	values["enable_tag_filtering"] = types.BoolNull()
+	for name, value := range overrides {
+		values[name] = value
+	}
+	object, diagnostics := types.ObjectValue(keyRouterSettingsAttrTypes, values)
+	if diagnostics.HasError() {
+		t.Fatalf("build router settings test value: %v", diagnostics)
+	}
+	return object
+}
+
+func retryPolicyTestValue(t *testing.T) types.Object {
+	t.Helper()
+	values := map[string]attr.Value{
+		"bad_request_error_retries":              types.Int64Value(1),
+		"authentication_error_retries":           types.Int64Value(2),
+		"timeout_error_retries":                  types.Int64Value(3),
+		"rate_limit_error_retries":               types.Int64Value(4),
+		"content_policy_violation_error_retries": types.Int64Value(5),
+		"internal_server_error_retries":          types.Int64Value(6),
+	}
+	object, diagnostics := types.ObjectValue(keyRetryPolicyAttrTypes, values)
+	if diagnostics.HasError() {
+		t.Fatalf("build retry policy: %v", diagnostics)
+	}
+	return object
+}
+
+func TestKeyRouterSettingsPayloadMatchesLiteLLMV198Schema(t *testing.T) {
+	t.Parallel()
+
+	settings := keyRouterSettingsTestValue(t, map[string]attr.Value{
+		"routing_strategy_args":       types.StringValue(`{"ttl":30,"nested":{"weight":0.5}}`),
+		"routing_strategy":            types.StringValue("usage-based-routing-v2"),
+		"routing_groups":              types.StringValue(`[{"group_name":"primary","models":["gpt-4o"],"routing_strategy":"simple-shuffle","routing_strategy_args":{"weight":2}}]`),
+		"retry_policy":                retryPolicyTestValue(t),
+		"model_group_retry_policy":    types.StringValue(`{"gpt-4o":{"RateLimitErrorRetries":7}}`),
+		"model_group_affinity_config": types.StringValue(`{"us":["gpt-4o","gpt-4o-mini"]}`),
+		"allowed_fails":               types.Int64Value(8),
+		"cooldown_time":               types.Float64Value(9.5),
+		"num_retries":                 types.Int64Value(10),
+		"timeout":                     types.Float64Value(11.5),
+		"max_retries":                 types.Int64Value(12),
+		"retry_after":                 types.Float64Value(0.25),
+		"fallbacks":                   types.StringValue(`[{"gpt-4o":["gpt-4o-mini"]},{"*":["fallback"]}]`),
+		"context_window_fallbacks":    types.StringValue(`[{"gpt-4o":["large-context"]}]`),
+		"model_group_alias":           types.StringValue(`{"fast":"gpt-4o-mini","hidden":{"model":"gpt-4o","hidden":true}}`),
+		"enable_tag_filtering":        types.BoolValue(true),
+		"tag_routing_prefix":          types.StringValue("tenant:"),
+	})
+
+	payload, err := keyRouterSettingsPayload(settings)
+	if err != nil {
+		t.Fatalf("keyRouterSettingsPayload: %v", err)
+	}
+	if len(payload) != 17 {
+		t.Fatalf("payload has %d fields, want 17: %#v", len(payload), payload)
+	}
+	if payload["retry_after"] != 0.25 {
+		t.Fatalf("retry_after = %#v, want decimal 0.25", payload["retry_after"])
+	}
+	policy, ok := payload["retry_policy"].(map[string]interface{})
+	if !ok || policy["RateLimitErrorRetries"] != int64(4) || len(policy) != 6 {
+		t.Fatalf("retry_policy does not use exact LiteLLM wire names: %#v", payload["retry_policy"])
+	}
+	fallbacks := payload["fallbacks"].([]interface{})
+	if len(fallbacks) != 2 {
+		t.Fatalf("fallback order was not preserved: %#v", fallbacks)
+	}
+	alias := payload["model_group_alias"].(map[string]interface{})
+	if _, ok := alias["hidden"].(map[string]interface{}); !ok {
+		t.Fatalf("object-valued model-group alias was lost: %#v", alias)
+	}
+}
+
+func TestKeyRouterSettingsUpdateReplacesAndClearsCompleteDocument(t *testing.T) {
+	t.Parallel()
+
+	prior := keyRouterSettingsTestValue(t, map[string]attr.Value{
+		"routing_strategy": types.StringValue("simple-shuffle"),
+		"num_retries":      types.Int64Value(5),
+		"fallbacks":        types.StringValue(`[{"gpt-4o":["gpt-4o-mini"]}]`),
+	})
+	planned := keyRouterSettingsTestValue(t, map[string]attr.Value{
+		"num_retries": types.Int64Value(2),
+	})
+	data := &KeyResourceModel{RouterSettings: planned}
+	request := mustBuildKeyRequest(t, &KeyResource{}, data)
+	applyKeyRouterSettingsUpdateSemantics(request, planned, prior)
+	settings, ok := request["router_settings"].(map[string]interface{})
+	if !ok || len(settings) != 1 || settings["num_retries"] != int64(2) {
+		t.Fatalf("partial plan must replace, not merge, the complete document: %#v", request["router_settings"])
+	}
+	if _, retained := settings["routing_strategy"]; retained {
+		t.Fatalf("removed prior field was retained: %#v", settings)
+	}
+
+	clearRequest := map[string]interface{}{"key": "hash"}
+	applyKeyRouterSettingsUpdateSemantics(clearRequest, types.ObjectNull(keyRouterSettingsAttrTypes), prior)
+	cleared, ok := clearRequest["router_settings"].(map[string]interface{})
+	if !ok || len(cleared) != 0 {
+		t.Fatalf("block removal must send an explicit empty object, got %#v", clearRequest["router_settings"])
+	}
+
+	unmanagedRequest := map[string]interface{}{"key": "hash"}
+	applyKeyRouterSettingsUpdateSemantics(unmanagedRequest, types.ObjectNull(keyRouterSettingsAttrTypes), types.ObjectNull(keyRouterSettingsAttrTypes))
+	if _, sent := unmanagedRequest["router_settings"]; sent {
+		t.Fatalf("unmanaged settings must be omitted: %#v", unmanagedRequest)
+	}
+}
+
+func TestKeyRouterSettingsFromAPIPreservesEquivalentConfiguredJSON(t *testing.T) {
+	t.Parallel()
+
+	configuredFallbacks := "[ { \"gpt-4o\" : [\"gpt-4o-mini\"] } ]"
+	current := keyRouterSettingsTestValue(t, map[string]attr.Value{
+		"fallbacks":    types.StringValue(configuredFallbacks),
+		"retry_after":  types.Float64Value(0.25),
+		"retry_policy": retryPolicyTestValue(t),
+	})
+	api := map[string]interface{}{
+		"fallbacks":   []interface{}{map[string]interface{}{"gpt-4o": []interface{}{"gpt-4o-mini"}}},
+		"retry_after": 0.25,
+		"retry_policy": map[string]interface{}{
+			"BadRequestErrorRetries":             float64(1),
+			"AuthenticationErrorRetries":         float64(2),
+			"TimeoutErrorRetries":                float64(3),
+			"RateLimitErrorRetries":              float64(4),
+			"ContentPolicyViolationErrorRetries": float64(5),
+			"InternalServerErrorRetries":         float64(6),
+		},
+	}
+
+	got, present, err := keyRouterSettingsFromAPI(api, current)
+	if err != nil || !present {
+		t.Fatalf("keyRouterSettingsFromAPI = present %t, error %v", present, err)
+	}
+	if got.Attributes()["fallbacks"].(types.String).ValueString() != configuredFallbacks {
+		t.Fatalf("equivalent configured JSON formatting was not preserved: %q", got.Attributes()["fallbacks"])
+	}
+	if !got.Attributes()["retry_policy"].Equal(current.Attributes()["retry_policy"]) {
+		t.Fatalf("retry policy changed: %#v", got.Attributes()["retry_policy"])
+	}
+}
+
+func TestKeyRouterSettingsCompleteDocumentComparison(t *testing.T) {
+	t.Parallel()
+
+	wanted := map[string]interface{}{
+		"num_retries": int64(3),
+		"fallbacks": []interface{}{
+			map[string]interface{}{"gpt-4o": []interface{}{"gpt-4o-mini"}},
+		},
+	}
+	observed := map[string]interface{}{
+		"num_retries": float64(3),
+		"fallbacks": []interface{}{
+			map[string]interface{}{"gpt-4o": []interface{}{"gpt-4o-mini"}},
+		},
+	}
+	matches, err := keyRouterSettingsMatchAPI(wanted, observed)
+	if err != nil || !matches {
+		t.Fatalf("equivalent complete documents = %t, %v", matches, err)
+	}
+	observed["routing_strategy"] = "simple-shuffle"
+	matches, err = keyRouterSettingsMatchAPI(wanted, observed)
+	if err != nil || matches {
+		t.Fatalf("API-added field must be drift: matches %t, error %v", matches, err)
+	}
+	for name, raw := range map[string]interface{}{"missing": nil, "empty object": map[string]interface{}{}, "encoded empty object": `{}`} {
+		t.Run(name, func(t *testing.T) {
+			matches, err := keyRouterSettingsMatchAPI(nil, raw)
+			if err != nil || !matches {
+				t.Fatalf("cleared document = %t, %v", matches, err)
+			}
+		})
+	}
+}
+
+func TestKeyRouterSettingsRejectsUnsupportedReadbackFields(t *testing.T) {
+	t.Parallel()
+
+	if _, _, err := keyRouterSettingsFromAPI(map[string]interface{}{"stream_timeout": 30.0}, types.ObjectNull(keyRouterSettingsAttrTypes)); err == nil {
+		t.Fatal("expected stale unsupported top-level field to fail instead of being silently discarded")
+	}
+	if _, _, err := keyRouterSettingsFromAPI(map[string]interface{}{
+		"retry_policy": map[string]interface{}{"UnknownErrorRetries": float64(1)},
+	}, types.ObjectNull(keyRouterSettingsAttrTypes)); err == nil {
+		t.Fatal("expected unsupported retry-policy field to fail instead of being silently discarded")
+	}
+}
+
+func TestKeyRouterSettingsStringAndNullReadback(t *testing.T) {
+	t.Parallel()
+
+	got, present, err := keyRouterSettingsFromAPI(`{"fallbacks":[],"model_group_alias":{"fast":"gpt-4o"}}`, types.ObjectNull(keyRouterSettingsAttrTypes))
+	if err != nil || !present {
+		t.Fatalf("string readback = present %t, error %v", present, err)
+	}
+	if got.Attributes()["fallbacks"].(types.String).ValueString() != "[]" {
+		t.Fatalf("explicit empty fallback list not retained: %#v", got)
+	}
+
+	got, present, err = keyRouterSettingsFromAPI(nil, got)
+	if err != nil || present || !got.IsNull() {
+		t.Fatalf("null readback = %#v, present %t, error %v", got, present, err)
+	}
+}
+
+func TestWaitForKeyRouterSettingsUsesWriteOnlyHashAndStableReads(t *testing.T) {
+	t.Parallel()
+
+	rawKey := "sk-write-only-router-settings-test"
+	hashID := hashKeyForID(rawKey)
+	hash, err := keyHashFromID(hashID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var reads atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if got := request.URL.Query().Get("key"); got != hash {
+			http.Error(writer, "unexpected key identifier", http.StatusBadRequest)
+			return
+		}
+		reads.Add(1)
+		writer.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(writer).Encode(map[string]interface{}{
+			"info": map[string]interface{}{
+				"router_settings": map[string]interface{}{
+					"routing_strategy": "simple-shuffle",
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	keyResource := &KeyResource{client: &Client{APIBase: server.URL, APIKey: "test", HTTPClient: server.Client()}}
+	data := KeyResourceModel{
+		ID:           types.StringValue(hashID),
+		Key:          types.StringNull(),
+		KeyWOVersion: types.StringValue("1"),
+		RouterSettings: keyRouterSettingsTestValue(t, map[string]attr.Value{
+			"routing_strategy": types.StringValue("simple-shuffle"),
+		}),
+	}
+	if err := keyResource.waitForKeyRouterSettings(context.Background(), &data); err != nil {
+		t.Fatalf("waitForKeyRouterSettings: %v", err)
+	}
+	if got := reads.Load(); got != 2 {
+		t.Fatalf("stable read count = %d, want 2", got)
+	}
+}
+
+func TestReadKeyRouterSettingsOwnership(t *testing.T) {
+	t.Parallel()
+
+	apiSettings := map[string]interface{}{
+		"fallbacks":         []interface{}{map[string]interface{}{"gpt-4o": []interface{}{"gpt-4o-mini"}}},
+		"routing_strategy":  "simple-shuffle",
+		"model_group_alias": map[string]interface{}{"fast": "gpt-4o"},
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(writer).Encode(map[string]interface{}{
+			"key": "sk-router-settings-test",
+			"info": map[string]interface{}{
+				"token":           "hash",
+				"router_settings": apiSettings,
+			},
+		})
+	}))
+	defer server.Close()
+
+	resource := &KeyResource{client: &Client{APIBase: server.URL, APIKey: "test", HTTPClient: server.Client()}}
+	unmanaged := KeyResourceModel{Key: types.StringValue("sk-router-settings-test"), RouterSettings: types.ObjectNull(keyRouterSettingsAttrTypes)}
+	if err := resource.readKey(context.Background(), &unmanaged); err != nil {
+		t.Fatalf("unmanaged read: %v", err)
+	}
+	if !unmanaged.RouterSettings.IsNull() {
+		t.Fatalf("absent block adopted API settings: %#v", unmanaged.RouterSettings)
+	}
+
+	managed := KeyResourceModel{
+		Key: types.StringValue("sk-router-settings-test"),
+		RouterSettings: keyRouterSettingsTestValue(t, map[string]attr.Value{
+			"fallbacks":         types.StringValue(`[{"gpt-4o":["gpt-4o-mini"]}]`),
+			"routing_strategy":  types.StringValue("simple-shuffle"),
+			"model_group_alias": types.StringValue(`{"fast":"gpt-4o"}`),
+		}),
+	}
+	if err := resource.readKey(context.Background(), &managed); err != nil {
+		t.Fatalf("managed read: %v", err)
+	}
+	want, _, _ := keyRouterSettingsFromAPI(apiSettings, managed.RouterSettings)
+	if !reflect.DeepEqual(managed.RouterSettings, want) {
+		t.Fatalf("managed settings did not refresh\n got: %#v\nwant: %#v", managed.RouterSettings, want)
+	}
+}

--- a/internal/provider/resource_key_test.go
+++ b/internal/provider/resource_key_test.go
@@ -15,6 +15,15 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 )
 
+func mustBuildKeyRequest(t *testing.T, r *KeyResource, data *KeyResourceModel) map[string]interface{} {
+	t.Helper()
+	request, err := r.buildKeyRequest(context.Background(), data)
+	if err != nil {
+		t.Fatalf("buildKeyRequest: %v", err)
+	}
+	return request
+}
+
 func TestKeyWriteOnlySchemaAndValidators(t *testing.T) {
 	t.Parallel()
 
@@ -227,7 +236,7 @@ func TestCreateKeyUsesHashedID(t *testing.T) {
 		Key: types.StringUnknown(),
 	}
 
-	keyReq := r.buildKeyRequest(context.Background(), data)
+	keyReq := mustBuildKeyRequest(t, r, data)
 	var result map[string]interface{}
 	if err := r.client.DoRequestWithResponse(context.Background(), "POST", "/key/generate", keyReq, &result); err != nil {
 		t.Fatalf("POST /key/generate: %v", err)
@@ -260,7 +269,7 @@ func TestBuildKeyRequestIncludesProjectID(t *testing.T) {
 		ProjectID: types.StringValue("project-123"),
 	}
 
-	keyReq := r.buildKeyRequest(context.Background(), data)
+	keyReq := mustBuildKeyRequest(t, r, data)
 
 	if keyReq["project_id"] != "project-123" {
 		t.Fatalf("expected project_id 'project-123', got %v", keyReq["project_id"])
@@ -460,7 +469,7 @@ func TestPredefinedKeyIsSentToAPI(t *testing.T) {
 		Key: types.StringValue("sk-my-predefined-key"),
 	}
 
-	keyReq := r.buildKeyRequest(context.Background(), data)
+	keyReq := mustBuildKeyRequest(t, r, data)
 
 	// Verify the predefined key is included in the request body
 	if keyReq["key"] != "sk-my-predefined-key" {
@@ -1052,7 +1061,7 @@ func TestBuildKeyRequestMetadataWithJSON(t *testing.T) {
 		}),
 	}
 
-	req := r.buildKeyRequest(context.Background(), data)
+	req := mustBuildKeyRequest(t, r, data)
 
 	meta, ok := req["metadata"].(map[string]interface{})
 	if !ok {
@@ -1158,7 +1167,7 @@ func TestMinimalKeyNoKeyAliasNoServiceAccountID(t *testing.T) {
 	}
 
 	// 1. buildKeyRequest must NOT include key_alias when neither field is set.
-	keyReq := r.buildKeyRequest(context.Background(), data)
+	keyReq := mustBuildKeyRequest(t, r, data)
 	if _, exists := keyReq["key_alias"]; exists {
 		t.Errorf("key_alias must not appear in request when neither key_alias nor service_account_id is configured, got %v", keyReq["key_alias"])
 	}
@@ -1215,7 +1224,7 @@ func TestServiceAccountIDDefaultsKeyAlias(t *testing.T) {
 		KeyAlias: types.StringNull(),
 	}
 
-	keyReq := r.buildKeyRequest(context.Background(), data)
+	keyReq := mustBuildKeyRequest(t, r, data)
 
 	if keyReq["key_alias"] != "github-ci" {
 		t.Errorf("expected key_alias 'github-ci', got %v", keyReq["key_alias"])
@@ -1244,7 +1253,7 @@ func TestServiceAccountIDKeyAliasExplicitOverride(t *testing.T) {
 		KeyAlias:         types.StringValue("my-custom-alias"),
 	}
 
-	keyReq := r.buildKeyRequest(context.Background(), data)
+	keyReq := mustBuildKeyRequest(t, r, data)
 
 	if keyReq["key_alias"] != "my-custom-alias" {
 		t.Errorf("expected explicit key_alias 'my-custom-alias', got %v", keyReq["key_alias"])

--- a/internal_testing/acceptance.sh
+++ b/internal_testing/acceptance.sh
@@ -50,7 +50,7 @@ run_case budget resources budget_minimal.tf
 run_case credential resources credential_minimal.tf
 run_case fallback resources fallback_minimal.tf
 run_case guardrail resources guardrail_minimal.tf
-run_case key resources key_minimal.tf
+run_case key resources key_minimal.tf,key_router_settings.tf datasources key.tf
 run_case key_block resources key_minimal.tf,key_block_minimal.tf
 run_case mcp_server resources mcp_server_minimal.tf
 run_case model resources model_minimal.tf

--- a/internal_testing/datasources/key.tf
+++ b/internal_testing/datasources/key.tf
@@ -32,3 +32,11 @@ output "ds_key_tags" {
 output "ds_key_metadata" {
   value = data.litellm_key.lookup.metadata
 }
+
+data "litellm_key" "router_settings" {
+  key_hash = litellm_key.router_settings.id
+}
+
+output "ds_key_router_settings" {
+  value = data.litellm_key.router_settings.router_settings
+}

--- a/internal_testing/resources/key_router_settings.tf
+++ b/internal_testing/resources/key_router_settings.tf
@@ -1,0 +1,39 @@
+# LiteLLM v1.98.0 key-level router settings, including heterogeneous JSON
+# fields and exact PascalCase nested retry-policy wire keys.
+resource "litellm_key" "router_settings" {
+  key_alias = "smoke-key-router-settings"
+  models    = ["gpt-4o", "gpt-4o-mini"]
+
+  router_settings = {
+    routing_strategy      = "simple-shuffle"
+    routing_strategy_args = jsonencode({ ttl = 30, nested = { weight = 0.5 } })
+    routing_groups = jsonencode([{
+      group_name            = "primary"
+      models                = ["gpt-4o"]
+      routing_strategy      = "simple-shuffle"
+      routing_strategy_args = { weight = 2 }
+    }])
+    model_group_retry_policy    = jsonencode({ "gpt-4o" = { RateLimitErrorRetries = 7 } })
+    model_group_affinity_config = jsonencode({ us = ["gpt-4o", "gpt-4o-mini"] })
+    allowed_fails               = 8
+    cooldown_time               = 9.5
+    num_retries                 = 10
+    timeout                     = 11.5
+    max_retries                 = 12
+    retry_after                 = 0.25
+    fallbacks                   = jsonencode([{ "gpt-4o" = ["gpt-4o-mini"] }, { "*" = ["emergency-model"] }])
+    context_window_fallbacks    = jsonencode([{ "gpt-4o" = ["large-context"] }])
+    model_group_alias           = jsonencode({ fast = "gpt-4o-mini", hidden = { model = "gpt-4o", hidden = true } })
+    enable_tag_filtering        = true
+    tag_routing_prefix          = "tenant:"
+
+    retry_policy = {
+      bad_request_error_retries              = 1
+      authentication_error_retries           = 2
+      timeout_error_retries                  = 3
+      rate_limit_error_retries               = 4
+      content_policy_violation_error_retries = 5
+      internal_server_error_retries          = 6
+    }
+  }
+}


### PR DESCRIPTION
### Summary

Closes #97. Adds complete key-level `router_settings` support for the exact LiteLLM v1.98.0 `UpdateRouterConfig` contract to the `litellm_key` resource and data source.

This preserves contributor credit and useful design/reproduction work from PRs #98 and #147 while reimplementing against the current provider and pinned backend. PR #98 used a stale 21-field Router constructor schema: nine fields are silently dropped by the v1.98 key API, five accepted fields were absent, `retry_after` was integer-only, and heterogeneous maps were lossy. PR #147 covered only two fallback fields, converted an ordered outer array to a map, and could create an unintended non-empty key override when routing was unconfigured.

The resource now exposes all 17 accepted fields. Homogeneous scalars and default retry policy are typed; routing groups, strategy arguments, model-group retry/affinity maps, ordered fallback arrays, and object-valued aliases use validated JSON strings for lossless round trips. `router_settings` is Optional-only complete-document ownership: omission ignores remote settings, a present block replaces the entire document, and removal sends `{}` to restore team/global inheritance. Two consecutive matching reads are required after mutation so silently dropped or stale fields cannot become false Terraform truth.

The data source exposes the complete document, URL-escapes raw key lookups, and uses a non-sensitive SHA256 management ID instead of copying its sensitive key argument into `id`. Its mutually exclusive `key_hash` input accepts the resource's `sha256:<digest>` ID and sends only the bare hash LiteLLM accepts, so write-only keys can be inspected without reintroducing plaintext into state. Existing state, imports, generated keys, and write-only/hash-managed key lifecycles remain compatible.

### Validation

Live LiteLLM v1.98.0 validation covered all 17 fields, full-to-partial replacement, partial retry policies, decimal `retry_after`, ordered fallbacks, object-valued aliases, explicit empty fallback lists, block removal, and direct API confirmation that removal persisted `{}`. The live API rejected `router_settings: null` despite the static request model, confirming the empty-object clear required by the implementation. Special-character raw keys verified resource and data-source URL escaping, while raw-key and hash-only data-source lifecycles showed only SHA256 IDs in CLI output.

Focused tests cover the exact field set and wire casing, JSON order/objects, semantic read-back, whole-document replacement/clear behavior, selective ownership, stable reads and transient-status classification, write-only/hash data-source identity, secret-safe read diagnostics, null/string API forms, and resource/data-source schema modes. `go vet ./...`, full tests, race tests, pinned loopback acceptance (22/23, project enterprise-only), and the real-dev lifecycle matrix (`PASS (23)`, `DRIFT (0)`, `FAIL (0)`) pass.

### Diff size

**Implementation** — resource/data-source wiring plus one focused router-settings helper

Adds exact v1.98 schemas, JSON validation/conversion, whole-document mutation/read-back, stable convergence, URL-safe lookups, and hash-only data-source IDs.

**Tests and acceptance** — focused unit coverage plus one all-fields pinned fixture

Covers schema ownership, all wire fields, lossless JSON, read-back, convergence, write-only identity, and resource/data-source no-drift lifecycle.

**Docs** — resource, data-source, and changelog updates

Documents precedence, replacement/removal semantics, all 17 fields, JSON shapes, accepted-versus-currently-effective LiteLLM behavior, and contributor attribution.