### PR TITLE
feat: add create-only invitation emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`litellm_key` / `litellm_user`**: Add create-only, write-only `send_invite_email` actions with recipient validation, no Update-time resends, and explicit existing-user adoption safety. ([#100](https://github.com/ncecere/terraform-provider-litellm/issues/100), [#101](https://github.com/ncecere/terraform-provider-litellm/pull/101)) — thanks @Kaago
 - **`litellm_key` resource and data source**: Add complete LiteLLM v1.98.0 `router_settings` support with ordered fallback JSON, retry policies, model-group aliases, routing groups, affinity, tag routing, whole-document ownership, and explicit removal semantics. Key data-source lookups now URL-escape raw tokens and expose only a SHA256 management ID instead of copying the token into a non-sensitive ID. ([#97](https://github.com/ncecere/terraform-provider-litellm/issues/97), [#98](https://github.com/ncecere/terraform-provider-litellm/pull/98), [#147](https://github.com/ncecere/terraform-provider-litellm/pull/147)) — thanks @orolega for #98 and @alexeishtakal for #147
 
 ### Changed

--- a/docs/resources/key.md
+++ b/docs/resources/key.md
@@ -55,6 +55,27 @@ In write-only mode, `key` remains null and `id` contains only `sha256:<key-hash>
 
 > **Compatibility:** The optional write-only argument requires Terraform or OpenTofu 1.11+. Older clients can continue using the provider when `key_wo` is omitted, but reject configurations that set it.
 
+### Create a Key and Email Its User
+
+```hcl
+resource "litellm_user" "recipient" {
+  user_email      = "person@example.com"
+  auto_create_key = false
+}
+
+resource "litellm_key" "invited" {
+  user_id           = litellm_user.recipient.id
+  key_alias         = "emailed-key"
+  send_invite_email = true
+}
+```
+
+`send_invite_email` is a write-only, create-only action flag. Before creating the key, the provider verifies that `user_id` resolves to that exact LiteLLM user and a syntactically valid, non-empty email address. LiteLLM then queues email processing after successful key creation, but returns before delivery and provides no delivery acknowledgement. Configure a supported [LiteLLM email backend](https://docs.litellm.ai/docs/proxy/email) before enabling it. Service-account keys cannot use this action.
+
+LiteLLM v1.98.0's enterprise email implementation defaults `EMAIL_INCLUDE_API_KEY` to `true`, including raw generated or predefined `key_wo` values in email. Set `EMAIL_INCLUDE_API_KEY=false` unless email infrastructure and recipient mailboxes are approved secret-delivery channels.
+
+The action is requested once per successful LiteLLM Create request, not once for the lifetime of the HCL configuration. Resource replacement requests another email. If the create response is lost before Terraform persists state, retrying can create another key and request another email; inspect LiteLLM before retrying an ambiguous failure.
+
 ### Key with Budget and Rate Limits
 
 ```hcl
@@ -178,6 +199,8 @@ The following arguments are supported:
 * `key_wo` - (Optional, Sensitive, Write-only) Predefined key sent to LiteLLM but represented only by null in plan and state. Must be configured with `key_wo_version`. Use a cryptographically random, high-entropy value because its SHA256 management identifier is persisted. Requires Terraform or OpenTofu 1.11+.
 
 * `key_wo_version` - (Optional, ForceNew) Persisted version or nonce for `key_wo`. Change this whenever the write-only secret changes. It conflicts with configurations that omit `key_wo`.
+
+* `send_invite_email` - (Optional, Write-only) Requests an asynchronous email for each successful key Create request. Requires `user_id` for an exact existing user with a syntactically valid email address and cannot be used with `service_account_id`. It is never persisted, read back, imported, or sent during Update; a successful apply does not confirm email delivery. Replacement or an ambiguous Create retry can request another email. Requires Terraform or compatible OpenTofu 1.11+ when configured.
 
 * `key_alias` - (Optional) Human-readable alias for this key.
 

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -35,6 +35,21 @@ resource "litellm_user" "full" {
 }
 ```
 
+### Create and Invite a User
+
+```hcl
+resource "litellm_user" "invited" {
+  user_alias        = "Invited User"
+  user_email        = "person@example.com"
+  auto_create_key   = false
+  send_invite_email = true
+}
+```
+
+`send_invite_email` is a write-only, create-only action flag. It requires a syntactically valid `user_email`. LiteLLM queues email processing after `/user/new` succeeds, but its API returns before delivery and provides no delivery acknowledgement. Configure a supported [LiteLLM email backend](https://docs.litellm.ai/docs/proxy/email) before enabling it.
+
+The action is requested for each successful user Create request, including replacement. If a create response is lost and a retry finds the account already exists, the provider refuses adoption rather than claiming another invitation was sent. When `auto_create_key` remains true, LiteLLM also creates a raw API key that the provider stores in sensitive Terraform state; set `auto_create_key = false` if that is not intended.
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -48,6 +63,7 @@ The following arguments are supported:
 * `tpm_limit` - (Optional) Tokens per minute limit for the user.
 * `rpm_limit` - (Optional) Requests per minute limit for the user.
 * `auto_create_key` - (Optional) Whether to automatically create an API key when the user is created. Defaults to `true`.
+* `send_invite_email` - (Optional, Write-only) Requests an asynchronous invitation for each successful user Create request. Requires a syntactically valid `user_email`. It is never persisted, read back, imported, or sent during Update; a successful apply does not confirm email delivery. Replacement can request another invitation. Requires Terraform or compatible OpenTofu 1.11+ when configured.
 * `teams` - (Optional) Unique team IDs the user belongs to. Membership order is not significant. Updates reconcile additions and removals through LiteLLM's team-member endpoints.
 * `models` - (Optional) List of model names the user is allowed to use.
 * `metadata` - (Optional) A map of key-value metadata pairs for the user.
@@ -81,10 +97,13 @@ terraform import litellm_user.example <user-id>
 
 If `/user/new` returns HTTP 409, the provider can adopt an existing user when `user_email` is known and `/user/list` returns exactly one account with that exact email. If `user_id` is configured, it must also match the existing account. Partial, missing, ambiguous, or conflicting identity matches fail without updating the account.
 
+When `send_invite_email = true`, a 409 conflict is not adopted because LiteLLM did not create the account and therefore sent no invitation. Import the exact existing user with the action omitted, or invite it outside this resource.
+
 After identity verification, configured user fields and team memberships are reconciled. Adoption fails before mutation if configuration would require clearing a non-empty alias, models list, or metadata map because LiteLLM ignores empty values for those fields. Adoption does not request another auto-created key because its raw value could not be recovered into Terraform state. Removing an existing team membership calls LiteLLM's `/team/member_delete`, which also deletes that user's keys scoped to the removed team. Once adopted, Terraform owns the user: destroying the resource deletes the existing LiteLLM user.
 
 ## Notes
 
-- The `user_email` attribute is **not** required for a new user, but it is required for safe automatic adoption after a conflict.
+- The `user_email` attribute is **not** required for an ordinary new user, but it is required for `send_invite_email = true` and for safe automatic adoption after a conflict.
+- Invitation delivery requires LiteLLM email/SMTP configuration. The action is asynchronous and cannot be verified from Terraform state.
 - The `user_id` attribute is ForceNew — changing it will destroy and recreate the resource.
 - When `auto_create_key` is `true` (the default), a `key` is generated and stored in state only when LiteLLM creates a new user.

--- a/internal/provider/invite_email.go
+++ b/internal/provider/invite_email.go
@@ -1,0 +1,106 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/mail"
+	"net/url"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// addSendInviteEmailToCreateRequest handles LiteLLM's create-only invitation
+// action flag. It must never be called by Update because v1.98.0 silently
+// ignores the field there and invitation delivery has no persistent state.
+func addSendInviteEmailToCreateRequest(request map[string]interface{}, value types.Bool) error {
+	if value.IsUnknown() {
+		return fmt.Errorf("send_invite_email must be known during apply")
+	}
+	if value.IsNull() {
+		return nil
+	}
+	request["send_invite_email"] = value.ValueBool()
+	return nil
+}
+
+func sendInviteEmailRequested(value types.Bool) bool {
+	return !value.IsNull() && !value.IsUnknown() && value.ValueBool()
+}
+
+func validateKeySendInviteEmail(data *KeyResourceModel, value types.Bool) error {
+	if !sendInviteEmailRequested(value) {
+		return nil
+	}
+	if data.ServiceAccountID.IsUnknown() {
+		return fmt.Errorf("send_invite_email requires service_account_id to be known during apply")
+	}
+	if !data.ServiceAccountID.IsNull() && data.ServiceAccountID.ValueString() != "" {
+		return fmt.Errorf("send_invite_email cannot be true for a service-account key because LiteLLM ignores user_id on that create endpoint")
+	}
+	if data.UserID.IsNull() || data.UserID.IsUnknown() || data.UserID.ValueString() == "" {
+		return fmt.Errorf("send_invite_email requires user_id so LiteLLM can resolve a recipient email address")
+	}
+	return nil
+}
+
+func validateInviteEmailAddress(value string) error {
+	address, err := mail.ParseAddress(value)
+	if err != nil || address.Address != value {
+		return fmt.Errorf("must be a valid email address without a display name")
+	}
+	return nil
+}
+
+func validateUserSendInviteEmail(data *UserResourceModel, value types.Bool) error {
+	if !sendInviteEmailRequested(value) {
+		return nil
+	}
+	if data.UserEmail.IsNull() || data.UserEmail.IsUnknown() || data.UserEmail.ValueString() == "" {
+		return fmt.Errorf("send_invite_email requires user_email so LiteLLM has a recipient address")
+	}
+	if err := validateInviteEmailAddress(data.UserEmail.ValueString()); err != nil {
+		return fmt.Errorf("send_invite_email user_email %s", err)
+	}
+	return nil
+}
+
+func keyInviteRecipientLookupError(err error) error {
+	var apiErr *APIError
+	if errors.As(err, &apiErr) {
+		return fmt.Errorf("LiteLLM returned HTTP %d while verifying the invitation recipient", apiErr.StatusCode)
+	}
+	return fmt.Errorf("the invitation recipient lookup failed at the transport layer")
+}
+
+func (r *KeyResource) validateKeyInviteRecipient(ctx context.Context, data *KeyResourceModel, value types.Bool) error {
+	if err := validateKeySendInviteEmail(data, value); err != nil {
+		return err
+	}
+	if !sendInviteEmailRequested(value) {
+		return nil
+	}
+
+	expectedUserID := data.UserID.ValueString()
+	endpoint := fmt.Sprintf("/user/info?user_id=%s", url.QueryEscape(expectedUserID))
+	var response map[string]interface{}
+	if err := r.client.DoRequestWithResponse(ctx, "GET", endpoint, nil, &response); err != nil {
+		return keyInviteRecipientLookupError(err)
+	}
+	userInfo := response
+	if nested, ok := response["user_info"].(map[string]interface{}); ok {
+		userInfo = nested
+	}
+	observedUserID, idOK := userInfo["user_id"].(string)
+	if !idOK || observedUserID == "" || observedUserID != expectedUserID {
+		return fmt.Errorf("LiteLLM did not return the exact configured user_id during invitation recipient verification")
+	}
+	email, emailOK := userInfo["user_email"].(string)
+	if !emailOK || email == "" {
+		return fmt.Errorf("the configured user_id does not have a non-empty user_email in LiteLLM")
+	}
+	if err := validateInviteEmailAddress(email); err != nil {
+		return fmt.Errorf("the configured user's user_email %s", err)
+	}
+	return nil
+}

--- a/internal/provider/invite_email_test.go
+++ b/internal/provider/invite_email_test.go
@@ -1,0 +1,223 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestSendInviteEmailSchemasAreCreateOnlyWriteOnly(t *testing.T) {
+	t.Parallel()
+
+	for name, resourceUnderTest := range map[string]resource.Resource{
+		"key":  &KeyResource{},
+		"user": &UserResource{},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var response resource.SchemaResponse
+			resourceUnderTest.Schema(context.Background(), resource.SchemaRequest{}, &response)
+			if response.Diagnostics.HasError() {
+				t.Fatalf("schema diagnostics: %v", response.Diagnostics)
+			}
+			attribute, ok := response.Schema.Attributes["send_invite_email"]
+			if !ok {
+				t.Fatal("send_invite_email schema attribute is missing")
+			}
+			if !attribute.IsOptional() || !attribute.IsWriteOnly() || attribute.IsComputed() {
+				t.Fatalf("send_invite_email must be Optional+WriteOnly and never Computed: %#v", attribute)
+			}
+		})
+	}
+}
+
+func TestAddSendInviteEmailToCreateRequest(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		value       types.Bool
+		wantPresent bool
+		wantValue   bool
+		wantError   bool
+	}{
+		"omitted": {value: types.BoolNull()},
+		"false":   {value: types.BoolValue(false), wantPresent: true},
+		"true":    {value: types.BoolValue(true), wantPresent: true, wantValue: true},
+		"unknown": {value: types.BoolUnknown(), wantError: true},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			request := map[string]interface{}{"unchanged": true}
+			err := addSendInviteEmailToCreateRequest(request, test.value)
+			if test.wantError {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				if _, present := request["send_invite_email"]; present {
+					t.Fatalf("invalid value mutated request: %#v", request)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			value, present := request["send_invite_email"]
+			if present != test.wantPresent {
+				t.Fatalf("presence = %t, want %t: %#v", present, test.wantPresent, request)
+			}
+			if present && value != test.wantValue {
+				t.Fatalf("value = %#v, want %t", value, test.wantValue)
+			}
+		})
+	}
+}
+
+func TestSendInviteEmailRecipientValidation(t *testing.T) {
+	t.Parallel()
+
+	trueValue := types.BoolValue(true)
+	falseValue := types.BoolValue(false)
+	validKey := &KeyResourceModel{UserID: types.StringValue("user-123")}
+	if err := validateKeySendInviteEmail(validKey, trueValue); err != nil {
+		t.Fatalf("valid key invitation: %v", err)
+	}
+	if err := validateKeySendInviteEmail(&KeyResourceModel{}, trueValue); err == nil {
+		t.Fatal("key invitation without user_id must fail")
+	}
+	if err := validateKeySendInviteEmail(&KeyResourceModel{
+		UserID:           types.StringValue("user-123"),
+		ServiceAccountID: types.StringValue("service-account"),
+	}, trueValue); err == nil {
+		t.Fatal("service-account key invitation must fail")
+	}
+	if err := validateKeySendInviteEmail(&KeyResourceModel{
+		UserID:           types.StringValue("user-123"),
+		ServiceAccountID: types.StringUnknown(),
+	}, trueValue); err == nil {
+		t.Fatal("unknown service_account_id must fail when invitation is requested")
+	}
+	if err := validateKeySendInviteEmail(&KeyResourceModel{}, falseValue); err != nil {
+		t.Fatalf("false key invitation should not require a recipient: %v", err)
+	}
+
+	if err := validateUserSendInviteEmail(&UserResourceModel{UserEmail: types.StringValue("person@example.com")}, trueValue); err != nil {
+		t.Fatalf("valid user invitation: %v", err)
+	}
+	if err := validateUserSendInviteEmail(&UserResourceModel{}, trueValue); err == nil {
+		t.Fatal("user invitation without user_email must fail")
+	}
+	if err := validateUserSendInviteEmail(&UserResourceModel{UserEmail: types.StringValue("not-an-email")}, trueValue); err == nil {
+		t.Fatal("user invitation with malformed user_email must fail")
+	}
+	if err := validateUserSendInviteEmail(&UserResourceModel{}, falseValue); err != nil {
+		t.Fatalf("false user invitation should not require email: %v", err)
+	}
+}
+
+func TestKeyInviteRecipientPreflight(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		responseStatus int
+		response       map[string]interface{}
+		wantError      string
+	}{
+		"exact user with email": {
+			responseStatus: http.StatusOK,
+			response: map[string]interface{}{"user_info": map[string]interface{}{
+				"user_id":    "user/id #1",
+				"user_email": "person@example.com",
+			}},
+		},
+		"missing email": {
+			responseStatus: http.StatusOK,
+			response: map[string]interface{}{"user_info": map[string]interface{}{
+				"user_id": "user/id #1",
+			}},
+			wantError: "non-empty user_email",
+		},
+		"mismatched identity": {
+			responseStatus: http.StatusOK,
+			response: map[string]interface{}{"user_info": map[string]interface{}{
+				"user_id":    "other-user",
+				"user_email": "person@example.com",
+			}},
+			wantError: "exact configured user_id",
+		},
+		"lookup not found": {
+			responseStatus: http.StatusNotFound,
+			response:       map[string]interface{}{"detail": "user/id #1 must not be echoed"},
+			wantError:      "HTTP 404",
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				if request.URL.Path != "/user/info" || request.URL.Query().Get("user_id") != "user/id #1" {
+					http.Error(writer, "unexpected recipient lookup", http.StatusBadRequest)
+					return
+				}
+				writer.Header().Set("Content-Type", "application/json")
+				writer.WriteHeader(test.responseStatus)
+				_ = json.NewEncoder(writer).Encode(test.response)
+			}))
+			defer server.Close()
+
+			keyResource := &KeyResource{client: &Client{APIBase: server.URL, APIKey: "test", HTTPClient: server.Client()}}
+			err := keyResource.validateKeyInviteRecipient(context.Background(), &KeyResourceModel{
+				UserID: types.StringValue("user/id #1"),
+			}, types.BoolValue(true))
+			if test.wantError == "" {
+				if err != nil {
+					t.Fatalf("unexpected preflight error: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), test.wantError) {
+				t.Fatalf("error = %v, want substring %q", err, test.wantError)
+			}
+			if strings.Contains(err.Error(), "must not be echoed") {
+				t.Fatalf("preflight diagnostic exposed API response body: %v", err)
+			}
+		})
+	}
+}
+
+func TestUpdateRequestBuildersNeverIncludeSendInviteEmail(t *testing.T) {
+	t.Parallel()
+
+	keyRequest, err := (&KeyResource{}).buildKeyRequest(context.Background(), &KeyResourceModel{
+		SendInviteEmail: types.BoolValue(true),
+	})
+	if err != nil {
+		t.Fatalf("build key request: %v", err)
+	}
+	if _, present := keyRequest["send_invite_email"]; present {
+		t.Fatalf("key update-capable request builder included create-only action: %#v", keyRequest)
+	}
+
+	userRequest := (&UserResource{}).buildUserRequest(context.Background(), &UserResourceModel{
+		SendInviteEmail: types.BoolValue(true),
+	})
+	if _, present := userRequest["send_invite_email"]; present {
+		t.Fatalf("user update-capable request builder included create-only action: %#v", userRequest)
+	}
+}
+
+func TestExistingUserWithInviteMustNotBeAdoptedAsInvited(t *testing.T) {
+	t.Parallel()
+
+	if !sendInviteEmailRequested(types.BoolValue(true)) {
+		t.Fatal("true create action must trigger existing-user rejection")
+	}
+	for _, value := range []types.Bool{types.BoolNull(), types.BoolValue(false), types.BoolUnknown()} {
+		if sendInviteEmailRequested(value) {
+			t.Fatalf("non-true value incorrectly triggers invitation semantics: %#v", value)
+		}
+	}
+}

--- a/internal/provider/resource_key.go
+++ b/internal/provider/resource_key.go
@@ -100,6 +100,7 @@ type KeyResourceModel struct {
 	Key                      types.String  `tfsdk:"key"`
 	KeyWO                    types.String  `tfsdk:"key_wo"`
 	KeyWOVersion             types.String  `tfsdk:"key_wo_version"`
+	SendInviteEmail          types.Bool    `tfsdk:"send_invite_email"`
 	Models                   types.List    `tfsdk:"models"`
 	AllowedRoutes            types.List    `tfsdk:"allowed_routes"`
 	AllowedPassthroughRoutes types.List    `tfsdk:"allowed_passthrough_routes"`
@@ -178,6 +179,11 @@ func (r *KeyResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
+			},
+			"send_invite_email": schema.BoolAttribute{
+				Description: "Create-only action flag that asks LiteLLM to asynchronously email the key's existing user. Requires user_id. It is write-only, is never sent during Update, and does not confirm delivery.",
+				Optional:    true,
+				WriteOnly:   true,
 			},
 			"models": schema.ListAttribute{
 				Description: "List of models this key can access.",
@@ -379,7 +385,9 @@ func (r *KeyResource) Create(ctx context.Context, req resource.CreateRequest, re
 	}
 
 	var writeOnlyKey types.String
+	var sendInviteEmail types.Bool
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("key_wo"), &writeOnlyKey)...)
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("send_invite_email"), &sendInviteEmail)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -402,6 +410,11 @@ func (r *KeyResource) Create(ctx context.Context, req resource.CreateRequest, re
 		return
 	}
 
+	if err := r.validateKeyInviteRecipient(ctx, &data, sendInviteEmail); err != nil {
+		resp.Diagnostics.AddError("Invalid Key Invitation", err.Error())
+		return
+	}
+
 	keyReq, err := r.buildKeyRequest(ctx, &data)
 	if err != nil {
 		resp.Diagnostics.AddError("Invalid Key Request", err.Error())
@@ -409,6 +422,10 @@ func (r *KeyResource) Create(ctx context.Context, req resource.CreateRequest, re
 	}
 	if writeOnlyMode {
 		keyReq["key"] = writeOnlyKey.ValueString()
+	}
+	if err := addSendInviteEmailToCreateRequest(keyReq, sendInviteEmail); err != nil {
+		resp.Diagnostics.AddError("Invalid Key Invitation", err.Error())
+		return
 	}
 
 	endpoint := "/key/generate"

--- a/internal/provider/resource_user.go
+++ b/internal/provider/resource_user.go
@@ -32,20 +32,21 @@ type UserResource struct {
 }
 
 type UserResourceModel struct {
-	ID             types.String  `tfsdk:"id"`
-	UserID         types.String  `tfsdk:"user_id"`
-	UserAlias      types.String  `tfsdk:"user_alias"`
-	UserEmail      types.String  `tfsdk:"user_email"`
-	UserRole       types.String  `tfsdk:"user_role"`
-	Teams          types.List    `tfsdk:"teams"`
-	Models         types.List    `tfsdk:"models"`
-	MaxBudget      types.Float64 `tfsdk:"max_budget"`
-	BudgetDuration types.String  `tfsdk:"budget_duration"`
-	TPMLimit       types.Int64   `tfsdk:"tpm_limit"`
-	RPMLimit       types.Int64   `tfsdk:"rpm_limit"`
-	AutoCreateKey  types.Bool    `tfsdk:"auto_create_key"`
-	Metadata       types.Map     `tfsdk:"metadata"`
-	Key            types.String  `tfsdk:"key"`
+	ID              types.String  `tfsdk:"id"`
+	UserID          types.String  `tfsdk:"user_id"`
+	UserAlias       types.String  `tfsdk:"user_alias"`
+	UserEmail       types.String  `tfsdk:"user_email"`
+	UserRole        types.String  `tfsdk:"user_role"`
+	Teams           types.List    `tfsdk:"teams"`
+	Models          types.List    `tfsdk:"models"`
+	MaxBudget       types.Float64 `tfsdk:"max_budget"`
+	BudgetDuration  types.String  `tfsdk:"budget_duration"`
+	TPMLimit        types.Int64   `tfsdk:"tpm_limit"`
+	RPMLimit        types.Int64   `tfsdk:"rpm_limit"`
+	AutoCreateKey   types.Bool    `tfsdk:"auto_create_key"`
+	SendInviteEmail types.Bool    `tfsdk:"send_invite_email"`
+	Metadata        types.Map     `tfsdk:"metadata"`
+	Key             types.String  `tfsdk:"key"`
 }
 
 func (r *UserResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -131,6 +132,11 @@ func (r *UserResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 				Computed:    true,
 				Default:     booldefault.StaticBool(true),
 			},
+			"send_invite_email": schema.BoolAttribute{
+				Description: "Create-only action flag that asks LiteLLM to asynchronously email this user. Requires user_email. It is write-only, is never sent during Update, and does not confirm delivery.",
+				Optional:    true,
+				WriteOnly:   true,
+			},
 			"metadata": schema.MapAttribute{
 				Description: "Metadata for the user.",
 				Optional:    true,
@@ -174,11 +180,32 @@ func (r *UserResource) Create(ctx context.Context, req resource.CreateRequest, r
 		return
 	}
 
+	var sendInviteEmail types.Bool
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("send_invite_email"), &sendInviteEmail)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if err := validateUserSendInviteEmail(&data, sendInviteEmail); err != nil {
+		resp.Diagnostics.AddError("Invalid User Invitation", err.Error())
+		return
+	}
+
 	userReq := r.buildUserRequest(ctx, &data)
+	if err := addSendInviteEmailToCreateRequest(userReq, sendInviteEmail); err != nil {
+		resp.Diagnostics.AddError("Invalid User Invitation", err.Error())
+		return
+	}
 
 	var result map[string]interface{}
 	if err := r.client.DoRequestWithResponse(ctx, "POST", "/user/new", userReq, &result); err != nil {
 		if IsAPIErrorStatus(err, 409) {
+			if sendInviteEmailRequested(sendInviteEmail) {
+				resp.Diagnostics.AddError(
+					"Existing User Was Not Invited",
+					"LiteLLM reported that the user already exists, so no create-time invitation was sent and Terraform did not adopt the account. Import the exact existing user with send_invite_email omitted, or invite the user outside this resource.",
+				)
+				return
+			}
 			mutated, adoptErr := r.adoptExistingUser(ctx, &data)
 			if adoptErr != nil {
 				if mutated {

--- a/internal_testing/acceptance.sh
+++ b/internal_testing/acceptance.sh
@@ -50,7 +50,7 @@ run_case budget resources budget_minimal.tf
 run_case credential resources credential_minimal.tf
 run_case fallback resources fallback_minimal.tf
 run_case guardrail resources guardrail_minimal.tf
-run_case key resources key_minimal.tf,key_router_settings.tf datasources key.tf
+run_case key resources key_minimal.tf,key_router_settings.tf,send_invite_email.tf datasources key.tf
 run_case key_block resources key_minimal.tf,key_block_minimal.tf
 run_case mcp_server resources mcp_server_minimal.tf
 run_case model resources model_minimal.tf

--- a/internal_testing/resources/send_invite_email.tf
+++ b/internal_testing/resources/send_invite_email.tf
@@ -1,0 +1,16 @@
+# Create-only invitation actions. The pinned loopback acceptance backend has no
+# external email transport, so this validates API/action wiring without sending
+# mail. A no-drift plan also proves the write-only action does not become
+# persistent state or trigger an Update-time resend.
+resource "litellm_user" "invite_email" {
+  user_alias        = "smoke-invite-user"
+  user_email        = "terraform-provider@example.invalid"
+  auto_create_key   = false
+  send_invite_email = true
+}
+
+resource "litellm_key" "invite_email" {
+  key_alias         = "smoke-invite-key"
+  user_id           = litellm_user.invite_email.id
+  send_invite_email = true
+}


### PR DESCRIPTION
### Summary

Closes #100. Adds safe create-only `send_invite_email` actions to `litellm_user` and `litellm_key` for LiteLLM v1.98.0.

This preserves @Kaago's contribution and PR #101 as the design reference while correcting its lifecycle model. v1.98 accepts the flag on `/user/new` and `/key/generate`, but not on `/user/update` or `/key/update`; it is asynchronous, non-persisted, and has no delivery acknowledgement. The provider therefore exposes an Optional+WriteOnly action read from apply configuration only during Create. It never enters state, Read/import, or Update payloads, so unrelated changes cannot resend an invitation.

User invitations require a syntactically valid `user_email`. Key invitations reject service-account/unknown service-account identity, require `user_id`, and perform a pre-mutation `/user/info` lookup that verifies the exact ID plus a syntactically valid non-empty recipient email. Lookup failures are secret-safe. If `/user/new` reports an existing account while invitation is enabled, the provider does not adopt or mutate it because no create-time invitation occurred.

Documentation distinguishes request acceptance from delivery, links email setup, explains replacement and ambiguous key-create retry behavior, and warns that LiteLLM v1.98's enterprise email implementation defaults to including raw generated or predefined `key_wo` values unless `EMAIL_INCLUDE_API_KEY=false`.

### Validation

Pinned loopback LiteLLM v1.98.0 validation created an invited user, verified it before invited-key creation, completed no-drift planning, and destroyed both. With no email backend, the user hook attempted delivery and failed asynchronously while the key hook skipped safely, confirming that API success does not acknowledge delivery; no Update request occurred. A pre-existing-user case returned `Existing User Was Not Invited`, made no `/user/update`, and wrote zero Terraform resources.

Focused tests cover Optional+WriteOnly schemas, true/false/null/unknown create payloads, recipient/service-account validation, exact/missing/mismatched/404 key preflight, malformed email, response-body-safe diagnostics, Update omission, and 409 adoption semantics. Full tests, race tests, vet, pinned 22/23 acceptance, and the real-dev 23-resource lifecycle suite pass.

### Diff size

**Implementation** — create-only action helpers plus key/user Create wiring

Adds write-only schemas, recipient validation/preflight, safe lookup errors, and existing-user action safety without changing Update, Read, import, or persisted state.

**Tests and acceptance** — focused unit coverage plus a pinned user-to-key action fixture

Covers protocol schema, payload/action boundaries, recipient identity, failure safety, no-drift, and destroy.

**Docs/changelog** — key, user, and contributor updates

Documents email prerequisites, asynchronous semantics, retry/replacement behavior, raw-key email risk, and PR #101 attribution.