### PR TITLE
docs: validate Bedrock AgentCore support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`litellm_agent`**: Document and validate AWS Bedrock AgentCore registration through LiteLLM v1.98.0's existing provider/model routing parameters, including A2A-native runtime and IAM guidance. ([#107](https://github.com/ncecere/terraform-provider-litellm/issues/107))
 - **`litellm_key` / `litellm_user`**: Add create-only, write-only `send_invite_email` actions with recipient validation, no Update-time resends, and explicit existing-user adoption safety. ([#100](https://github.com/ncecere/terraform-provider-litellm/issues/100), [#101](https://github.com/ncecere/terraform-provider-litellm/pull/101)) — thanks @Kaago
 - **`litellm_key` resource and data source**: Add complete LiteLLM v1.98.0 `router_settings` support with ordered fallback JSON, retry policies, model-group aliases, routing groups, affinity, tag routing, whole-document ownership, and explicit removal semantics. Key data-source lookups now URL-escape raw tokens and expose only a SHA256 management ID instead of copying the token into a non-sensitive ID. ([#97](https://github.com/ncecere/terraform-provider-litellm/issues/97), [#98](https://github.com/ncecere/terraform-provider-litellm/pull/98), [#147](https://github.com/ncecere/terraform-provider-litellm/pull/147)) — thanks @orolega for #98 and @alexeishtakal for #147
 
 ### Changed
+- **`litellm_agent` resource and data source**: Mark credential-bearing `litellm_params` and `static_headers` sensitive, preserve owned masked secrets, reject masked imports, and exclude LiteLLM's synthetic `is_public` response field. Existing outputs exposing these maps must opt into sensitivity. ([#107](https://github.com/ncecere/terraform-provider-litellm/issues/107))
 - **Development and CI**: Add read-only build/vet/format/race-test CI with coverage and JUnit artifacts, broaden provider unit coverage, make local provider installation architecture-aware, and add an isolated, failure-preserving LiteLLM v1.98.0 smoke/acceptance harness covering 22 non-enterprise resources. ([#145](https://github.com/ncecere/terraform-provider-litellm/issues/145)) — thanks @msabramo
 
 ### Fixed

--- a/docs/data-sources/agent.md
+++ b/docs/data-sources/agent.md
@@ -22,15 +22,17 @@ output "agent_name" {
 
 * `agent_name` - The name of the agent.
 * `agent_card_params` - The agent card parameters as a flat string map.
-* `litellm_params` - LiteLLM-specific parameters for the agent.
+* `litellm_params` - (Sensitive) LiteLLM-specific parameters for the agent. Redacted in normal CLI output but still present in state.
 * `tpm_limit` - Tokens per minute limit.
 * `rpm_limit` - Requests per minute limit.
 * `session_tpm_limit` - Per-session tokens per minute limit.
 * `session_rpm_limit` - Per-session requests per minute limit.
-* `static_headers` - Static headers sent with agent requests.
+* `static_headers` - (Sensitive) Static headers sent with agent requests. Redacted in normal CLI output but still present in state.
 * `extra_headers` - Extra header names forwarded from incoming requests.
 * `spend` - Total spend for this agent.
 * `created_at` - Timestamp when the agent was created.
 * `updated_at` - Timestamp when the agent was last updated.
 * `created_by` - User who created the agent.
 * `updated_by` - User who last updated the agent.
+
+> **Upgrade note:** `litellm_params` and `static_headers` now propagate Terraform sensitivity. Root outputs exposing them must set `sensitive = true` or deliberately use `nonsensitive(...)`. Use a LiteLLM `PROXY_ADMIN` credential when reading secret-bearing agent configuration; lower-privilege responses redact or omit those fields.

--- a/docs/resources/agent.md
+++ b/docs/resources/agent.md
@@ -17,6 +17,42 @@ resource "litellm_agent" "simple" {
 }
 ```
 
+### AWS Bedrock AgentCore
+
+LiteLLM v1.98.0 does not persist an `agent_type` value. Its dashboard's “Bedrock AgentCore” recipe creates an ordinary agent with `custom_llm_provider = "bedrock"` and a `bedrock/agentcore/` model. The current resource supports that payload directly:
+
+```hcl
+variable "agent_runtime_arn" {
+  type = string
+}
+
+resource "litellm_agent" "agentcore" {
+  agent_name = "bedrock-agentcore"
+
+  # AgentCore derives the invocation endpoint from the ARN, so an empty
+  # agent-card URL is intentional for this provider-backed agent.
+  agent_card {
+    name             = "Bedrock AgentCore"
+    url              = ""
+    protocol_version = "1.0"
+
+    capabilities {
+      streaming = true
+    }
+  }
+
+  litellm_params = {
+    custom_llm_provider = "bedrock"
+    model               = "bedrock/agentcore/${var.agent_runtime_arn}"
+    qualifier           = "PROD" # optional
+  }
+}
+```
+
+Agent CRUD itself is not enterprise-gated. Invocation requires AWS permissions and an AgentCore runtime that implements the **A2A protocol**; a generic non-A2A AgentCore handler is not compatible with LiteLLM's `/a2a/{agent_id}` bridge.
+
+By default, LiteLLM uses AWS workload credentials and SigV4. Prefer an IAM role attached to the LiteLLM proxy with `bedrock-agentcore:InvokeAgentRuntime` scoped to the runtime ARN, plus any environment-specific KMS and network permissions. Cognito/JWT authentication can be configured through `litellm_params.api_key`; static AWS keys and session tokens are also accepted by LiteLLM but become Terraform state data. `litellm_params` and `static_headers` are marked sensitive to redact normal CLI output, but sensitivity does not encrypt or remove values from state.
+
 ### Full Agent with Capabilities and Skills
 
 ```hcl
@@ -94,18 +130,18 @@ resource "litellm_agent" "full" {
 ### Top-level
 
 * `agent_name` - (Required) The name of the agent.
-* `litellm_params` - (Optional) Map of LiteLLM-specific parameters (e.g. `model`, `api_key`).
+* `litellm_params` - (Optional, Sensitive) Map of LiteLLM-specific parameters (e.g. `model`, `api_key`). Prefer proxy workload identity over static credentials. Sensitive values remain present in Terraform state.
 * `tpm_limit` - (Optional) Tokens per minute limit for the agent.
 * `rpm_limit` - (Optional) Requests per minute limit for the agent.
 * `session_tpm_limit` - (Optional) Per-session tokens per minute limit.
 * `session_rpm_limit` - (Optional) Per-session requests per minute limit.
-* `static_headers` - (Optional) Map of static headers to send with agent requests.
+* `static_headers` - (Optional, Sensitive) Map of static headers to send with agent requests. Sensitive values remain present in Terraform state.
 * `extra_headers` - (Optional) List of extra header names to forward from incoming requests.
 
 ### agent_card Block (Required)
 
 * `name` - (Required) Display name of the agent.
-* `url` - (Required) The URL endpoint for the agent.
+* `url` - (Required) The URL endpoint for the agent. Set it to an empty string for provider-backed agents such as Bedrock AgentCore, where LiteLLM derives the endpoint from `litellm_params`.
 * `description` - (Optional) Human-readable description of the agent.
 * `version` - (Optional) Version of the agent.
 * `protocol_version` - (Optional) A2A protocol version (e.g. `0.2.6`).
@@ -162,3 +198,9 @@ Agents can be imported using their agent ID:
 ```shell
 terraform import litellm_agent.example <agent-id>
 ```
+
+Import and Read should use a LiteLLM `PROXY_ADMIN` credential when agent configuration contains secrets. LiteLLM masks `litellm_params` and omits `static_headers` for lower-privilege readers; the provider rejects an import that would otherwise store an unrecoverable masked value. Before every PUT, a proxy-admin preflight rehydrates unmanaged parameter/header fields so an earlier redacted import cannot erase remote credentials.
+
+## Upgrade Note: Sensitive Agent Maps
+
+`litellm_params` and `static_headers` are now schema-sensitive in both the resource and data source. Existing root-module outputs that expose either map must also set `sensitive = true`, or deliberately call `nonsensitive(...)` after reviewing the contents. This redacts ordinary Terraform CLI/UI rendering but does not remove or encrypt values already held in state.

--- a/internal/provider/datasource_agent.go
+++ b/internal/provider/datasource_agent.go
@@ -61,8 +61,9 @@ func (d *AgentDataSource) Schema(ctx context.Context, req datasource.SchemaReque
 				ElementType: types.StringType,
 			},
 			"litellm_params": schema.MapAttribute{
-				Description: "LiteLLM-specific parameters for the agent.",
+				Description: "LiteLLM-specific parameters for the agent. Marked sensitive because it can contain JWTs or AWS credentials.",
 				Computed:    true,
+				Sensitive:   true,
 				ElementType: types.StringType,
 			},
 			"tpm_limit": schema.Int64Attribute{
@@ -82,8 +83,9 @@ func (d *AgentDataSource) Schema(ctx context.Context, req datasource.SchemaReque
 				Computed:    true,
 			},
 			"static_headers": schema.MapAttribute{
-				Description: "Static headers sent with agent requests.",
+				Description: "Static headers sent with agent requests. Marked sensitive because headers commonly contain authorization credentials.",
 				Computed:    true,
+				Sensitive:   true,
 				ElementType: types.StringType,
 			},
 			"extra_headers": schema.ListAttribute{

--- a/internal/provider/resource_agent.go
+++ b/internal/provider/resource_agent.go
@@ -114,9 +114,10 @@ func (r *AgentResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 				Required:    true,
 			},
 			"litellm_params": schema.MapAttribute{
-				Description: "LiteLLM-specific parameters for the agent (e.g. model, api_key).",
+				Description: "LiteLLM-specific parameters for the agent (e.g. model, api_key). Marked sensitive because it can contain JWTs or AWS credentials.",
 				Optional:    true,
 				Computed:    true,
+				Sensitive:   true,
 				ElementType: types.StringType,
 			},
 			"tpm_limit": schema.Int64Attribute{
@@ -136,9 +137,10 @@ func (r *AgentResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 				Optional:    true,
 			},
 			"static_headers": schema.MapAttribute{
-				Description: "Static headers to send with agent requests.",
+				Description: "Static headers to send with agent requests. Marked sensitive because headers commonly contain authorization credentials.",
 				Optional:    true,
 				Computed:    true,
+				Sensitive:   true,
 				ElementType: types.StringType,
 			},
 			"extra_headers": schema.ListAttribute{
@@ -395,6 +397,10 @@ func (r *AgentResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		return
 	}
 	data.ID = state.ID
+	if err := r.hydrateUnmanagedAgentUpdateFields(ctx, &data); err != nil {
+		resp.Diagnostics.AddError("Agent Update Preflight Error", fmt.Sprintf("Unable to preserve unmanaged agent configuration before update: %s", err))
+		return
+	}
 
 	agentReq := r.buildAgentRequest(&data)
 
@@ -433,6 +439,93 @@ func (r *AgentResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 
 func (r *AgentResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+func agentMapContainsMaskedValues(value types.Map) bool {
+	if value.IsNull() || value.IsUnknown() {
+		return false
+	}
+	for key, element := range value.Elements() {
+		if stringValue, ok := element.(types.String); ok && !stringValue.IsNull() && !stringValue.IsUnknown() && isMaskedAgentAPIValue(key, stringValue.ValueString()) {
+			return true
+		}
+	}
+	return false
+}
+
+func hydrateAgentUpdateMap(planned types.Map, remote map[string]interface{}, excludeSyntheticIsPublic bool) (types.Map, error) {
+	if planned.IsNull() || planned.IsUnknown() {
+		return reconcileAgentStringMap(planned, remote, excludeSyntheticIsPublic)
+	}
+	values := make(map[string]attr.Value, len(planned.Elements()))
+	for key, element := range planned.Elements() {
+		if excludeSyntheticIsPublic && key == "is_public" {
+			continue
+		}
+		stringValue, ok := element.(types.String)
+		if !ok || stringValue.IsNull() || stringValue.IsUnknown() {
+			values[key] = element
+			continue
+		}
+		if !isMaskedAgentAPIValue(key, stringValue.ValueString()) {
+			// Preserve genuine planned updates; preflight only replaces masks.
+			values[key] = stringValue
+			continue
+		}
+		remoteValue, exists := remote[key]
+		if !exists || isMaskedAgentAPIValue(key, remoteValue) {
+			return planned, fmt.Errorf("LiteLLM did not return an unmasked value for agent configuration key %q during update preflight", key)
+		}
+		values[key] = types.StringValue(metadataValueToString(remoteValue))
+	}
+	value, diagnostics := types.MapValue(types.StringType, values)
+	if diagnostics.HasError() {
+		return planned, fmt.Errorf("build hydrated agent map: %v", diagnostics.Errors())
+	}
+	return value, nil
+}
+
+// hydrateUnmanagedAgentUpdateFields protects secret-bearing fields that
+// LiteLLM's PUT endpoint clears when omitted. Update requires PROXY_ADMIN, so
+// this preflight can recover the full values even when an earlier lower-role
+// import/read response redacted them.
+func (r *AgentResource) hydrateUnmanagedAgentUpdateFields(ctx context.Context, data *AgentResourceModel) error {
+	needsParams := data.LiteLLMParams.IsNull() || data.LiteLLMParams.IsUnknown() || agentMapContainsMaskedValues(data.LiteLLMParams)
+	needsHeaders := data.StaticHeaders.IsNull() || data.StaticHeaders.IsUnknown() || agentMapContainsMaskedValues(data.StaticHeaders)
+	needsExtraHeaders := data.ExtraHeaders.IsNull() || data.ExtraHeaders.IsUnknown()
+	if !needsParams && !needsHeaders && !needsExtraHeaders {
+		return nil
+	}
+
+	endpoint := fmt.Sprintf("/v1/agents/%s", url.PathEscape(data.ID.ValueString()))
+	var result map[string]interface{}
+	if err := r.client.DoRequestWithResponse(ctx, "GET", endpoint, nil, &result); err != nil {
+		return err
+	}
+	if needsParams {
+		params, _ := result["litellm_params"].(map[string]interface{})
+		value, err := hydrateAgentUpdateMap(data.LiteLLMParams, params, true)
+		if err != nil {
+			return err
+		}
+		data.LiteLLMParams = value
+	}
+	if needsHeaders {
+		headers, _ := result["static_headers"].(map[string]interface{})
+		value, err := hydrateAgentUpdateMap(data.StaticHeaders, headers, false)
+		if err != nil {
+			return err
+		}
+		data.StaticHeaders = value
+	}
+	if needsExtraHeaders {
+		if headers, ok := result["extra_headers"].([]interface{}); ok {
+			data.ExtraHeaders = interfaceSliceToStringList(headers)
+		} else {
+			data.ExtraHeaders = types.ListValueMust(types.StringType, []attr.Value{})
+		}
+	}
+	return nil
 }
 
 // --- Build request ---
@@ -616,6 +709,79 @@ func (r *AgentResource) buildAgentRequest(data *AgentResourceModel) map[string]i
 	return req
 }
 
+// reconcileAgentStringMap keeps configured map keys selectively owned while
+// allowing imports/unconfigured Optional+Computed maps to adopt API values.
+// LiteLLM injects fields such as litellm_params.is_public and can mask
+// credential values, neither of which should create false drift or expose
+// secrets in normal CLI output.
+func isMaskedAgentAPIValue(key string, rawValue interface{}) bool {
+	value, ok := rawValue.(string)
+	if !ok {
+		return false
+	}
+	if isMaskedMetadataAPIString(value) {
+		return true
+	}
+	lowerKey := strings.ToLower(key)
+	sensitiveKey := false
+	for _, keyword := range []string{"authorization", "token", "key", "secret", "vertex_credentials", "credentials", "password", "passwd"} {
+		if strings.Contains(lowerKey, keyword) {
+			sensitiveKey = true
+			break
+		}
+	}
+	if !sensitiveKey {
+		return false
+	}
+	if value == "*****" {
+		return true
+	}
+	runes := []rune(value)
+	return len(runes) == 8 && string(runes[2:6]) == "****"
+}
+
+func reconcileAgentStringMap(current types.Map, raw map[string]interface{}, excludeSyntheticIsPublic bool) (types.Map, error) {
+	managed := !current.IsNull() && !current.IsUnknown()
+	configured := map[string]string{}
+	if managed {
+		if diagnostics := current.ElementsAs(context.Background(), &configured, false); diagnostics.HasError() {
+			return current, fmt.Errorf("decode configured agent map: %v", diagnostics.Errors())
+		}
+	}
+	observed := make(map[string]attr.Value)
+	for key, rawValue := range raw {
+		// LiteLLM injects is_public into response litellm_params, but it is not
+		// part of the persisted/user-managed request map.
+		if excludeSyntheticIsPublic && key == "is_public" {
+			continue
+		}
+		configuredValue, owned := configured[key]
+		if managed && !owned {
+			continue
+		}
+		if isMaskedAgentAPIValue(key, rawValue) {
+			if !owned {
+				return current, fmt.Errorf("LiteLLM returned masked agent configuration without a prior Terraform value; use a PROXY_ADMIN credential for import/read")
+			}
+			observed[key] = types.StringValue(configuredValue)
+			continue
+		}
+		value := metadataValueToString(rawValue)
+		if owned {
+			value = metadataValueToStringPreservingMasked(rawValue, configuredValue)
+		}
+		observed[key] = types.StringValue(value)
+	}
+	if stringMapMatchesAttrValues(current, observed) {
+		return current, nil
+	}
+	value, diagnostics := types.MapValue(types.StringType, observed)
+	if diagnostics.HasError() {
+		return current, fmt.Errorf("build agent map state: %v", diagnostics.Errors())
+	}
+	return value, nil
+}
+
 // --- Read agent ---
 
 func (r *AgentResource) readAgent(ctx context.Context, data *AgentResourceModel) error {
@@ -671,22 +837,22 @@ func (r *AgentResource) readAgent(ctx context.Context, data *AgentResourceModel)
 
 	// LiteLLM params
 	if params, ok := result["litellm_params"].(map[string]interface{}); ok && len(params) > 0 {
-		paramMap := map[string]attr.Value{}
-		for k, v := range params {
-			paramMap[k] = types.StringValue(fmt.Sprintf("%v", v))
+		value, err := reconcileAgentStringMap(data.LiteLLMParams, params, true)
+		if err != nil {
+			return err
 		}
-		data.LiteLLMParams, _ = types.MapValue(types.StringType, paramMap)
+		data.LiteLLMParams = value
 	} else if data.LiteLLMParams.IsUnknown() {
 		data.LiteLLMParams = types.MapNull(types.StringType)
 	}
 
 	// Static headers
 	if headers, ok := result["static_headers"].(map[string]interface{}); ok && len(headers) > 0 {
-		headerMap := map[string]attr.Value{}
-		for k, v := range headers {
-			headerMap[k] = types.StringValue(fmt.Sprintf("%v", v))
+		value, err := reconcileAgentStringMap(data.StaticHeaders, headers, false)
+		if err != nil {
+			return err
 		}
-		data.StaticHeaders, _ = types.MapValue(types.StringType, headerMap)
+		data.StaticHeaders = value
 	} else if data.StaticHeaders.IsUnknown() {
 		data.StaticHeaders = types.MapNull(types.StringType)
 	}

--- a/internal/provider/resource_agent_test.go
+++ b/internal/provider/resource_agent_test.go
@@ -10,8 +10,245 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	frameworkdatasource "github.com/hashicorp/terraform-plugin-framework/datasource"
+	frameworkresource "github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
+
+func TestAgentCredentialBearingMapsAreSensitive(t *testing.T) {
+	t.Parallel()
+
+	var resourceResponse frameworkresource.SchemaResponse
+	(&AgentResource{}).Schema(context.Background(), frameworkresource.SchemaRequest{}, &resourceResponse)
+	if resourceResponse.Diagnostics.HasError() {
+		t.Fatalf("resource schema diagnostics: %v", resourceResponse.Diagnostics)
+	}
+	var dataSourceResponse frameworkdatasource.SchemaResponse
+	(&AgentDataSource{}).Schema(context.Background(), frameworkdatasource.SchemaRequest{}, &dataSourceResponse)
+	if dataSourceResponse.Diagnostics.HasError() {
+		t.Fatalf("data source schema diagnostics: %v", dataSourceResponse.Diagnostics)
+	}
+	for _, name := range []string{"litellm_params", "static_headers"} {
+		if !resourceResponse.Schema.Attributes[name].IsSensitive() {
+			t.Errorf("resource %s must be sensitive", name)
+		}
+		if !dataSourceResponse.Schema.Attributes[name].IsSensitive() {
+			t.Errorf("data source %s must be sensitive", name)
+		}
+	}
+}
+
+func TestBuildAgentRequest_BedrockAgentCore(t *testing.T) {
+	t.Parallel()
+
+	arn := "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/example"
+	data := &AgentResourceModel{
+		AgentName: types.StringValue("agentcore-agent"),
+		AgentCard: &AgentCardModel{
+			Name:            types.StringValue("AgentCore Agent"),
+			URL:             types.StringValue(""),
+			ProtocolVersion: types.StringValue("1.0"),
+			Capabilities: &AgentCapabilitiesModel{
+				Streaming: types.BoolValue(true),
+			},
+		},
+		LiteLLMParams: stringMapValue(map[string]string{
+			"custom_llm_provider": "bedrock",
+			"model":               "bedrock/agentcore/" + arn,
+			"qualifier":           "PROD",
+		}),
+	}
+
+	request := (&AgentResource{}).buildAgentRequest(data)
+	card := request["agent_card_params"].(map[string]interface{})
+	if card["url"] != "" || card["protocolVersion"] != "1.0" {
+		t.Fatalf("AgentCore card = %#v, want empty URL and protocolVersion 1.0", card)
+	}
+	capabilities := card["capabilities"].(map[string]interface{})
+	if capabilities["streaming"] != true {
+		t.Fatalf("AgentCore capabilities = %#v", capabilities)
+	}
+	params := request["litellm_params"].(map[string]interface{})
+	if params["custom_llm_provider"] != "bedrock" || params["model"] != "bedrock/agentcore/"+arn || params["qualifier"] != "PROD" {
+		t.Fatalf("AgentCore litellm_params = %#v", params)
+	}
+	if _, present := request["agent_type"]; present {
+		t.Fatalf("AgentCore must not send dashboard-only agent_type: %#v", request)
+	}
+}
+
+func TestReconcileAgentStringMapOwnershipAndSecrets(t *testing.T) {
+	t.Parallel()
+
+	configured := stringMapValue(map[string]string{
+		"model":   "bedrock/agentcore/runtime",
+		"api_key": "secret-value",
+	})
+	observed := map[string]interface{}{
+		"model":     "bedrock/agentcore/runtime",
+		"api_key":   "litellm_enc::masked",
+		"is_public": false,
+	}
+	reconciled, err := reconcileAgentStringMap(configured, observed, true)
+	if err != nil {
+		t.Fatalf("configured reconciliation: %v", err)
+	}
+	if !reconciled.Equal(configured) {
+		t.Fatalf("configured keys or masked secret changed: %#v", reconciled.Elements())
+	}
+	if _, adopted := reconciled.Elements()["is_public"]; adopted {
+		t.Fatalf("API-injected is_public was adopted into configured state: %#v", reconciled.Elements())
+	}
+
+	if _, err := reconcileAgentStringMap(types.MapUnknown(types.StringType), observed, true); err == nil {
+		t.Fatal("unmanaged/imported masked API value must fail instead of entering state")
+	}
+
+	imported, err := reconcileAgentStringMap(types.MapUnknown(types.StringType), map[string]interface{}{
+		"model":     "bedrock/agentcore/runtime",
+		"is_public": false,
+	}, true)
+	if err != nil {
+		t.Fatalf("unmasked import reconciliation: %v", err)
+	}
+	if _, adopted := imported.Elements()["is_public"]; adopted {
+		t.Fatalf("imported map adopted synthetic is_public: %#v", imported.Elements())
+	}
+	if got := imported.Elements()["model"].(types.String).ValueString(); got != "bedrock/agentcore/runtime" {
+		t.Fatalf("imported model = %q", got)
+	}
+
+	headers, err := reconcileAgentStringMap(types.MapUnknown(types.StringType), map[string]interface{}{
+		"is_public": "legitimate-header-value",
+	}, false)
+	if err != nil {
+		t.Fatalf("static header reconciliation: %v", err)
+	}
+	if got := headers.Elements()["is_public"].(types.String).ValueString(); got != "legitimate-header-value" {
+		t.Fatalf("static header is_public = %q", got)
+	}
+}
+
+func TestHydrateUnmanagedAgentUpdateFieldsPreservesRemoteSecrets(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(writer).Encode(map[string]interface{}{
+			"litellm_params": map[string]interface{}{
+				"model":     "bedrock/agentcore/runtime",
+				"is_public": false,
+			},
+			"static_headers": map[string]interface{}{
+				"Authorization": "Bearer preserved",
+				"is_public":     "legitimate-header-value",
+			},
+			"extra_headers": []interface{}{"X-Request-ID"},
+		})
+	}))
+	defer server.Close()
+
+	resource := &AgentResource{client: &Client{APIBase: server.URL, APIKey: "test", HTTPClient: server.Client()}}
+	data := AgentResourceModel{
+		ID:            types.StringValue("agent-update"),
+		AgentName:     types.StringValue("agent"),
+		LiteLLMParams: types.MapNull(types.StringType),
+		StaticHeaders: types.MapNull(types.StringType),
+		ExtraHeaders:  types.ListNull(types.StringType),
+	}
+	if err := resource.hydrateUnmanagedAgentUpdateFields(context.Background(), &data); err != nil {
+		t.Fatalf("hydrate unmanaged fields: %v", err)
+	}
+	if _, present := data.LiteLLMParams.Elements()["is_public"]; present {
+		t.Fatalf("synthetic litellm_params.is_public was retained: %#v", data.LiteLLMParams.Elements())
+	}
+	if got := data.StaticHeaders.Elements()["is_public"].(types.String).ValueString(); got != "legitimate-header-value" {
+		t.Fatalf("legitimate static header is_public = %q", got)
+	}
+	request := resource.buildAgentRequest(&data)
+	params := request["litellm_params"].(map[string]interface{})
+	if _, present := params["is_public"]; present {
+		t.Fatalf("update request included synthetic is_public: %#v", params)
+	}
+	headers := request["static_headers"].(map[string]interface{})
+	if headers["Authorization"] != "Bearer preserved" || headers["is_public"] != "legitimate-header-value" {
+		t.Fatalf("update request lost static headers: %#v", headers)
+	}
+}
+
+func TestHydrateMaskedPlannedAgentValuesPreservesRealChanges(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(writer).Encode(map[string]interface{}{
+			"litellm_params": map[string]interface{}{
+				"model":   "remote-old-model",
+				"api_key": "real-api-key-value",
+			},
+			"static_headers": map[string]interface{}{},
+			"extra_headers":  []interface{}{},
+		})
+	}))
+	defer server.Close()
+
+	resource := &AgentResource{client: &Client{APIBase: server.URL, APIKey: "test", HTTPClient: server.Client()}}
+	data := AgentResourceModel{
+		ID:        types.StringValue("agent-masked-plan"),
+		AgentName: types.StringValue("agent"),
+		LiteLLMParams: stringMapValue(map[string]string{
+			"model":   "planned-new-model",
+			"api_key": "ab****yz",
+		}),
+		StaticHeaders: types.MapNull(types.StringType),
+		ExtraHeaders:  types.ListNull(types.StringType),
+	}
+	if err := resource.hydrateUnmanagedAgentUpdateFields(context.Background(), &data); err != nil {
+		t.Fatalf("hydrate masked planned value: %v", err)
+	}
+	params := data.LiteLLMParams.Elements()
+	if got := params["api_key"].(types.String).ValueString(); got != "real-api-key-value" {
+		t.Fatalf("hydrated api_key = %q", got)
+	}
+	if got := params["model"].(types.String).ValueString(); got != "planned-new-model" {
+		t.Fatalf("genuine planned model update was overwritten: %q", got)
+	}
+	request := resource.buildAgentRequest(&data)
+	requestParams := request["litellm_params"].(map[string]interface{})
+	if requestParams["api_key"] != "real-api-key-value" || requestParams["model"] != "planned-new-model" {
+		t.Fatalf("update request params = %#v", requestParams)
+	}
+}
+
+func TestReadAgentRejectsMaskedImportState(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(writer).Encode(map[string]interface{}{
+			"agent_id":   "agent-masked-import",
+			"agent_name": "masked",
+			"litellm_params": map[string]interface{}{
+				"model":   "bedrock/agentcore/runtime",
+				"api_key": "ab****yz",
+			},
+		})
+	}))
+	defer server.Close()
+
+	resource := &AgentResource{client: &Client{APIBase: server.URL, APIKey: "test", HTTPClient: server.Client()}}
+	data := AgentResourceModel{
+		ID:            types.StringValue("agent-masked-import"),
+		LiteLLMParams: types.MapUnknown(types.StringType),
+	}
+	err := resource.readAgent(context.Background(), &data)
+	if err == nil || !strings.Contains(err.Error(), "PROXY_ADMIN") {
+		t.Fatalf("masked import read error = %v, want PROXY_ADMIN guidance", err)
+	}
+	if !data.LiteLLMParams.IsUnknown() {
+		t.Fatalf("masked import value entered state: %#v", data.LiteLLMParams)
+	}
+}
 
 func TestBuildAgentRequest_Minimal(t *testing.T) {
 	t.Parallel()

--- a/internal_testing/acceptance.sh
+++ b/internal_testing/acceptance.sh
@@ -45,7 +45,7 @@ run_case() {
 # Explicit coverage table. litellm_project is enterprise-only and intentionally
 # excluded; every other registered resource has a lifecycle case here.
 run_case access_group resources model_minimal.tf,access_group_minimal.tf
-run_case agent resources agent_minimal.tf datasources agent.tf,agents_list.tf
+run_case agent resources agent_minimal.tf,agent_bedrock_agentcore.tf datasources agent.tf,agents_list.tf
 run_case budget resources budget_minimal.tf
 run_case credential resources credential_minimal.tf
 run_case fallback resources fallback_minimal.tf

--- a/internal_testing/resources/agent_bedrock_agentcore.tf
+++ b/internal_testing/resources/agent_bedrock_agentcore.tf
@@ -1,0 +1,23 @@
+# Bedrock AgentCore is represented by LiteLLM v1.98.0 as ordinary agent CRUD
+# with provider/model routing parameters; there is no persisted agent_type.
+# Registry lifecycle does not invoke AWS, so this placeholder ARN is safe for
+# pinned local CRUD/no-drift/destroy validation.
+resource "litellm_agent" "bedrock_agentcore" {
+  agent_name = "smoke-bedrock-agentcore"
+
+  agent_card {
+    name             = "Smoke Bedrock AgentCore"
+    url              = ""
+    protocol_version = "1.0"
+
+    capabilities {
+      streaming = true
+    }
+  }
+
+  litellm_params = {
+    custom_llm_provider = "bedrock"
+    model               = "bedrock/agentcore/arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/smoke"
+    qualifier           = "PROD"
+  }
+}


### PR DESCRIPTION
### Summary

Closes #107. Documents and validates AWS Bedrock AgentCore support through the existing `litellm_agent` resource, while hardening credential-bearing agent state.

LiteLLM v1.98.0 does not persist an `agent_type`. Its dashboard's AgentCore option is a recipe for ordinary `/v1/agents` CRUD using `custom_llm_provider = "bedrock"`, `model = "bedrock/agentcore/<runtime ARN>"`, and an intentionally empty agent-card URL. The existing resource already emits that exact payload, so adding a synthetic Terraform enum would diverge from the API.

This change adds the full Terraform recipe, A2A-native runtime limitation, workload-IAM/SigV4 and JWT guidance, qualifier support, and least-privilege `bedrock-agentcore:InvokeAgentRuntime` guidance. It marks `litellm_params` and `static_headers` sensitive in both resource and data source and documents output migration/state implications.

Read/update hardening prevents LiteLLM's synthetic `litellm_params.is_public` from creating drift, preserves configured masked secrets, rejects unrecoverable masked imports, and uses a proxy-admin Update preflight to recover params/static/extra headers that lower-role reads omit. Saved plans containing masks replace only masked leaves from the full response while retaining genuine planned changes. Filtering is map-specific so legitimate static headers named `is_public` remain managed.

### Validation

Pinned LiteLLM v1.98.0 CRUD passed create, read, no-drift plan, and destroy for the AgentCore fixture without an Enterprise license. Full-admin import → normalization Update → no-drift → destroy also passed, with synthetic `is_public` omitted. AWS invocation was not attempted because it requires a real A2A-native AgentCore runtime and billable AWS permissions.

Focused tests cover exact AgentCore payload/no synthetic `agent_type`, empty card URL, sensitive schemas, injected-field filtering, masked-secret preservation and import rejection, static-header name preservation, lower-role/saved-plan rehydration, and genuine planned-update retention. Full tests, race tests, vet, pinned 22/23 acceptance, and the real-dev 23-resource lifecycle suite pass. Final independent review returned **Ship** with no blocker/high/medium findings.

### Diff size

**Implementation** — agent resource/data-source security and update preservation

Adds sensitive schemas, selective map ownership, masking detection, import safety, and full-admin preflight hydration without changing LiteLLM's CRUD contract.

**Tests/acceptance** — AgentCore and secret-state regressions

Adds exact payload, sensitivity, synthetic-field, masked import/saved-plan, static-header, and pinned AgentCore lifecycle coverage.

**Docs/changelog** — AgentCore recipe and upgrade guidance

Documents the inferred provider/model type, A2A requirement, IAM/auth options, state sensitivity, import requirements, and compatibility migration.