### PR TITLE
fix(model): enforce explicit clear semantics

### DIFF
--- a/docs/resources/model.md
+++ b/docs/resources/model.md
@@ -171,11 +171,11 @@ The following arguments are supported:
 
 * `tier` - (Optional) string. The usage tier for this model. LiteLLM v1.98 accepts exactly `"free"` or `"paid"`; the provider validates the value during planning. Default: `"free"`.
 
-* `team_id` - (Optional) string. Associate the model with a specific team.
+* `team_id` - (Optional) string. Associate the model with a specific team. Changing or removing an owned team association replaces the model because LiteLLM v1.98 does not provide a reliable in-place detach operation.
 
 * `access_groups` - (Optional) list(string). List of access groups this model belongs to. Teams and keys with access to these groups can use this model. See [LiteLLM Access Groups](https://docs.litellm.ai/docs/proxy/model_access_groups) for more details.
 
-* `mode` - (Optional) string. The intended use of the model. LiteLLM v1.98 keeps this request field extensible rather than declaring an endpoint enum; common values include:
+* `mode` - (Optional) string. The intended use of the model. Removing an owned mode replaces the model because LiteLLM may infer and retain a mode during updates. LiteLLM v1.98 keeps this request field extensible rather than declaring an endpoint enum; common values include:
   * `chat`
   * `completion`
   * `embedding`
@@ -190,9 +190,9 @@ The following arguments are supported:
   * `ocr`
   * `moderation`
 
-* `tpm` - (Optional) integer. Tokens per minute limit for this model.
+* `tpm` - (Optional) integer. Tokens per minute limit for this model. Zero is a valid configured limit; it does not mean "unset." Removing an owned value replaces the model.
 
-* `rpm` - (Optional) integer. Requests per minute limit for this model.
+* `rpm` - (Optional) integer. Requests per minute limit for this model. Zero is a valid configured limit; it does not mean "unset." Removing an owned value replaces the model.
 
 * `reasoning_effort` - (Optional) string. Configures the provider-specific reasoning effort level. Common values are:
   * `low`
@@ -209,13 +209,13 @@ The following arguments are supported:
 
 * `output_cost_per_million_tokens` - (Optional) float. Cost per million output tokens. The provider converts this to a per-token cost sent to the API.
 
-* `input_cost_per_pixel` - (Optional) float. Cost applied per input pixel for models that charge by image size.
+* `input_cost_per_pixel` - (Optional) float. Cost applied per input pixel for models that charge by image size. Removing an owned value replaces the model.
 
-* `output_cost_per_pixel` - (Optional) float. Cost applied per output pixel for image-generation models.
+* `output_cost_per_pixel` - (Optional) float. Cost applied per output pixel for image-generation models. Removing an owned value replaces the model.
 
-* `input_cost_per_second` - (Optional) float. Cost applied per input second for audio/transcription models.
+* `input_cost_per_second` - (Optional) float. Cost applied per input second for audio/transcription models. Removing an owned value replaces the model.
 
-* `output_cost_per_second` - (Optional) float. Cost applied per output second for audio/transcription models.
+* `output_cost_per_second` - (Optional) float. Cost applied per output second for audio/transcription models. Removing an owned value replaces the model.
 
 * `vertex_project` - (Optional) string. Vertex AI project id (for `custom_llm_provider = "vertex"`).
 
@@ -301,6 +301,26 @@ The following arguments are supported:
 
 * `aws_role_name` - (Optional) string (Sensitive). AWS IAM role name for cross-account access scenarios.
 
+## Clear and Replacement Behavior
+
+LiteLLM v1.98 merges model updates, so Terraform distinguishes fields with a verified clear representation from fields that cannot be removed safely.
+
+The required `model_name`, `custom_llm_provider`, and `base_model` arguments can be changed in place but cannot be omitted. Setting `tier` back to its default (`"free"`) and setting a new non-empty `mode` are also in-place updates.
+
+Removing an owned value clears or resets these fields in place:
+
+* Provider connection fields: `model_api_key`, `model_api_base`, and `api_version`
+* AWS, Vertex AI, and `litellm_credential_name` fields
+* `reasoning_effort`, `thinking_enabled`, `thinking_budget_tokens`, and `merge_reasoning_content_in_choices`; removing the thinking arguments disables thinking and restores the state default of 1024 budget tokens
+* `access_groups`
+* `input_cost_per_million_tokens` and `output_cost_per_million_tokens`
+
+Terraform verifies LiteLLM's authoritative update response before committing cleared state. Because the update response contains encrypted-at-rest strings, string and secret clears additionally require a decrypted fresh-worker read; ciphertext or a masked secret is not accepted as proof of removal. If LiteLLM workers temporarily retain an older cached model, Terraform reports `Model Clear Readback Not Yet Consistent` and retains prior state. Retry after worker caches converge.
+
+Removing `tpm`, `rpm`, `mode`, per-pixel costs, or per-second costs replaces the model. Changing or removing `team_id` also replaces it. Removing keys from either additional map follows the replacement rules documented with those arguments. Replacement is intentional: sending `null` or omission for these fields can leave the previous remote value active. Review plans carefully when the model ID is referenced elsewhere.
+
+Imported optional fields remain unmanaged while their arguments are omitted, preventing an import-only configuration from clearing or replacing remote settings. Explicitly configuring an imported field transfers ownership to Terraform, even when the configured value already matches LiteLLM. A later removal then follows the in-place clear or replacement behavior above.
+
 ## Attribute Reference
 
 In addition to the arguments above, the following attributes are exported:
@@ -315,8 +335,8 @@ Model configurations can be imported using the model ID:
 terraform import litellm_model.gpt4 <model-id>
 ```
 
-Note: The model ID is generated when the model is created and is different from the `model_name`.
+The model ID is generated when the model is created and is different from `model_name`. Imported optional values are preserved while omitted from configuration. See [Clear and Replacement Behavior](#clear-and-replacement-behavior) before taking ownership of an imported value.
 
 ## Security Note
 
-When using this resource, ensure that sensitive information such as API keys and AWS credentials are stored securely. It's recommended to use environment variables or a secure secret management solution rather than hardcoding these values in your Terraform configuration files.
+Sensitive arguments are redacted in Terraform output, but values supplied directly can still be stored in Terraform state. Protect state and plan artifacts, restrict backend access, and prefer `litellm_credential_name` with a separately managed credential instead of hardcoding provider credentials. The provider preserves configured sensitive values when LiteLLM returns a recognized mask, but never treats a masked response as proof that a requested clear succeeded.

--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -74,7 +74,7 @@ type clientRequestOptions struct {
 }
 
 // executeRequestWithOptions keeps fresh-connection behavior deliberately narrow.
-// Credential cache probes require the provider's cloneable *http.Transport, then
+// Bounded worker-cache and write-convergence probes require the provider's cloneable *http.Transport, then
 // set request.Close and use a cloned transport with an empty connection pool.
 // request.Close also makes Go's HTTP/2 transport allocate a single-use connection.
 // An arbitrary custom RoundTripper fails closed because connection freshness cannot
@@ -151,9 +151,10 @@ func (c *Client) DoRequestWithResponse(ctx context.Context, method, requestPath 
 	return err
 }
 
-// doFreshRequestWithResponse is reserved for bounded credential cache probes.
-// It preserves the normal bounded response and redaction path while preventing
-// HTTP keepalive from pinning consecutive probes to one LiteLLM worker.
+// doFreshRequestWithResponse is reserved for bounded worker-cache and
+// write-convergence probes. It preserves the normal bounded response and
+// redaction path while preventing HTTP keepalive from pinning consecutive
+// probes to one LiteLLM worker.
 func (c *Client) doFreshRequestWithResponse(ctx context.Context, method, requestPath string, body interface{}, result interface{}) error {
 	_, err := c.doRequestWithResponseOptions(ctx, method, requestPath, body, result, clientRequestOptions{freshConnection: true})
 	return err

--- a/internal/provider/resource_model.go
+++ b/internal/provider/resource_model.go
@@ -30,6 +30,7 @@ import (
 // Ensure provider defined types fully satisfy framework interfaces.
 var _ resource.Resource = &ModelResource{}
 var _ resource.ResourceWithImportState = &ModelResource{}
+var _ resource.ResourceWithModifyPlan = &ModelResource{}
 
 func NewModelResource() resource.Resource {
 	return &ModelResource{}
@@ -41,8 +42,12 @@ type ModelResource struct {
 }
 
 type modelReadOwnership struct {
-	imported         bool
-	topThinkingOwned bool
+	imported             bool
+	importedFields       map[string]struct{}
+	topThinkingOwned     bool
+	clearedFields        map[string]struct{}
+	durablyClearedFields map[string]struct{}
+	freshConnection      bool
 }
 
 // ModelResourceModel describes the resource data model.
@@ -111,14 +116,17 @@ func (r *ModelResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 			"tpm": schema.Int64Attribute{
 				Description: "Tokens per minute limit.",
 				Optional:    true,
+				Computed:    true,
 			},
 			"rpm": schema.Int64Attribute{
 				Description: "Requests per minute limit.",
 				Optional:    true,
+				Computed:    true,
 			},
 			"reasoning_effort": schema.StringAttribute{
 				Description: "Reasoning effort level (low, medium, high).",
 				Optional:    true,
+				Computed:    true,
 			},
 			"thinking_enabled": schema.BoolAttribute{
 				Description: "Enable thinking/reasoning mode.",
@@ -144,10 +152,12 @@ func (r *ModelResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 			"model_api_base": schema.StringAttribute{
 				Description: "Base URL for the model API.",
 				Optional:    true,
+				Computed:    true,
 			},
 			"api_version": schema.StringAttribute{
 				Description: "API version (e.g., for Azure OpenAI).",
 				Optional:    true,
+				Computed:    true,
 			},
 			"base_model": schema.StringAttribute{
 				Description: "The base model name from the provider.",
@@ -165,6 +175,7 @@ func (r *ModelResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 			"team_id": schema.StringAttribute{
 				Description: "Team ID to associate with this model.",
 				Optional:    true,
+				Computed:    true,
 			},
 			"mode": schema.StringAttribute{
 				Description: "Model mode. Supported values: chat, completion, embedding, audio_speech, audio_transcription, image_generation, video_generation, batch, rerank, realtime, responses, ocr, moderation.",
@@ -177,30 +188,37 @@ func (r *ModelResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 			"litellm_credential_name": schema.StringAttribute{
 				Description: "Name of the credential to use for this model. References a credential created via litellm_credential resource.",
 				Optional:    true,
+				Computed:    true,
 			},
 			"input_cost_per_million_tokens": schema.Float64Attribute{
 				Description: "Input cost per million tokens.",
 				Optional:    true,
+				Computed:    true,
 			},
 			"output_cost_per_million_tokens": schema.Float64Attribute{
 				Description: "Output cost per million tokens.",
 				Optional:    true,
+				Computed:    true,
 			},
 			"input_cost_per_pixel": schema.Float64Attribute{
 				Description: "Input cost per pixel.",
 				Optional:    true,
+				Computed:    true,
 			},
 			"output_cost_per_pixel": schema.Float64Attribute{
 				Description: "Output cost per pixel.",
 				Optional:    true,
+				Computed:    true,
 			},
 			"input_cost_per_second": schema.Float64Attribute{
 				Description: "Input cost per second.",
 				Optional:    true,
+				Computed:    true,
 			},
 			"output_cost_per_second": schema.Float64Attribute{
 				Description: "Output cost per second.",
 				Optional:    true,
+				Computed:    true,
 			},
 			"aws_access_key_id": schema.StringAttribute{
 				Description: "AWS access key ID for Bedrock.",
@@ -215,6 +233,7 @@ func (r *ModelResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 			"aws_region_name": schema.StringAttribute{
 				Description: "AWS region name for Bedrock.",
 				Optional:    true,
+				Computed:    true,
 			},
 			"aws_session_name": schema.StringAttribute{
 				Description: "AWS session name for Bedrock.",
@@ -313,6 +332,206 @@ func (r *ModelResource) Configure(ctx context.Context, req resource.ConfigureReq
 	r.client = client
 }
 
+func (r *ModelResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.Plan.Raw.IsNull() || req.State.Raw.IsNull() {
+		return
+	}
+
+	var plan, state, config ModelResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	marker, diagnostics := req.Private.GetKey(ctx, modelImportedFieldsPrivateKey)
+	resp.Diagnostics.Append(diagnostics...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	importedFields := decodeModelImportedFields(marker)
+	forceOwnershipUpdate := false
+
+	stringFields := []struct {
+		name                string
+		plan, state, config *types.String
+	}{
+		{"model_api_base", &plan.ModelAPIBase, &state.ModelAPIBase, &config.ModelAPIBase},
+		{"api_version", &plan.APIVersion, &state.APIVersion, &config.APIVersion},
+		{"reasoning_effort", &plan.ReasoningEffort, &state.ReasoningEffort, &config.ReasoningEffort},
+		{"aws_region_name", &plan.AWSRegionName, &state.AWSRegionName, &config.AWSRegionName},
+		{"litellm_credential_name", &plan.LiteLLMCredentialName, &state.LiteLLMCredentialName, &config.LiteLLMCredentialName},
+		{"mode", &plan.Mode, &state.Mode, &config.Mode},
+		{"team_id", &plan.TeamID, &state.TeamID, &config.TeamID},
+	}
+	for _, field := range stringFields {
+		_, imported := importedFields[field.name]
+		if imported {
+			if field.config.IsNull() {
+				*field.plan = *field.state
+				continue
+			}
+			if field.config.IsUnknown() {
+				continue
+			}
+			delete(importedFields, field.name)
+			if field.plan.Equal(*field.state) {
+				forceOwnershipUpdate = true
+			}
+			continue
+		}
+		if field.config.IsNull() && field.state.IsNull() {
+			*field.plan = *field.state
+			continue
+		}
+		if field.config.IsNull() && !field.state.IsNull() && !field.state.IsUnknown() && field.name != "mode" && field.name != "team_id" {
+			*field.plan = types.StringNull()
+		}
+	}
+
+	intFields := []struct {
+		name                string
+		plan, state, config *types.Int64
+	}{
+		{"tpm", &plan.TPM, &state.TPM, &config.TPM},
+		{"rpm", &plan.RPM, &state.RPM, &config.RPM},
+	}
+	for _, field := range intFields {
+		_, imported := importedFields[field.name]
+		if imported {
+			if field.config.IsNull() {
+				*field.plan = *field.state
+				continue
+			}
+			if field.config.IsUnknown() {
+				continue
+			}
+			delete(importedFields, field.name)
+			if field.plan.Equal(*field.state) {
+				forceOwnershipUpdate = true
+			}
+			continue
+		}
+		if field.config.IsNull() && field.state.IsNull() {
+			*field.plan = *field.state
+			continue
+		}
+		if field.config.IsNull() && !field.state.IsNull() && !field.state.IsUnknown() {
+			*field.plan = types.Int64Unknown()
+		}
+	}
+
+	floatFields := []struct {
+		name                string
+		plan, state, config *types.Float64
+	}{
+		{"input_cost_per_million_tokens", &plan.InputCostPerMillionTokens, &state.InputCostPerMillionTokens, &config.InputCostPerMillionTokens},
+		{"output_cost_per_million_tokens", &plan.OutputCostPerMillionTokens, &state.OutputCostPerMillionTokens, &config.OutputCostPerMillionTokens},
+		{"input_cost_per_pixel", &plan.InputCostPerPixel, &state.InputCostPerPixel, &config.InputCostPerPixel},
+		{"output_cost_per_pixel", &plan.OutputCostPerPixel, &state.OutputCostPerPixel, &config.OutputCostPerPixel},
+		{"input_cost_per_second", &plan.InputCostPerSecond, &state.InputCostPerSecond, &config.InputCostPerSecond},
+		{"output_cost_per_second", &plan.OutputCostPerSecond, &state.OutputCostPerSecond, &config.OutputCostPerSecond},
+	}
+	for _, field := range floatFields {
+		_, imported := importedFields[field.name]
+		if imported {
+			if field.config.IsNull() {
+				*field.plan = *field.state
+				continue
+			}
+			if field.config.IsUnknown() {
+				continue
+			}
+			delete(importedFields, field.name)
+			if field.plan.Equal(*field.state) {
+				forceOwnershipUpdate = true
+			}
+			continue
+		}
+		if field.config.IsNull() && field.state.IsNull() {
+			*field.plan = *field.state
+			continue
+		}
+		if field.config.IsNull() && !field.state.IsNull() && !field.state.IsUnknown() {
+			switch field.name {
+			case "input_cost_per_million_tokens", "output_cost_per_million_tokens":
+				*field.plan = types.Float64Null()
+			default:
+				*field.plan = types.Float64Unknown()
+			}
+		}
+	}
+
+	if !config.AdditionalLiteLLMParams.IsNull() && !config.AdditionalLiteLLMParams.IsUnknown() {
+		delete(importedFields, "additional_litellm_params.thinking")
+		delete(importedFields, "additional_litellm_params.merge_reasoning_content_in_choices")
+	}
+
+	if _, imported := importedFields["access_groups"]; imported {
+		switch {
+		case config.AccessGroups.IsNull():
+			plan.AccessGroups = state.AccessGroups
+		case !config.AccessGroups.IsUnknown():
+			delete(importedFields, "access_groups")
+			if plan.AccessGroups.Equal(state.AccessGroups) {
+				forceOwnershipUpdate = true
+			}
+		}
+	}
+
+	// LiteLLM v1.98 merges these fields and has no semantic clear sentinel.
+	// Replacement is safer than publishing null state while the old limit,
+	// inferred mode, or non-token pricing remains active.
+	for _, field := range []struct {
+		name   string
+		remove bool
+	}{
+		{"tpm", config.TPM.IsNull() && !state.TPM.IsNull() && !state.TPM.IsUnknown()},
+		{"rpm", config.RPM.IsNull() && !state.RPM.IsNull() && !state.RPM.IsUnknown()},
+		{"input_cost_per_pixel", config.InputCostPerPixel.IsNull() && !state.InputCostPerPixel.IsNull() && !state.InputCostPerPixel.IsUnknown()},
+		{"output_cost_per_pixel", config.OutputCostPerPixel.IsNull() && !state.OutputCostPerPixel.IsNull() && !state.OutputCostPerPixel.IsUnknown()},
+		{"input_cost_per_second", config.InputCostPerSecond.IsNull() && !state.InputCostPerSecond.IsNull() && !state.InputCostPerSecond.IsUnknown()},
+		{"output_cost_per_second", config.OutputCostPerSecond.IsNull() && !state.OutputCostPerSecond.IsNull() && !state.OutputCostPerSecond.IsUnknown()},
+		{"mode", config.Mode.IsNull() && !state.Mode.IsNull() && !state.Mode.IsUnknown()},
+	} {
+		_, imported := importedFields[field.name]
+		if field.remove && !imported {
+			if field.name == "mode" {
+				// Optional+Computed would otherwise retain state, leaving no public
+				// diff for Terraform to attach replacement to.
+				plan.Mode = types.StringUnknown()
+			}
+			resp.RequiresReplace = append(resp.RequiresReplace, path.Root(field.name))
+		}
+	}
+	if _, imported := importedFields["team_id"]; !imported && config.TeamID.IsNull() && !state.TeamID.IsNull() && !state.TeamID.IsUnknown() {
+		plan.TeamID = types.StringUnknown()
+	}
+	if !plan.TeamID.Equal(state.TeamID) {
+		if _, imported := importedFields["team_id"]; !imported {
+			resp.RequiresReplace = append(resp.RequiresReplace, path.Root("team_id"))
+		}
+	}
+
+	// Optional+Computed collections otherwise retain prior state when omitted.
+	// A non-imported, previously configured value is owned and omission clears it.
+	if config.AccessGroups.IsNull() && !state.AccessGroups.IsNull() && !state.AccessGroups.IsUnknown() && len(state.AccessGroups.Elements()) > 0 {
+		if _, imported := importedFields["access_groups"]; !imported {
+			plan.AccessGroups = types.ListValueMust(types.StringType, []attr.Value{})
+		}
+	}
+
+	if forceOwnershipUpdate {
+		plan.ID = types.StringUnknown()
+	}
+	resp.Diagnostics.Append(resp.Plan.Set(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, modelImportedFieldsPrivateKey, encodeModelImportedFields(importedFields))...)
+}
+
 func (r *ModelResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var data ModelResourceModel
 
@@ -393,6 +612,8 @@ func (r *ModelResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	priorModelInfo := data.AdditionalModelInfo
 	importedMarker, privateDiags := req.Private.GetKey(ctx, modelImportedPrivateKey)
 	resp.Diagnostics.Append(privateDiags...)
+	importedFieldsMarker, importedFieldsDiags := req.Private.GetKey(ctx, modelImportedFieldsPrivateKey)
+	resp.Diagnostics.Append(importedFieldsDiags...)
 	topThinkingMarker, topThinkingDiags := req.Private.GetKey(ctx, modelTopThinkingOwnedPrivateKey)
 	resp.Diagnostics.Append(topThinkingDiags...)
 	if resp.Diagnostics.HasError() {
@@ -406,8 +627,10 @@ func (r *ModelResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		topThinkingOwned = !data.ThinkingEnabled.IsNull() && !data.ThinkingEnabled.IsUnknown() && data.ThinkingEnabled.ValueBool()
 	}
 
+	importedFields := decodeModelImportedFields(importedFieldsMarker)
 	err := r.readModelWithRetryOwnership(ctx, &data, 8, modelReadOwnership{
 		imported:         imported,
+		importedFields:   importedFields,
 		topThinkingOwned: topThinkingOwned,
 	})
 	if err != nil {
@@ -438,6 +661,11 @@ func (r *ModelResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	if !resp.Diagnostics.HasError() && resp.Private != nil {
 		resp.Diagnostics.Append(resp.Private.SetKey(ctx, modelTopThinkingOwnedPrivateKey, []byte(strconv.FormatBool(topThinkingOwned)))...)
 		if imported {
+			fields := importedFields
+			for name := range modelImportedFieldsFromState(data) {
+				fields[name] = struct{}{}
+			}
+			resp.Diagnostics.Append(resp.Private.SetKey(ctx, modelImportedFieldsPrivateKey, encodeModelImportedFields(fields))...)
 			resp.Diagnostics.Append(resp.Private.SetKey(ctx, modelImportedPrivateKey, nil)...)
 		}
 	}
@@ -481,21 +709,55 @@ func (r *ModelResource) Update(ctx context.Context, req resource.UpdateRequest, 
 
 	var state ModelResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	priorThinkingMarker, priorThinkingDiags := req.Private.GetKey(ctx, modelTopThinkingOwnedPrivateKey)
+	resp.Diagnostics.Append(priorThinkingDiags...)
+	importedFieldsMarker, importedFieldsDiags := req.Private.GetKey(ctx, modelImportedFieldsPrivateKey)
+	resp.Diagnostics.Append(importedFieldsDiags...)
 	if resp.Diagnostics.HasError() {
 		return
+	}
+	priorTopThinkingOwned := string(priorThinkingMarker) == "true"
+	if len(priorThinkingMarker) == 0 {
+		priorTopThinkingOwned = !state.ThinkingEnabled.IsNull() && !state.ThinkingEnabled.IsUnknown() && state.ThinkingEnabled.ValueBool()
 	}
 
 	data.ID = state.ID
 	plannedData := data
+	clearedFields := modelClearedFields(plannedData, state, priorTopThinkingOwned)
+	patchVerifiedClears, readbackClears := partitionModelClears(clearedFields)
+	var durablyClearedFields map[string]struct{}
 
-	// Use PATCH endpoint for partial updates
-	if err := r.patchModel(ctx, &data); err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update model: %s", err))
-		return
+	// A configured-equal imported field uses an unknown ID only to force a
+	// read-backed ownership transition. Avoid a mutation when no API field changed.
+	if modelAPIFieldsChanged(data, state) {
+		patchResult, err := r.patchModel(ctx, &data, &state, topThinkingOwned, priorTopThinkingOwned)
+		if err != nil {
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update model: %s", err))
+			return
+		}
+		if len(patchVerifiedClears) > 0 {
+			if err := verifyModelPatchClears(patchResult, patchVerifiedClears); err != nil {
+				resp.Diagnostics.AddError("Model Clear Not Confirmed", err.Error())
+				return
+			}
+			durablyClearedFields = patchVerifiedClears
+		}
 	}
 
-	if err := r.readModelAfterUpdateWithOwnership(ctx, &data, plannedData, state, 8, modelReadOwnership{topThinkingOwned: topThinkingOwned}); err != nil {
-		resp.Diagnostics.AddError("Model Update Not Yet Consistent", fmt.Sprintf("LiteLLM accepted the model update but did not return the planned values before the consistency timeout: %s", err))
+	ownership := modelReadOwnership{
+		importedFields:       decodeModelImportedFields(importedFieldsMarker),
+		topThinkingOwned:     topThinkingOwned,
+		clearedFields:        readbackClears,
+		durablyClearedFields: durablyClearedFields,
+		freshConnection:      true,
+	}
+	// v1.98 model reads can lag durable writes across workers for several seconds.
+	if err := r.readModelAfterUpdateWithOwnership(ctx, &data, plannedData, state, 24, ownership); err != nil {
+		if len(readbackClears) > 0 {
+			resp.Diagnostics.AddError("Model Clear Readback Not Yet Consistent", fmt.Sprintf("LiteLLM accepted the model update, but bounded fresh-worker reads did not return the decrypted cleared values before the consistency timeout. Terraform retained prior state so a retry can confirm worker-cache convergence: %s", err))
+		} else {
+			resp.Diagnostics.AddError("Model Update Not Yet Consistent", fmt.Sprintf("LiteLLM accepted the model update but did not return the planned values before the consistency timeout: %s", err))
+		}
 		return
 	}
 
@@ -526,6 +788,7 @@ func (r *ModelResource) ImportState(ctx context.Context, req resource.ImportStat
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 	if resp.Private != nil {
 		resp.Diagnostics.Append(resp.Private.SetKey(ctx, modelImportedPrivateKey, []byte("true"))...)
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, modelImportedFieldsPrivateKey, nil)...)
 		resp.Diagnostics.Append(resp.Private.SetKey(ctx, modelTopThinkingOwnedPrivateKey, []byte("false"))...)
 	}
 }
@@ -698,7 +961,13 @@ func (r *ModelResource) readModelWithOwnership(ctx context.Context, data *ModelR
 	endpoint := fmt.Sprintf("/model/info?litellm_model_id=%s", data.ID.ValueString())
 
 	var rawResult map[string]interface{}
-	if err := r.client.DoRequestWithResponse(ctx, "GET", endpoint, nil, &rawResult); err != nil {
+	var err error
+	if ownership.freshConnection {
+		err = r.client.doFreshRequestWithResponse(ctx, "GET", endpoint, nil, &rawResult)
+	} else {
+		err = r.client.DoRequestWithResponse(ctx, "GET", endpoint, nil, &rawResult)
+	}
+	if err != nil {
 		return err
 	}
 
@@ -781,7 +1050,21 @@ func (r *ModelResource) readModelWithOwnership(ctx context.Context, data *ModelR
 		data.ModelName = types.StringValue(modelName)
 	}
 
-	if litellmParams, ok := result["litellm_params"].(map[string]interface{}); ok {
+	litellmParams, hasLiteLLMParams := result["litellm_params"].(map[string]interface{})
+	modelInfo, hasModelInfo := result["model_info"].(map[string]interface{})
+	if len(ownership.clearedFields) > 0 {
+		if !hasLiteLLMParams {
+			litellmParams = map[string]interface{}{}
+		}
+		if !hasModelInfo {
+			modelInfo = map[string]interface{}{}
+		}
+		if err := verifyModelClears(litellmParams, modelInfo, ownership.clearedFields); err != nil {
+			return err
+		}
+	}
+
+	if hasLiteLLMParams {
 		// Update top-level attributes from API response.
 		// For optional attributes (tpm, rpm, merge_reasoning_content_in_choices),
 		// only update if the attribute was set in the config (!IsNull).
@@ -791,11 +1074,32 @@ func (r *ModelResource) readModelWithOwnership(ctx context.Context, data *ModelR
 		if provider, ok := litellmParams["custom_llm_provider"].(string); ok && provider != "" {
 			data.CustomLLMProvider = types.StringValue(provider)
 		}
-		if apiBase, ok := litellmParams["api_base"].(string); ok && apiBase != "" {
-			data.ModelAPIBase = types.StringValue(apiBase)
-		}
-		if apiVersion, ok := litellmParams["api_version"].(string); ok && apiVersion != "" {
-			data.APIVersion = types.StringValue(apiVersion)
+		for _, field := range []struct {
+			name      string
+			target    *types.String
+			sensitive bool
+		}{
+			{"api_key", &data.ModelAPIKey, true},
+			{"api_base", &data.ModelAPIBase, false},
+			{"api_version", &data.APIVersion, false},
+			{"reasoning_effort", &data.ReasoningEffort, false},
+			{"aws_access_key_id", &data.AWSAccessKeyID, true},
+			{"aws_secret_access_key", &data.AWSSecretAccessKey, true},
+			{"aws_region_name", &data.AWSRegionName, false},
+			{"aws_session_name", &data.AWSSessionName, true},
+			{"aws_role_name", &data.AWSRoleName, true},
+			{"vertex_project", &data.VertexProject, true},
+			{"vertex_location", &data.VertexLocation, true},
+			{"vertex_credentials", &data.VertexCredentials, true},
+			{"litellm_credential_name", &data.LiteLLMCredentialName, false},
+		} {
+			if _, cleared := ownership.durablyClearedFields[field.name]; cleared {
+				continue
+			}
+			owned := ownership.imported || (!field.target.IsNull() && !field.target.IsUnknown())
+			if err := updateModelStringFromAPI(field.target, litellmParams, field.name, owned, field.sensitive); err != nil {
+				return err
+			}
 		}
 		tpmOwned := ownership.imported || (!data.TPM.IsNull() && !data.TPM.IsUnknown())
 		if err := updateInt64FromAPI(&data.TPM, litellmParams, tpmOwned, tpmOwned, "tpm"); err != nil {
@@ -827,7 +1131,8 @@ func (r *ModelResource) readModelWithOwnership(ctx context.Context, data *ModelR
 		// Request construction writes top-level thinking first and additional
 		// parameters last. Mirror that precedence: an owned additional key is
 		// authoritative while top-level state remains byte-for-byte unchanged.
-		if ownership.topThinkingOwned && !additionalThinkingOwned {
+		_, thinkingDurablyCleared := ownership.durablyClearedFields["thinking"]
+		if ownership.topThinkingOwned && !additionalThinkingOwned && !thinkingDurablyCleared {
 			enabled := false
 			if thinkingPresence == apiValuePresent {
 				typeValue, exists := thinking["type"]
@@ -848,12 +1153,6 @@ func (r *ModelResource) readModelWithOwnership(ctx context.Context, data *ModelR
 					data.ThinkingBudgetTokens = types.Int64Null()
 				}
 			}
-		}
-		if awsRegion, ok := litellmParams["aws_region_name"].(string); ok && awsRegion != "" {
-			data.AWSRegionName = types.StringValue(awsRegion)
-		}
-		if credName, ok := litellmParams["litellm_credential_name"].(string); ok && credName != "" {
-			data.LiteLLMCredentialName = types.StringValue(credName)
 		}
 		// Read back cost attributes. The API stores costs per token while the
 		// resource exposes them per million tokens, so scale on the way back.
@@ -885,30 +1184,31 @@ func (r *ModelResource) readModelWithOwnership(ctx context.Context, data *ModelR
 
 		// Handle additional_litellm_params map - preserve state when API omits custom params.
 		knownLiteLLMParams := map[string]struct{}{
-			"custom_llm_provider":     {},
-			"model":                   {},
-			"input_cost_per_token":    {},
-			"output_cost_per_token":   {},
-			"tpm":                     {},
-			"rpm":                     {},
-			"api_key":                 {},
-			"api_base":                {},
-			"api_version":             {},
-			"reasoning_effort":        {},
-			"thinking":                {},
-			"aws_access_key_id":       {},
-			"aws_secret_access_key":   {},
-			"aws_region_name":         {},
-			"aws_session_name":        {},
-			"aws_role_name":           {},
-			"vertex_project":          {},
-			"vertex_location":         {},
-			"vertex_credentials":      {},
-			"litellm_credential_name": {},
-			"input_cost_per_pixel":    {},
-			"output_cost_per_pixel":   {},
-			"input_cost_per_second":   {},
-			"output_cost_per_second":  {},
+			"custom_llm_provider":                {},
+			"model":                              {},
+			"input_cost_per_token":               {},
+			"output_cost_per_token":              {},
+			"tpm":                                {},
+			"rpm":                                {},
+			"api_key":                            {},
+			"api_base":                           {},
+			"api_version":                        {},
+			"reasoning_effort":                   {},
+			"thinking":                           {},
+			"merge_reasoning_content_in_choices": {},
+			"aws_access_key_id":                  {},
+			"aws_secret_access_key":              {},
+			"aws_region_name":                    {},
+			"aws_session_name":                   {},
+			"aws_role_name":                      {},
+			"vertex_project":                     {},
+			"vertex_location":                    {},
+			"vertex_credentials":                 {},
+			"litellm_credential_name":            {},
+			"input_cost_per_pixel":               {},
+			"output_cost_per_pixel":              {},
+			"input_cost_per_second":              {},
+			"output_cost_per_second":             {},
 		}
 
 		// Build a set of keys the user configured in additional_litellm_params.
@@ -927,6 +1227,10 @@ func (r *ModelResource) readModelWithOwnership(ctx context.Context, data *ModelR
 			}
 		}
 
+		additionalParamsOwned := !data.AdditionalLiteLLMParamsConfigured.IsNull() && !data.AdditionalLiteLLMParamsConfigured.IsUnknown() && data.AdditionalLiteLLMParamsConfigured.ValueBool()
+		if data.AdditionalLiteLLMParamsConfigured.IsNull() || data.AdditionalLiteLLMParamsConfigured.IsUnknown() {
+			additionalParamsOwned = len(inferLegacyConfiguredAdditionalParamKeys(data.AdditionalLiteLLMParams)) > 0
+		}
 		additionalParams := make(map[string]attr.Value)
 		for key, rawValue := range litellmParams {
 			// Skip "known" params (handled by top-level attributes) UNLESS the
@@ -935,7 +1239,9 @@ func (r *ModelResource) readModelWithOwnership(ctx context.Context, data *ModelR
 			// adopt that complete document through additional parameters.
 			if _, isKnown := knownLiteLLMParams[key]; isKnown {
 				_, inState := stateKeys[key]
-				if !inState && !(ownership.imported && key == "thinking") {
+				_, importedDocument := ownership.importedFields["additional_litellm_params."+key]
+				importAdoptsDocument := (ownership.imported || importedDocument) && (key == "thinking" || key == "merge_reasoning_content_in_choices")
+				if (!inState || !additionalParamsOwned) && !importAdoptsDocument {
 					continue
 				}
 			}
@@ -1012,6 +1318,9 @@ func (r *ModelResource) readModelWithOwnership(ctx context.Context, data *ModelR
 		if filterByState {
 			priorParams := data.AdditionalLiteLLMParams.Elements()
 			for k := range stateKeys {
+				if _, dedicated := knownLiteLLMParams[k]; dedicated && !additionalParamsOwned {
+					continue
+				}
 				if _, present := additionalParams[k]; !present {
 					if prior, ok := priorParams[k]; ok {
 						additionalParams[k] = prior
@@ -1027,7 +1336,6 @@ func (r *ModelResource) readModelWithOwnership(ctx context.Context, data *ModelR
 		data.AdditionalLiteLLMParams, _ = types.MapValue(types.StringType, map[string]attr.Value{})
 	}
 
-	modelInfo, hasModelInfo := result["model_info"].(map[string]interface{})
 	if hasModelInfo {
 		if baseModel, ok := modelInfo["base_model"].(string); ok && baseModel != "" {
 			data.BaseModel = types.StringValue(baseModel)
@@ -1036,12 +1344,9 @@ func (r *ModelResource) readModelWithOwnership(ctx context.Context, data *ModelR
 			data.Tier = types.StringValue(tier)
 		}
 		if mode, ok := modelInfo["mode"].(string); ok && mode != "" {
-			// Only update mode from the API when the user configured it or it
-			// was previously set (not null).  This prevents an API-inferred
-			// mode (e.g. "video_generation") from appearing when the user
-			// didn't set it, which would cause "was null, but now ..." errors.
-			// During Import, mode will be Unknown, so we always populate it.
-			if !data.Mode.IsNull() {
+			// API-inferred mode is unmanaged on create/refresh. Import adopts it;
+			// configured state remains authoritative until explicitly replaced.
+			if ownership.imported || (!data.Mode.IsNull() && !data.Mode.IsUnknown()) {
 				data.Mode = types.StringValue(mode)
 			}
 		}
@@ -1051,14 +1356,15 @@ func (r *ModelResource) readModelWithOwnership(ctx context.Context, data *ModelR
 		// Read access_groups from model_info
 		// The API may not echo back access_groups, so only update if the API
 		// actually returns them. If the API is silent, preserve the current value.
-		if accessGroups, ok := modelInfo["access_groups"].([]interface{}); ok && len(accessGroups) > 0 {
+		_, accessGroupsDurablyCleared := ownership.durablyClearedFields["access_groups"]
+		if accessGroups, ok := modelInfo["access_groups"].([]interface{}); ok && len(accessGroups) > 0 && !accessGroupsDurablyCleared {
 			groupStrings := make([]string, 0, len(accessGroups))
 			for _, g := range accessGroups {
 				if groupStr, ok := g.(string); ok {
 					groupStrings = append(groupStrings, groupStr)
 				}
 			}
-			if len(groupStrings) > 0 {
+			if len(groupStrings) > 0 && (ownership.imported || (!data.AccessGroups.IsNull() && !data.AccessGroups.IsUnknown())) {
 				listValue, diags := types.ListValueFrom(ctx, types.StringType, groupStrings)
 				if !diags.HasError() {
 					data.AccessGroups = listValue
@@ -1107,8 +1413,12 @@ func (r *ModelResource) readModelWithOwnership(ctx context.Context, data *ModelR
 	// Wildcard routes (e.g. openai/*) may not have a mode set in the API
 	// response, which would leave the attribute Unknown and cause:
 	//   "provider still indicated an unknown value for litellm_model.*.mode"
-	if data.Mode.IsUnknown() {
-		data.Mode = types.StringNull()
+	finalizeModelComputedDefaults(data)
+	if data.ThinkingEnabled.IsNull() || data.ThinkingEnabled.IsUnknown() {
+		data.ThinkingEnabled = types.BoolValue(false)
+	}
+	if data.ThinkingBudgetTokens.IsNull() || data.ThinkingBudgetTokens.IsUnknown() {
+		data.ThinkingBudgetTokens = types.Int64Value(1024)
 	}
 
 	return nil
@@ -1120,12 +1430,20 @@ func (r *ModelResource) readModelWithOwnership(ctx context.Context, data *ModelR
 // uses readModelAfterUpdate instead and verifies changed costs stabilize before
 // publishing state. Ordinary Read remains authoritative for out-of-band drift.
 func reassertPlannedCosts(data *ModelResourceModel, planned *ModelResourceModel) {
-	data.InputCostPerMillionTokens = planned.InputCostPerMillionTokens
-	data.OutputCostPerMillionTokens = planned.OutputCostPerMillionTokens
-	data.InputCostPerPixel = planned.InputCostPerPixel
-	data.OutputCostPerPixel = planned.OutputCostPerPixel
-	data.InputCostPerSecond = planned.InputCostPerSecond
-	data.OutputCostPerSecond = planned.OutputCostPerSecond
+	for _, field := range []struct {
+		state, plan *types.Float64
+	}{
+		{&data.InputCostPerMillionTokens, &planned.InputCostPerMillionTokens},
+		{&data.OutputCostPerMillionTokens, &planned.OutputCostPerMillionTokens},
+		{&data.InputCostPerPixel, &planned.InputCostPerPixel},
+		{&data.OutputCostPerPixel, &planned.OutputCostPerPixel},
+		{&data.InputCostPerSecond, &planned.InputCostPerSecond},
+		{&data.OutputCostPerSecond, &planned.OutputCostPerSecond},
+	} {
+		if !field.plan.IsUnknown() {
+			*field.state = *field.plan
+		}
+	}
 }
 
 // readBackCost returns the refreshed value for a cost attribute, scaled
@@ -1198,9 +1516,85 @@ func stringifyAPIValue(rawValue interface{}) (attr.Value, bool) {
 	}
 }
 
+func modelImportedFieldsFromState(data ModelResourceModel) map[string]struct{} {
+	fields := make(map[string]struct{})
+	for _, field := range []struct {
+		name  string
+		value types.String
+	}{
+		{"model_api_base", data.ModelAPIBase},
+		{"api_version", data.APIVersion},
+		{"reasoning_effort", data.ReasoningEffort},
+		{"aws_region_name", data.AWSRegionName},
+		{"litellm_credential_name", data.LiteLLMCredentialName},
+		{"mode", data.Mode},
+		{"team_id", data.TeamID},
+	} {
+		if !field.value.IsNull() && !field.value.IsUnknown() {
+			fields[field.name] = struct{}{}
+		}
+	}
+	for _, field := range []struct {
+		name  string
+		value types.Int64
+	}{
+		{"tpm", data.TPM}, {"rpm", data.RPM},
+	} {
+		if !field.value.IsNull() && !field.value.IsUnknown() {
+			fields[field.name] = struct{}{}
+		}
+	}
+	for _, field := range []struct {
+		name  string
+		value types.Float64
+	}{
+		{"input_cost_per_million_tokens", data.InputCostPerMillionTokens},
+		{"output_cost_per_million_tokens", data.OutputCostPerMillionTokens},
+		{"input_cost_per_pixel", data.InputCostPerPixel},
+		{"output_cost_per_pixel", data.OutputCostPerPixel},
+		{"input_cost_per_second", data.InputCostPerSecond},
+		{"output_cost_per_second", data.OutputCostPerSecond},
+	} {
+		if !field.value.IsNull() && !field.value.IsUnknown() {
+			fields[field.name] = struct{}{}
+		}
+	}
+	if !data.AdditionalLiteLLMParams.IsNull() && !data.AdditionalLiteLLMParams.IsUnknown() {
+		for _, key := range []string{"thinking", "merge_reasoning_content_in_choices"} {
+			if _, exists := data.AdditionalLiteLLMParams.Elements()[key]; exists {
+				fields["additional_litellm_params."+key] = struct{}{}
+			}
+		}
+	}
+	// Optional+Computed access_groups resolves to an empty list during import.
+	// Keep that list import-owned too, so later remote additions remain unmanaged
+	// until the user explicitly configures this argument.
+	fields["access_groups"] = struct{}{}
+	return fields
+}
+
 func finalizeModelComputedDefaults(data *ModelResourceModel) {
-	if data.Mode.IsUnknown() {
-		data.Mode = types.StringNull()
+	for _, target := range []*types.String{
+		&data.ModelAPIBase, &data.APIVersion, &data.ReasoningEffort,
+		&data.TeamID, &data.Mode, &data.LiteLLMCredentialName, &data.AWSRegionName,
+	} {
+		if target.IsUnknown() {
+			*target = types.StringNull()
+		}
+	}
+	for _, target := range []*types.Int64{&data.TPM, &data.RPM} {
+		if target.IsUnknown() {
+			*target = types.Int64Null()
+		}
+	}
+	for _, target := range []*types.Float64{
+		&data.InputCostPerMillionTokens, &data.OutputCostPerMillionTokens,
+		&data.InputCostPerPixel, &data.OutputCostPerPixel,
+		&data.InputCostPerSecond, &data.OutputCostPerSecond,
+	} {
+		if target.IsUnknown() {
+			*target = types.Float64Null()
+		}
 	}
 	if data.AccessGroups.IsUnknown() {
 		data.AccessGroups, _ = types.ListValue(types.StringType, []attr.Value{})
@@ -1337,109 +1731,280 @@ func changedModelFieldsNotConverged(planned, prior, observed ModelResourceModel)
 	return stale
 }
 
-// patchModel uses the PATCH /model/{model_id}/update endpoint for partial updates
-func (r *ModelResource) patchModel(ctx context.Context, data *ModelResourceModel) error {
+func modelAPIFieldsChanged(planned, prior ModelResourceModel) bool {
+	plannedValue := reflect.ValueOf(planned)
+	priorValue := reflect.ValueOf(prior)
+	modelType := plannedValue.Type()
+	for i := 0; i < plannedValue.NumField(); i++ {
+		name := modelType.Field(i).Tag.Get("tfsdk")
+		if name == "id" || name == "additional_litellm_params_configured" || name == "additional_model_info_configured" {
+			continue
+		}
+		plannedAttr, plannedOK := plannedValue.Field(i).Interface().(attr.Value)
+		priorAttr, priorOK := priorValue.Field(i).Interface().(attr.Value)
+		if plannedOK && priorOK && !plannedAttr.IsUnknown() && !plannedAttr.Equal(priorAttr) {
+			return true
+		}
+	}
+	return false
+}
+
+func modelClearedFields(planned, prior ModelResourceModel, topThinkingOwned bool) map[string]struct{} {
+	cleared := make(map[string]struct{})
+	for _, field := range []struct {
+		name           string
+		planned, prior types.String
+	}{
+		{"api_key", planned.ModelAPIKey, prior.ModelAPIKey},
+		{"api_base", planned.ModelAPIBase, prior.ModelAPIBase},
+		{"api_version", planned.APIVersion, prior.APIVersion},
+		{"aws_access_key_id", planned.AWSAccessKeyID, prior.AWSAccessKeyID},
+		{"aws_secret_access_key", planned.AWSSecretAccessKey, prior.AWSSecretAccessKey},
+		{"aws_region_name", planned.AWSRegionName, prior.AWSRegionName},
+		{"aws_session_name", planned.AWSSessionName, prior.AWSSessionName},
+		{"aws_role_name", planned.AWSRoleName, prior.AWSRoleName},
+		{"vertex_project", planned.VertexProject, prior.VertexProject},
+		{"vertex_location", planned.VertexLocation, prior.VertexLocation},
+		{"vertex_credentials", planned.VertexCredentials, prior.VertexCredentials},
+		{"litellm_credential_name", planned.LiteLLMCredentialName, prior.LiteLLMCredentialName},
+		{"reasoning_effort", planned.ReasoningEffort, prior.ReasoningEffort},
+		{"mode", planned.Mode, prior.Mode},
+	} {
+		if field.planned.IsNull() && !field.prior.IsNull() && !field.prior.IsUnknown() {
+			cleared[field.name] = struct{}{}
+		}
+	}
+	for _, field := range []struct {
+		name           string
+		planned, prior types.Float64
+	}{
+		{"input_cost_per_token", planned.InputCostPerMillionTokens, prior.InputCostPerMillionTokens},
+		{"output_cost_per_token", planned.OutputCostPerMillionTokens, prior.OutputCostPerMillionTokens},
+		{"input_cost_per_pixel", planned.InputCostPerPixel, prior.InputCostPerPixel},
+		{"output_cost_per_pixel", planned.OutputCostPerPixel, prior.OutputCostPerPixel},
+		{"input_cost_per_second", planned.InputCostPerSecond, prior.InputCostPerSecond},
+		{"output_cost_per_second", planned.OutputCostPerSecond, prior.OutputCostPerSecond},
+	} {
+		if field.planned.IsNull() && !field.prior.IsNull() && !field.prior.IsUnknown() {
+			cleared[field.name] = struct{}{}
+		}
+	}
+	if topThinkingOwned && !prior.ThinkingEnabled.IsNull() && prior.ThinkingEnabled.ValueBool() && !planned.ThinkingEnabled.ValueBool() {
+		cleared["thinking"] = struct{}{}
+	}
+	if !prior.MergeReasoningContentInChoices.IsNull() && prior.MergeReasoningContentInChoices.ValueBool() && (planned.MergeReasoningContentInChoices.IsNull() || (!planned.MergeReasoningContentInChoices.IsUnknown() && !planned.MergeReasoningContentInChoices.ValueBool())) {
+		cleared["merge_reasoning_content_in_choices"] = struct{}{}
+	}
+	if !prior.AccessGroups.IsNull() && !prior.AccessGroups.IsUnknown() && len(prior.AccessGroups.Elements()) > 0 && !planned.AccessGroups.IsUnknown() && len(planned.AccessGroups.Elements()) == 0 {
+		cleared["access_groups"] = struct{}{}
+	}
+	return cleared
+}
+
+func updateModelStringFromAPI(target *types.String, object map[string]interface{}, field string, owned, sensitive bool) error {
+	if !owned {
+		return nil
+	}
+	value, presence, err := apiValueAt(object, field)
+	if err != nil {
+		return err
+	}
+	if presence == apiValueAbsent {
+		if sensitive {
+			return nil
+		}
+		*target = types.StringNull()
+		return nil
+	}
+	if presence == apiValueNull {
+		*target = types.StringNull()
+		return nil
+	}
+	text, ok := value.(string)
+	if !ok {
+		return fmt.Errorf("invalid response field %q: expected a string", field)
+	}
+	if text == "" {
+		*target = types.StringNull()
+		return nil
+	}
+	if sensitive && isMaskedAPIString(text) {
+		return nil
+	}
+	*target = types.StringValue(text)
+	return nil
+}
+
+func partitionModelClears(cleared map[string]struct{}) (patchVerified, readback map[string]struct{}) {
+	patchVerified = make(map[string]struct{})
+	readback = make(map[string]struct{})
+	for field := range cleared {
+		switch field {
+		case "api_key", "api_base", "api_version", "reasoning_effort",
+			"aws_access_key_id", "aws_secret_access_key", "aws_region_name", "aws_session_name", "aws_role_name",
+			"vertex_project", "vertex_location", "vertex_credentials", "litellm_credential_name":
+			// PATCH returns encrypted-at-rest string values. Only a fresh
+			// decrypted read can prove the clear without trusting ciphertext.
+			readback[field] = struct{}{}
+		default:
+			patchVerified[field] = struct{}{}
+		}
+	}
+	return patchVerified, readback
+}
+
+func verifyModelPatchClears(result map[string]interface{}, cleared map[string]struct{}) error {
+	litellmParams, paramsOK := result["litellm_params"].(map[string]interface{})
+	modelInfo, infoOK := result["model_info"].(map[string]interface{})
+	if !paramsOK || !infoOK {
+		return fmt.Errorf("LiteLLM accepted the model update but did not return the authoritative litellm_params and model_info documents needed to verify requested clears; Terraform retained prior state")
+	}
+	return verifyModelClears(litellmParams, modelInfo, cleared)
+}
+
+func verifyModelClears(litellmParams, modelInfo map[string]interface{}, cleared map[string]struct{}) error {
+	for field := range cleared {
+		switch field {
+		case "mode", "access_groups":
+			value, present := modelInfo[field]
+			if !present || value == nil {
+				continue
+			}
+			if field == "mode" {
+				if text, ok := value.(string); ok && text == "" {
+					continue
+				}
+			} else if list, ok := value.([]interface{}); ok && len(list) == 0 {
+				continue
+			}
+			return fmt.Errorf("model_info.%s remains set after LiteLLM accepted its clear", field)
+		case "thinking":
+			value, present := litellmParams[field]
+			if !present || value == nil {
+				continue
+			}
+			document, ok := value.(map[string]interface{})
+			if ok {
+				kind, _ := document["type"].(string)
+				if kind == "disabled" {
+					continue
+				}
+			}
+			return fmt.Errorf("litellm_params.thinking remains enabled after LiteLLM accepted its clear")
+		case "merge_reasoning_content_in_choices":
+			value, present := litellmParams[field]
+			if !present || value == nil || value == false {
+				continue
+			}
+			return fmt.Errorf("litellm_params.%s remains enabled after LiteLLM accepted its clear", field)
+		case "reasoning_effort":
+			value, present := litellmParams[field]
+			if !present || value == nil || value == "" || value == "none" {
+				continue
+			}
+			return fmt.Errorf("litellm_params.reasoning_effort remains enabled after LiteLLM accepted its clear")
+		case "input_cost_per_token", "output_cost_per_token", "input_cost_per_pixel", "output_cost_per_pixel", "input_cost_per_second", "output_cost_per_second":
+			if value, present := litellmParams[field]; !present || value == nil {
+				continue
+			}
+			return fmt.Errorf("litellm_params.%s remains set after LiteLLM accepted its clear", field)
+		default:
+			value, present := litellmParams[field]
+			if !present || value == nil || value == "" {
+				continue
+			}
+			return fmt.Errorf("litellm_params.%s remains set after LiteLLM accepted its clear", field)
+		}
+	}
+	return nil
+}
+
+func setModelPatchString(target map[string]interface{}, key string, planned, prior types.String) {
+	if !planned.IsNull() && !planned.IsUnknown() {
+		target[key] = planned.ValueString()
+		return
+	}
+	if planned.IsNull() && !prior.IsNull() && !prior.IsUnknown() {
+		target[key] = ""
+	}
+}
+
+func setModelPatchCost(target map[string]interface{}, key string, planned, prior types.Float64, scale float64, clearable bool) {
+	if !planned.IsNull() && !planned.IsUnknown() {
+		target[key] = planned.ValueFloat64() / scale
+		return
+	}
+	if clearable && planned.IsNull() && !prior.IsNull() && !prior.IsUnknown() {
+		// LiteLLM v1.98 recognizes explicit null only for SPECIAL_MODEL_INFO_PARAMS.
+		target[key] = nil
+	}
+}
+
+// patchModel uses the PATCH /model/{model_id}/update endpoint for partial updates.
+func (r *ModelResource) patchModel(ctx context.Context, data, prior *ModelResourceModel, topThinkingOwned, priorTopThinkingOwned bool) (map[string]interface{}, error) {
 	modelID := data.ID.ValueString()
 	customLLMProvider := data.CustomLLMProvider.ValueString()
 	baseModel := data.BaseModel.ValueString()
 	modelName := fmt.Sprintf("%s/%s", customLLMProvider, baseModel)
 
-	// Build litellm_params for the patch request.
-	// NOTE: LiteLLM PATCH API merges litellm_params (via dict.update), it does not replace them.
-	// Parameters removed from config will NOT be removed from the API.
-	// To fully remove a parameter, the model must be recreated (e.g. terraform apply -replace=...).
+	// LiteLLM v1.98 shallow-merges both documents. Use only endpoint-proven
+	// semantic sentinels here; unsupported removals are replacement-planned.
 	litellmParams := map[string]interface{}{
 		"custom_llm_provider": customLLMProvider,
 		"model":               modelName,
 	}
 
-	// Add cost parameters
-	if !data.InputCostPerMillionTokens.IsNull() && !data.InputCostPerMillionTokens.IsUnknown() {
-		litellmParams["input_cost_per_token"] = data.InputCostPerMillionTokens.ValueFloat64() / 1000000.0
-	}
-	if !data.OutputCostPerMillionTokens.IsNull() && !data.OutputCostPerMillionTokens.IsUnknown() {
-		litellmParams["output_cost_per_token"] = data.OutputCostPerMillionTokens.ValueFloat64() / 1000000.0
-	}
+	setModelPatchCost(litellmParams, "input_cost_per_token", data.InputCostPerMillionTokens, prior.InputCostPerMillionTokens, 1000000.0, true)
+	setModelPatchCost(litellmParams, "output_cost_per_token", data.OutputCostPerMillionTokens, prior.OutputCostPerMillionTokens, 1000000.0, true)
 
-	// Add optional parameters
-	if !data.TPM.IsNull() && !data.TPM.IsUnknown() && data.TPM.ValueInt64() > 0 {
+	// Zero is a real deny-all limit, not a clear sentinel.
+	if !data.TPM.IsNull() && !data.TPM.IsUnknown() {
 		litellmParams["tpm"] = data.TPM.ValueInt64()
 	}
-	if !data.RPM.IsNull() && !data.RPM.IsUnknown() && data.RPM.ValueInt64() > 0 {
+	if !data.RPM.IsNull() && !data.RPM.IsUnknown() {
 		litellmParams["rpm"] = data.RPM.ValueInt64()
 	}
-	if !data.ModelAPIKey.IsNull() && !data.ModelAPIKey.IsUnknown() && data.ModelAPIKey.ValueString() != "" {
-		litellmParams["api_key"] = data.ModelAPIKey.ValueString()
-	}
-	if !data.ModelAPIBase.IsNull() && !data.ModelAPIBase.IsUnknown() && data.ModelAPIBase.ValueString() != "" {
-		litellmParams["api_base"] = data.ModelAPIBase.ValueString()
-	}
-	if !data.APIVersion.IsNull() && !data.APIVersion.IsUnknown() && data.APIVersion.ValueString() != "" {
-		litellmParams["api_version"] = data.APIVersion.ValueString()
-	}
-	if !data.ReasoningEffort.IsNull() && !data.ReasoningEffort.IsUnknown() && data.ReasoningEffort.ValueString() != "" {
+	setModelPatchString(litellmParams, "api_key", data.ModelAPIKey, prior.ModelAPIKey)
+	setModelPatchString(litellmParams, "api_base", data.ModelAPIBase, prior.ModelAPIBase)
+	setModelPatchString(litellmParams, "api_version", data.APIVersion, prior.APIVersion)
+	if !data.ReasoningEffort.IsNull() && !data.ReasoningEffort.IsUnknown() {
 		litellmParams["reasoning_effort"] = data.ReasoningEffort.ValueString()
+	} else if data.ReasoningEffort.IsNull() && !prior.ReasoningEffort.IsNull() && !prior.ReasoningEffort.IsUnknown() {
+		litellmParams["reasoning_effort"] = "none"
 	}
 	if !data.MergeReasoningContentInChoices.IsNull() && !data.MergeReasoningContentInChoices.IsUnknown() {
 		litellmParams["merge_reasoning_content_in_choices"] = data.MergeReasoningContentInChoices.ValueBool()
+	} else if data.MergeReasoningContentInChoices.IsNull() && !prior.MergeReasoningContentInChoices.IsNull() && !prior.MergeReasoningContentInChoices.IsUnknown() {
+		litellmParams["merge_reasoning_content_in_choices"] = false
 	}
 
-	// Thinking configuration
-	if !data.ThinkingEnabled.IsNull() && !data.ThinkingEnabled.IsUnknown() && data.ThinkingEnabled.ValueBool() {
-		litellmParams["thinking"] = map[string]interface{}{
-			"type":          "enabled",
-			"budget_tokens": data.ThinkingBudgetTokens.ValueInt64(),
+	if topThinkingOwned || priorTopThinkingOwned {
+		if topThinkingOwned && data.ThinkingEnabled.ValueBool() {
+			litellmParams["thinking"] = map[string]interface{}{
+				"type":          "enabled",
+				"budget_tokens": data.ThinkingBudgetTokens.ValueInt64(),
+			}
+		} else {
+			litellmParams["thinking"] = map[string]interface{}{"type": "disabled"}
 		}
 	}
 
-	// AWS parameters
-	if !data.AWSAccessKeyID.IsNull() && !data.AWSAccessKeyID.IsUnknown() && data.AWSAccessKeyID.ValueString() != "" {
-		litellmParams["aws_access_key_id"] = data.AWSAccessKeyID.ValueString()
-	}
-	if !data.AWSSecretAccessKey.IsNull() && !data.AWSSecretAccessKey.IsUnknown() && data.AWSSecretAccessKey.ValueString() != "" {
-		litellmParams["aws_secret_access_key"] = data.AWSSecretAccessKey.ValueString()
-	}
-	if !data.AWSRegionName.IsNull() && !data.AWSRegionName.IsUnknown() && data.AWSRegionName.ValueString() != "" {
-		litellmParams["aws_region_name"] = data.AWSRegionName.ValueString()
-	}
-	if !data.AWSSessionName.IsNull() && !data.AWSSessionName.IsUnknown() && data.AWSSessionName.ValueString() != "" {
-		litellmParams["aws_session_name"] = data.AWSSessionName.ValueString()
-	}
-	if !data.AWSRoleName.IsNull() && !data.AWSRoleName.IsUnknown() && data.AWSRoleName.ValueString() != "" {
-		litellmParams["aws_role_name"] = data.AWSRoleName.ValueString()
-	}
+	setModelPatchString(litellmParams, "aws_access_key_id", data.AWSAccessKeyID, prior.AWSAccessKeyID)
+	setModelPatchString(litellmParams, "aws_secret_access_key", data.AWSSecretAccessKey, prior.AWSSecretAccessKey)
+	setModelPatchString(litellmParams, "aws_region_name", data.AWSRegionName, prior.AWSRegionName)
+	setModelPatchString(litellmParams, "aws_session_name", data.AWSSessionName, prior.AWSSessionName)
+	setModelPatchString(litellmParams, "aws_role_name", data.AWSRoleName, prior.AWSRoleName)
+	setModelPatchString(litellmParams, "vertex_project", data.VertexProject, prior.VertexProject)
+	setModelPatchString(litellmParams, "vertex_location", data.VertexLocation, prior.VertexLocation)
+	setModelPatchString(litellmParams, "vertex_credentials", data.VertexCredentials, prior.VertexCredentials)
+	setModelPatchString(litellmParams, "litellm_credential_name", data.LiteLLMCredentialName, prior.LiteLLMCredentialName)
 
-	// Vertex parameters
-	if !data.VertexProject.IsNull() && !data.VertexProject.IsUnknown() && data.VertexProject.ValueString() != "" {
-		litellmParams["vertex_project"] = data.VertexProject.ValueString()
-	}
-	if !data.VertexLocation.IsNull() && !data.VertexLocation.IsUnknown() && data.VertexLocation.ValueString() != "" {
-		litellmParams["vertex_location"] = data.VertexLocation.ValueString()
-	}
-	if !data.VertexCredentials.IsNull() && !data.VertexCredentials.IsUnknown() && data.VertexCredentials.ValueString() != "" {
-		litellmParams["vertex_credentials"] = data.VertexCredentials.ValueString()
-	}
+	setModelPatchCost(litellmParams, "input_cost_per_pixel", data.InputCostPerPixel, prior.InputCostPerPixel, 1.0, false)
+	setModelPatchCost(litellmParams, "output_cost_per_pixel", data.OutputCostPerPixel, prior.OutputCostPerPixel, 1.0, false)
+	setModelPatchCost(litellmParams, "input_cost_per_second", data.InputCostPerSecond, prior.InputCostPerSecond, 1.0, false)
+	setModelPatchCost(litellmParams, "output_cost_per_second", data.OutputCostPerSecond, prior.OutputCostPerSecond, 1.0, false)
 
-	// Credential reference
-	if !data.LiteLLMCredentialName.IsNull() && !data.LiteLLMCredentialName.IsUnknown() && data.LiteLLMCredentialName.ValueString() != "" {
-		litellmParams["litellm_credential_name"] = data.LiteLLMCredentialName.ValueString()
-	}
-
-	// Cost per pixel/second
-	if !data.InputCostPerPixel.IsNull() && !data.InputCostPerPixel.IsUnknown() {
-		litellmParams["input_cost_per_pixel"] = data.InputCostPerPixel.ValueFloat64()
-	}
-	if !data.OutputCostPerPixel.IsNull() && !data.OutputCostPerPixel.IsUnknown() {
-		litellmParams["output_cost_per_pixel"] = data.OutputCostPerPixel.ValueFloat64()
-	}
-	if !data.InputCostPerSecond.IsNull() && !data.InputCostPerSecond.IsUnknown() {
-		litellmParams["input_cost_per_second"] = data.InputCostPerSecond.ValueFloat64()
-	}
-	if !data.OutputCostPerSecond.IsNull() && !data.OutputCostPerSecond.IsUnknown() {
-		litellmParams["output_cost_per_second"] = data.OutputCostPerSecond.ValueFloat64()
-	}
-
-	// Add additional_litellm_params to the request.
+	// Additional-map removals remain replacement-only via their plan modifiers.
 	// NOTE: LiteLLM PATCH API merges litellm_params (via dict.update), it does not replace them.
 	// Parameters removed from config will NOT be removed from the API.
 	// To fully remove a parameter, the model must be recreated (e.g. terraform apply -replace=...).
@@ -1451,30 +2016,25 @@ func (r *ModelResource) patchModel(ctx context.Context, data *ModelResourceModel
 		}
 	}
 
-	// Build model_info for the PATCH request
+	// Build model_info for the PATCH request.
 	modelInfo := map[string]interface{}{
 		"base_model": baseModel,
 	}
 
-	// Only add optional model_info fields if they have values
 	if !data.Tier.IsNull() && !data.Tier.IsUnknown() && data.Tier.ValueString() != "" {
 		modelInfo["tier"] = data.Tier.ValueString()
 	}
-	if !data.Mode.IsNull() && !data.Mode.IsUnknown() && data.Mode.ValueString() != "" {
-		modelInfo["mode"] = data.Mode.ValueString()
-	}
+	setModelPatchString(modelInfo, "mode", data.Mode, prior.Mode)
 	if !data.TeamID.IsNull() && !data.TeamID.IsUnknown() && data.TeamID.ValueString() != "" {
 		modelInfo["team_id"] = data.TeamID.ValueString()
 		modelInfo["team_public_model_name"] = data.ModelName.ValueString()
 	}
 
-	// Add access_groups to model_info if specified
+	// Empty access_groups is the endpoint-supported authorization clear.
 	if !data.AccessGroups.IsNull() && !data.AccessGroups.IsUnknown() {
 		var accessGroups []string
 		data.AccessGroups.ElementsAs(ctx, &accessGroups, false)
-		if len(accessGroups) > 0 {
-			modelInfo["access_groups"] = accessGroups
-		}
+		modelInfo["access_groups"] = accessGroups
 	}
 
 	// Add additional_model_info to the request. Like additional_litellm_params,
@@ -1495,7 +2055,11 @@ func (r *ModelResource) patchModel(ctx context.Context, data *ModelResourceModel
 	}
 
 	endpoint := fmt.Sprintf("/model/%s/update", modelID)
-	return r.client.DoRequestWithResponse(ctx, "PATCH", endpoint, patchReq, nil)
+	var result map[string]interface{}
+	if err := r.client.DoRequestWithResponse(ctx, "PATCH", endpoint, patchReq, &result); err != nil {
+		return nil, err
+	}
+	return result, nil
 }
 
 // normalizeNumericString normalises a string that represents a number into a

--- a/internal/provider/resource_model_clear_protocol_test.go
+++ b/internal/provider/resource_model_clear_protocol_test.go
@@ -1,0 +1,116 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+)
+
+func TestModelImportedLimitOwnershipTransitionsBeforeRemovalReplacementProtocol(t *testing.T) {
+	ctx := context.Background()
+	var reads, patches atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		switch {
+		case request.Method == http.MethodGet && request.URL.Path == "/model/info":
+			reads.Add(1)
+			_, _ = fmt.Fprint(writer, `{"data":[{"model_name":"imported-model","litellm_params":{"custom_llm_provider":"anthropic","model":"anthropic/claude","tpm":100,"input_cost_per_pixel":0.25},"model_info":{"id":"model-import","base_model":"claude","tier":"free","mode":"chat"}}]}`)
+		case request.Method == http.MethodPatch:
+			patches.Add(1)
+			_, _ = fmt.Fprint(writer, `{"status":"ok"}`)
+		default:
+			http.NotFound(writer, request)
+		}
+	}))
+	defer server.Close()
+
+	protocolServer, schemas := configuredImportProtocolServer(t, ctx, server.URL)
+	const typeName = "litellm_model"
+	schema := schemas.ResourceSchemas[typeName]
+	imported, err := protocolServer.ImportResourceState(ctx, &tfprotov6.ImportResourceStateRequest{TypeName: typeName, ID: "model-import"})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(imported.Diagnostics) || len(imported.ImportedResources) != 1 {
+		t.Fatalf("import: err=%v diagnostics=%v", err, imported.Diagnostics)
+	}
+	read, err := protocolServer.ReadResource(ctx, &tfprotov6.ReadResourceRequest{
+		TypeName: typeName, CurrentState: imported.ImportedResources[0].State, Private: imported.ImportedResources[0].Private,
+	})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(read.Diagnostics) {
+		t.Fatalf("read: err=%v diagnostics=%v", err, read.Diagnostics)
+	}
+
+	configValues := map[string]interface{}{
+		"model_name": "imported-model", "custom_llm_provider": "anthropic", "base_model": "claude",
+	}
+	plan := func(values map[string]interface{}, proposed *tfprotov6.DynamicValue, prior *tfprotov6.DynamicValue, private []byte) *tfprotov6.PlanResourceChangeResponse {
+		t.Helper()
+		config := accessGroupProtocolDynamicValue(t, schema, organizationProjectProtocolValue(t, schema, values))
+		response, planErr := protocolServer.PlanResourceChange(ctx, &tfprotov6.PlanResourceChangeRequest{
+			TypeName: typeName, Config: config, PriorState: prior, ProposedNewState: proposed, PriorPrivate: private,
+		})
+		if planErr != nil {
+			t.Fatal(planErr)
+		}
+		return response
+	}
+
+	omittedProposed := organizationProjectProtocolReplace(t, schema, read.NewState, map[string]interface{}{"tpm": nil})
+	omitted := plan(configValues, omittedProposed, read.NewState, read.Private)
+	if accessGroupProtocolDiagnosticsHaveError(omitted.Diagnostics) || len(omitted.RequiresReplace) != 0 || organizationProjectProtocolPlannedAction(t, schema, read.NewState, omitted) != organizationProjectProtocolActionNoOp {
+		priorAttributes := protocolAttributeMap(t, schema, read.NewState)
+		plannedAttributes := protocolAttributeMap(t, schema, omitted.PlannedState)
+		for name, priorValue := range priorAttributes {
+			if plannedValue := plannedAttributes[name]; !priorValue.Equal(plannedValue) {
+				t.Logf("%s: prior=%s planned=%s", name, priorValue, plannedValue)
+			}
+		}
+		t.Fatalf("fresh imported omission: diagnostics=%v replace=%v action=%s", omitted.Diagnostics, omitted.RequiresReplace, organizationProjectProtocolPlannedAction(t, schema, read.NewState, omitted))
+	}
+
+	ownedConfig := map[string]interface{}{
+		"model_name": "imported-model", "custom_llm_provider": "anthropic", "base_model": "claude", "tpm": int64(100),
+	}
+	owned := plan(ownedConfig, read.NewState, read.NewState, read.Private)
+	if accessGroupProtocolDiagnosticsHaveError(owned.Diagnostics) || len(owned.RequiresReplace) != 0 || organizationProjectProtocolPlannedAction(t, schema, read.NewState, owned) != organizationProjectProtocolActionUpdate {
+		t.Fatalf("configured-equal transition: diagnostics=%v replace=%v action=%s", owned.Diagnostics, owned.RequiresReplace, organizationProjectProtocolPlannedAction(t, schema, read.NewState, owned))
+	}
+	ownedDynamic := accessGroupProtocolDynamicValue(t, schema, organizationProjectProtocolValue(t, schema, ownedConfig))
+	readsBefore := reads.Load()
+	applied, err := protocolServer.ApplyResourceChange(ctx, &tfprotov6.ApplyResourceChangeRequest{
+		TypeName: typeName, Config: ownedDynamic, PriorState: read.NewState, PlannedState: owned.PlannedState, PlannedPrivate: owned.PlannedPrivate,
+	})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(applied.Diagnostics) || patches.Load() != 0 || reads.Load() != readsBefore+2 {
+		t.Fatalf("ownership apply: err=%v diagnostics=%v patches=%d reads=%d, want %d", err, applied.Diagnostics, patches.Load(), reads.Load(), readsBefore+2)
+	}
+
+	removalProposed := organizationProjectProtocolReplace(t, schema, applied.NewState, map[string]interface{}{"tpm": nil})
+	removal := plan(configValues, removalProposed, applied.NewState, applied.Private)
+	if accessGroupProtocolDiagnosticsHaveError(removal.Diagnostics) || len(removal.RequiresReplace) == 0 || organizationProjectProtocolPlannedAction(t, schema, applied.NewState, removal) != organizationProjectProtocolActionReplace {
+		t.Fatalf("owned limit removal: diagnostics=%v replace=%v action=%s", removal.Diagnostics, removal.RequiresReplace, organizationProjectProtocolPlannedAction(t, schema, applied.NewState, removal))
+	}
+
+	modeConfig := map[string]interface{}{
+		"model_name": "imported-model", "custom_llm_provider": "anthropic", "base_model": "claude", "tpm": int64(100), "mode": "chat", "input_cost_per_pixel": 0.25,
+	}
+	modeOwned := plan(modeConfig, applied.NewState, applied.NewState, applied.Private)
+	if accessGroupProtocolDiagnosticsHaveError(modeOwned.Diagnostics) || len(modeOwned.RequiresReplace) != 0 || organizationProjectProtocolPlannedAction(t, schema, applied.NewState, modeOwned) != organizationProjectProtocolActionUpdate {
+		t.Fatalf("configured-equal mode transition: diagnostics=%v replace=%v action=%s", modeOwned.Diagnostics, modeOwned.RequiresReplace, organizationProjectProtocolPlannedAction(t, schema, applied.NewState, modeOwned))
+	}
+	modeDynamic := accessGroupProtocolDynamicValue(t, schema, organizationProjectProtocolValue(t, schema, modeConfig))
+	readsBefore = reads.Load()
+	modeApplied, err := protocolServer.ApplyResourceChange(ctx, &tfprotov6.ApplyResourceChangeRequest{
+		TypeName: typeName, Config: modeDynamic, PriorState: applied.NewState, PlannedState: modeOwned.PlannedState, PlannedPrivate: modeOwned.PlannedPrivate,
+	})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(modeApplied.Diagnostics) || patches.Load() != 0 || reads.Load() != readsBefore+2 {
+		t.Fatalf("mode ownership apply: err=%v diagnostics=%v patches=%d reads=%d, want %d", err, modeApplied.Diagnostics, patches.Load(), reads.Load(), readsBefore+2)
+	}
+
+	modeRemoval := plan(ownedConfig, modeApplied.NewState, modeApplied.NewState, modeApplied.Private)
+	if accessGroupProtocolDiagnosticsHaveError(modeRemoval.Diagnostics) || len(modeRemoval.RequiresReplace) < 2 || organizationProjectProtocolPlannedAction(t, schema, modeApplied.NewState, modeRemoval) != organizationProjectProtocolActionReplace {
+		t.Fatalf("owned mode removal: diagnostics=%v replace=%v action=%s", modeRemoval.Diagnostics, modeRemoval.RequiresReplace, organizationProjectProtocolPlannedAction(t, schema, modeApplied.NewState, modeRemoval))
+	}
+}

--- a/internal/provider/resource_model_clear_test.go
+++ b/internal/provider/resource_model_clear_test.go
@@ -1,0 +1,215 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestPatchModelEmitsOnlySupportedClearSentinels(t *testing.T) {
+	t.Parallel()
+	var body map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.Method != http.MethodPatch || request.URL.Path != "/model/model-clear/update" {
+			http.NotFound(writer, request)
+			return
+		}
+		if err := json.NewDecoder(request.Body).Decode(&body); err != nil {
+			t.Error(err)
+			http.Error(writer, "bad request", http.StatusBadRequest)
+			return
+		}
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = writer.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer server.Close()
+
+	prior := ModelResourceModel{
+		ID:                             types.StringValue("model-clear"),
+		ModelName:                      types.StringValue("clear-model"),
+		CustomLLMProvider:              types.StringValue("anthropic"),
+		BaseModel:                      types.StringValue("claude"),
+		Tier:                           types.StringValue("paid"),
+		ModelAPIKey:                    types.StringValue("prior-key"),
+		ModelAPIBase:                   types.StringValue("https://example.invalid"),
+		APIVersion:                     types.StringValue("v1"),
+		ReasoningEffort:                types.StringValue("high"),
+		ThinkingEnabled:                types.BoolValue(true),
+		ThinkingBudgetTokens:           types.Int64Value(2048),
+		MergeReasoningContentInChoices: types.BoolValue(true),
+		AWSAccessKeyID:                 types.StringValue("access"),
+		AWSSecretAccessKey:             types.StringValue("secret"),
+		AWSRegionName:                  types.StringValue("us-east-1"),
+		AWSSessionName:                 types.StringValue("session"),
+		AWSRoleName:                    types.StringValue("role"),
+		VertexProject:                  types.StringValue("project"),
+		VertexLocation:                 types.StringValue("location"),
+		VertexCredentials:              types.StringValue("credentials"),
+		LiteLLMCredentialName:          types.StringValue("credential"),
+		InputCostPerMillionTokens:      types.Float64Value(3),
+		OutputCostPerMillionTokens:     types.Float64Value(4),
+		InputCostPerPixel:              types.Float64Value(5),
+		OutputCostPerPixel:             types.Float64Value(6),
+		InputCostPerSecond:             types.Float64Value(7),
+		OutputCostPerSecond:            types.Float64Value(8),
+		Mode:                           types.StringNull(),
+		AccessGroups:                   types.ListValueMust(types.StringType, []attr.Value{types.StringValue("group")}),
+	}
+	planned := ModelResourceModel{
+		ID:                             prior.ID,
+		ModelName:                      prior.ModelName,
+		CustomLLMProvider:              prior.CustomLLMProvider,
+		BaseModel:                      prior.BaseModel,
+		Tier:                           types.StringValue("free"),
+		ModelAPIKey:                    types.StringNull(),
+		ModelAPIBase:                   types.StringNull(),
+		APIVersion:                     types.StringNull(),
+		ReasoningEffort:                types.StringNull(),
+		ThinkingEnabled:                types.BoolValue(false),
+		ThinkingBudgetTokens:           types.Int64Value(1024),
+		MergeReasoningContentInChoices: types.BoolNull(),
+		AWSAccessKeyID:                 types.StringNull(),
+		AWSSecretAccessKey:             types.StringNull(),
+		AWSRegionName:                  types.StringNull(),
+		AWSSessionName:                 types.StringNull(),
+		AWSRoleName:                    types.StringNull(),
+		VertexProject:                  types.StringNull(),
+		VertexLocation:                 types.StringNull(),
+		VertexCredentials:              types.StringNull(),
+		LiteLLMCredentialName:          types.StringNull(),
+		InputCostPerMillionTokens:      types.Float64Null(),
+		OutputCostPerMillionTokens:     types.Float64Null(),
+		InputCostPerPixel:              types.Float64Null(),
+		OutputCostPerPixel:             types.Float64Null(),
+		InputCostPerSecond:             types.Float64Null(),
+		OutputCostPerSecond:            types.Float64Null(),
+		Mode:                           types.StringNull(),
+		AccessGroups:                   types.ListValueMust(types.StringType, []attr.Value{}),
+	}
+	resource := &ModelResource{client: &Client{APIBase: server.URL, APIKey: "test", HTTPClient: server.Client()}}
+	if _, err := resource.patchModel(context.Background(), &planned, &prior, false, true); err != nil {
+		t.Fatal(err)
+	}
+
+	params, ok := body["litellm_params"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("litellm_params = %#v", body["litellm_params"])
+	}
+	for _, key := range []string{"api_key", "api_base", "api_version", "aws_access_key_id", "aws_secret_access_key", "aws_region_name", "aws_session_name", "aws_role_name", "vertex_project", "vertex_location", "vertex_credentials", "litellm_credential_name"} {
+		if value, present := params[key]; !present || value != "" {
+			t.Errorf("%s clear = %#v, present=%t", key, value, present)
+		}
+	}
+	if params["reasoning_effort"] != "none" {
+		t.Errorf("reasoning_effort clear = %#v", params["reasoning_effort"])
+	}
+	if params["merge_reasoning_content_in_choices"] != false {
+		t.Errorf("merge reasoning clear = %#v", params["merge_reasoning_content_in_choices"])
+	}
+	thinking, ok := params["thinking"].(map[string]interface{})
+	if !ok || thinking["type"] != "disabled" {
+		t.Errorf("thinking clear = %#v", params["thinking"])
+	}
+	for _, key := range []string{"input_cost_per_token", "output_cost_per_token"} {
+		value, present := params[key]
+		if !present || value != nil {
+			t.Errorf("%s clear = %#v, present=%t", key, value, present)
+		}
+	}
+	for _, key := range []string{"input_cost_per_pixel", "output_cost_per_pixel", "input_cost_per_second", "output_cost_per_second", "tpm", "rpm"} {
+		if _, present := params[key]; present {
+			t.Errorf("unsupported %s clear was sent", key)
+		}
+	}
+
+	info, ok := body["model_info"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("model_info = %#v", body["model_info"])
+	}
+	if _, present := info["mode"]; present {
+		t.Error("unsupported mode clear was sent")
+	}
+	if info["tier"] != "free" {
+		t.Errorf("tier reset = %#v", info["tier"])
+	}
+	groups, ok := info["access_groups"].([]interface{})
+	if !ok || len(groups) != 0 {
+		t.Errorf("access_groups clear = %#v", info["access_groups"])
+	}
+}
+
+func TestPartitionModelClearsRequiresDecryptedReadbackForSecrets(t *testing.T) {
+	t.Parallel()
+	patchVerified, readback := partitionModelClears(map[string]struct{}{
+		"api_key": {}, "aws_session_name": {}, "thinking": {}, "api_base": {}, "access_groups": {},
+	})
+	for _, field := range []string{"api_key", "aws_session_name", "api_base"} {
+		if _, ok := readback[field]; !ok {
+			t.Errorf("%s was not assigned to decrypted readback verification", field)
+		}
+	}
+	for _, field := range []string{"thinking", "access_groups"} {
+		if _, ok := patchVerified[field]; !ok {
+			t.Errorf("%s was not assigned to authoritative PATCH verification", field)
+		}
+	}
+}
+
+func TestVerifyModelPatchClearsRequiresAuthoritativeDocuments(t *testing.T) {
+	t.Parallel()
+	cleared := map[string]struct{}{"api_key": {}}
+	if err := verifyModelPatchClears(map[string]interface{}{"status": "ok"}, cleared); err == nil {
+		t.Fatal("clear accepted without authoritative response documents")
+	}
+	if err := verifyModelPatchClears(map[string]interface{}{
+		"litellm_params": map[string]interface{}{"api_key": ""},
+		"model_info":     map[string]interface{}{},
+	}, cleared); err != nil {
+		t.Fatalf("authoritative clear rejected: %v", err)
+	}
+}
+
+func TestModelClearedFieldsUsesWireNames(t *testing.T) {
+	t.Parallel()
+	planned := ModelResourceModel{ModelAPIKey: types.StringNull(), ModelAPIBase: types.StringNull()}
+	prior := ModelResourceModel{ModelAPIKey: types.StringValue("secret"), ModelAPIBase: types.StringValue("https://example.invalid")}
+	cleared := modelClearedFields(planned, prior, false)
+	for _, field := range []string{"api_key", "api_base"} {
+		if _, ok := cleared[field]; !ok {
+			t.Errorf("clear did not use %s wire name", field)
+		}
+	}
+	for _, field := range []string{"model_api_key", "model_api_base"} {
+		if _, ok := cleared[field]; ok {
+			t.Errorf("schema name %s leaked into API clear verification", field)
+		}
+	}
+}
+
+func TestVerifyModelClearsRejectsRetainedValues(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name   string
+		params map[string]interface{}
+		info   map[string]interface{}
+		field  string
+	}{
+		{"masked secret", map[string]interface{}{"api_key": "********"}, nil, "api_key"},
+		{"reasoning", map[string]interface{}{"reasoning_effort": "high"}, nil, "reasoning_effort"},
+		{"thinking", map[string]interface{}{"thinking": map[string]interface{}{"type": "enabled"}}, nil, "thinking"},
+		{"cost", map[string]interface{}{"input_cost_per_token": 0.1}, nil, "input_cost_per_token"},
+		{"mode", nil, map[string]interface{}{"mode": "chat"}, "mode"},
+		{"access groups", nil, map[string]interface{}{"access_groups": []interface{}{"group"}}, "access_groups"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if err := verifyModelClears(test.params, test.info, map[string]struct{}{test.field: {}}); err == nil {
+				t.Fatal("retained clear value was accepted")
+			}
+		})
+	}
+}

--- a/internal/provider/resource_model_plan_modifier.go
+++ b/internal/provider/resource_model_plan_modifier.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 	"sort"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -11,8 +12,39 @@ import (
 
 const (
 	modelImportedPrivateKey         = "model_imported_v1"
+	modelImportedFieldsPrivateKey   = "model_imported_fields_v1"
 	modelTopThinkingOwnedPrivateKey = "model_top_thinking_owned_v1"
 )
+
+func decodeModelImportedFields(raw []byte) map[string]struct{} {
+	fields := make(map[string]struct{})
+	if len(raw) == 0 {
+		return fields
+	}
+	var names []string
+	if err := json.Unmarshal(raw, &names); err != nil {
+		return fields
+	}
+	for _, name := range names {
+		if name != "" {
+			fields[name] = struct{}{}
+		}
+	}
+	return fields
+}
+
+func encodeModelImportedFields(fields map[string]struct{}) []byte {
+	if len(fields) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(fields))
+	for name := range fields {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	raw, _ := json.Marshal(names)
+	return raw
+}
 
 // LiteLLM v1.98.0 injects this complete set into litellm_params for models
 // created without additional_litellm_params. Older provider state has no

--- a/internal/provider/resource_model_test.go
+++ b/internal/provider/resource_model_test.go
@@ -148,8 +148,8 @@ func TestReadModelImportAdoptsRemoteThinkingThroughAdditionalParams(t *testing.T
 	if err := (&ModelResource{client: client}).readModelWithOwnership(context.Background(), data, modelReadOwnership{imported: true}); err != nil {
 		t.Fatal(err)
 	}
-	if !data.ThinkingEnabled.IsNull() || !data.ThinkingBudgetTokens.IsNull() {
-		t.Fatalf("import invented top-level thinking ownership: %#v", data)
+	if data.ThinkingEnabled.IsNull() || data.ThinkingEnabled.ValueBool() || data.ThinkingBudgetTokens.ValueInt64() != 1024 {
+		t.Fatalf("import did not resolve schema defaults without adopting remote thinking: %#v", data)
 	}
 	var additional map[string]string
 	data.AdditionalLiteLLMParams.ElementsAs(context.Background(), &additional, false)
@@ -727,7 +727,7 @@ func TestPatchModelSendsAdditionalLiteLLMParams(t *testing.T) {
 		AccessGroups:            types.ListNull(types.StringType),
 	}
 
-	err := r.patchModel(context.Background(), data)
+	_, err := r.patchModel(context.Background(), data, &ModelResourceModel{}, false, false)
 	if err != nil {
 		t.Fatalf("patchModel returned error: %v", err)
 	}
@@ -784,7 +784,7 @@ func TestPatchModelSendsTeamPublicModelNameWhenTeamIDSet(t *testing.T) {
 		AccessGroups:      types.ListNull(types.StringType),
 	}
 
-	err := r.patchModel(context.Background(), data)
+	_, err := r.patchModel(context.Background(), data, &ModelResourceModel{}, false, false)
 	if err != nil {
 		t.Fatalf("patchModel returned error: %v", err)
 	}
@@ -1836,7 +1836,7 @@ func TestPatchModelSendsAdditionalModelInfo(t *testing.T) {
 		AdditionalModelInfo: additionalInfo,
 	}
 
-	if err := r.patchModel(context.Background(), data); err != nil {
+	if _, err := r.patchModel(context.Background(), data, &ModelResourceModel{}, false, false); err != nil {
 		t.Fatalf("patchModel returned error: %v", err)
 	}
 


### PR DESCRIPTION
### Summary

Closes #190. `litellm_model` now treats removal as an explicit lifecycle operation instead of omitting fields from LiteLLM v1.98's merge-only PATCH payload and falsely publishing cleared Terraform state.

Supported clears use endpoint-specific sentinels: empty strings for connection/provider fields, `"none"` for reasoning effort, disabled thinking, `false` for reasoning-content merging, empty access groups, and explicit null for token pricing. TPM/RPM, mode, per-pixel/per-second pricing, and team reassociation use replacement where v1.98 cannot remove the old value safely; configured zero limits remain real values.

Fresh imports preserve omitted remote fields through private per-field provenance. Explicitly configuring an imported value transfers ownership with one read-backed update, after which removal follows the same clear-or-replace rules. Additional parameter and model-info map ownership remains unchanged.

### Compatibility

Resource addresses, import IDs, schema version 0, attribute types, required arguments, and additional-map behavior are preserved. Readable optional fields become additive Optional+Computed surfaces so import-only configurations can remain stable; ordinary configured values retain their existing representation.

String clears require decrypted fresh-worker confirmation because PATCH responses contain encrypted-at-rest strings. Terraform rejects masks and ciphertext as proof, retains prior state when worker caches have not converged, and allows a safe retry. Non-string clears are verified against the authoritative PATCH response before state is committed.

### Validation

Validated set-to-clear transitions for API/provider credentials, AWS and Vertex fields, reasoning/thinking booleans, access groups, and token costs against LiteLLM v1.98, including safe recovery after stale worker-cache readback. Also validated zero TPM/RPM values, replacement for TPM/RPM and mode removal, fresh import omission, configured-equal ownership transfer, in-place imported-field clearing, replacement after imported ownership, no-drift plans, and destroy.

The complete live provider matrix passed **23 resources / 0 drift / 0 failures** at the branch head. Focused protocol tests passed repeatedly, and the full Go, race, and vet suites passed.

### Review focus

Please pay particular attention to the Optional+Computed import compatibility bridge, per-field private ownership transitions, and the split between authoritative PATCH verification and decrypted fresh-worker readback for string clears.

### Checklist

- [x] Backward-compatible schema and state behavior preserved
- [x] Focused lifecycle, clear, replacement, import, and failure-path coverage added
- [x] Live LiteLLM v1.98 validation completed
- [x] Registry documentation updated
- [x] Full test, race, vet, repeated protocol, and no-drift suites passed

### Diff size

**Docs** — 1 file · `+30 / -10`

Documents the complete clear/replacement inventory, import ownership, retry behavior, and state-security guidance.

**Implementation** — 3 files · `+752 / -155`

Adds presence-aware planning, import provenance, endpoint-specific payload construction, authoritative clear verification, decrypted worker readback, and stable post-update convergence. Most of the size replaces the previous omission-based PATCH builder with explicit per-field lifecycle handling.

**Tests** — 3 files · `+336 / -5`

Covers wire sentinels, fail-closed clear confirmation, masked values, import ownership persistence, exact/zero limits, and replacement planning at Terraform protocol level.
