### PR TITLE
fix(vector-store): enforce v1.98 lifecycle contract

### DIFF
--- a/docs/data-sources/vector_store.md
+++ b/docs/data-sources/vector_store.md
@@ -107,7 +107,7 @@ In addition to all arguments above, the following attributes are exported:
 * `vector_store_description` - Description of the vector store.
 * `vector_store_metadata` - Map of metadata associated with the vector store.
 * `litellm_credential_name` - Name of the LiteLLM credential used.
-* `litellm_params` - Map of additional LiteLLM parameters.
+* `litellm_params` - Sensitive map of additional LiteLLM parameters. LiteLLM redacts credential-bearing leaves; nested values are represented as canonical JSON strings.
 * `created_at` - Timestamp when the vector store was created.
 * `updated_at` - Timestamp when the vector store was last updated.
 
@@ -213,5 +213,7 @@ output "compliance_report" {
 
 * Vector store IDs are unique identifiers assigned by the LiteLLM system.
 * The data source will fail if the specified vector store ID does not exist.
-* All computed attributes reflect the current state of the vector store in the LiteLLM system.
+* The data source strictly reads LiteLLM v1.98's nested `vector_store` response and rejects missing or mismatched identity.
+* Vector-store management is protected by LiteLLM's `vector_stores` feature gate and may require an applicable license and role.
+* Sensitive values remain redacted by LiteLLM and the `litellm_params` attribute is marked sensitive in Terraform.
 * Use this data source to integrate with existing vector stores or to reference stores created outside of Terraform.

--- a/docs/resources/vector_store.md
+++ b/docs/resources/vector_store.md
@@ -39,10 +39,24 @@ The following arguments are supported:
 
 - `vector_store_name` - (Required) The name of the vector store.
 - `custom_llm_provider` - (Required) The LLM provider for the vector store. Supported values: `bedrock`, `openai`, `azure`, `vertex_ai`, `pgvector`.
-- `vector_store_description` - (Optional) A human-readable description of the vector store.
-- `vector_store_metadata` - (Optional) A map of string key-value pairs containing metadata for the vector store.
-- `litellm_credential_name` - (Optional) The name of the LiteLLM credential to use for authenticating with the provider.
-- `litellm_params` - (Optional) A map of string key-value pairs containing additional LiteLLM-specific parameters for the vector store.
+- `vector_store_description` - (Optional) A human-readable description of the vector store. Removing it sends an explicit empty-string update.
+- `vector_store_metadata` - (Optional) A complete map of string key-value pairs containing metadata for the vector store. `{}` and removal of an owned map send an explicit empty-map update. Imported metadata remains unmanaged while omitted.
+- `litellm_credential_name` - (Optional) The name of the LiteLLM credential to use for authenticating with the provider. LiteLLM v1.98 does not accept this field on update, so changing or removing an owned value replaces the vector store.
+- `litellm_params` - (Optional, Sensitive) A map of string key-value pairs containing additional LiteLLM-specific parameters. LiteLLM may redact credential-bearing values on read; Terraform preserves recognized masks only when prior owned values exist. Changing or removing this create-only map replaces the vector store.
+
+## Update and Replacement Behavior
+
+LiteLLM v1.98 updates only `custom_llm_provider`, `vector_store_name`, `vector_store_description`, and `vector_store_metadata`. Terraform never sends `litellm_credential_name` or `litellm_params` to the update endpoint because v1.98 silently ignores those fields.
+
+Explicitly configuring an imported description or metadata map transfers ownership and enables later in-place clearing. Explicitly configuring an imported credential name or parameter map transfers ownership without mutation when the value already matches; later changes use replacement. Omitted imported values remain stable.
+
+The public metadata and parameter types remain `map(string)` for compatibility. Nested API values are represented as canonical JSON strings on read; this version does not coerce Terraform strings into heterogeneous request objects.
+
+Create and update operations require two stable fresh-worker reads before Terraform commits state. LiteLLM v1.98 can persist a database mutation and then report a registry-synchronization error; when the complete planned object is subsequently confirmed, Terraform recovers with a warning. Otherwise it retains prior state and fails safely for retry. Delete errors are accepted only when a fresh authoritative read confirms absence.
+
+## Feature Availability
+
+Vector-store management is protected by LiteLLM's `vector_stores` feature gate and may require an applicable LiteLLM license and role. Terraform reports the API's authorization or feature-gate failure without falling back to local configuration or database access.
 
 ## Attribute Reference
 
@@ -61,3 +75,9 @@ Vector stores can be imported using the vector store ID:
 ```shell
 terraform import litellm_vector_store.example <vector-store-id>
 ```
+
+The configuration must provide `vector_store_name` and `custom_llm_provider`. Omitted imported optional values remain unmanaged. If LiteLLM returns a masked `litellm_params` value with no prior Terraform value, import fails rather than storing the redaction marker as if it were the secret.
+
+## Security Note
+
+`litellm_params` is sensitive in Terraform output, but configured values remain in Terraform state. Protect state and plan artifacts and prefer `litellm_credential_name` where possible. LiteLLM redaction markers are never treated as imported credentials, and only matching masked leaves preserve prior owned state; visible unmasked changes remain detectable.

--- a/internal/provider/datasource_vector_store.go
+++ b/internal/provider/datasource_vector_store.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -71,8 +70,9 @@ func (d *VectorStoreDataSource) Schema(ctx context.Context, req datasource.Schem
 				Computed:    true,
 			},
 			"litellm_params": schema.MapAttribute{
-				Description: "Additional LiteLLM parameters.",
+				Description: "Additional LiteLLM parameters. Credential-bearing values are redacted by LiteLLM.",
 				Computed:    true,
+				Sensitive:   true,
 				ElementType: types.StringType,
 			},
 			"created_at": schema.StringAttribute{
@@ -124,55 +124,36 @@ func (d *VectorStoreDataSource) Read(ctx context.Context, req datasource.ReadReq
 		return
 	}
 
-	// Update fields from response
-	if vsID, ok := result["vector_store_id"].(string); ok {
-		data.VectorStoreID = types.StringValue(vsID)
-		data.ID = types.StringValue(vsID)
+	store, err := unwrapVectorStoreResponse(result, vectorStoreID)
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid Vector Store Response", err.Error())
+		return
 	}
-	if vsName, ok := result["vector_store_name"].(string); ok {
-		data.VectorStoreName = types.StringValue(vsName)
+	name, nameOK := store["vector_store_name"].(string)
+	provider, providerOK := store["custom_llm_provider"].(string)
+	if !nameOK || name == "" || !providerOK || provider == "" {
+		resp.Diagnostics.AddError("Invalid Vector Store Response", "LiteLLM returned a vector store without the required name or provider identity.")
+		return
 	}
-	if provider, ok := result["custom_llm_provider"].(string); ok {
-		data.CustomLLMProvider = types.StringValue(provider)
+	data.ID = types.StringValue(vectorStoreID)
+	data.VectorStoreID = types.StringValue(vectorStoreID)
+	data.VectorStoreName = types.StringValue(name)
+	data.CustomLLMProvider = types.StringValue(provider)
+	data.VectorStoreDescription = nullableVectorStoreString(store["vector_store_description"])
+	data.LiteLLMCredentialName = nullableVectorStoreString(store["litellm_credential_name"])
+	data.CreatedAt = nullableVectorStoreString(store["created_at"])
+	data.UpdatedAt = nullableVectorStoreString(store["updated_at"])
+	metadata, err := vectorStoreStringMap(store["vector_store_metadata"], types.MapNull(types.StringType), false, false, "vector_store_metadata")
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid Vector Store Response", err.Error())
+		return
 	}
-	if desc, ok := result["vector_store_description"].(string); ok {
-		data.VectorStoreDescription = types.StringValue(desc)
+	params, err := vectorStoreStringMap(store["litellm_params"], types.MapNull(types.StringType), false, false, "litellm_params")
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid Vector Store Response", err.Error())
+		return
 	}
-	if credName, ok := result["litellm_credential_name"].(string); ok {
-		data.LiteLLMCredentialName = types.StringValue(credName)
-	}
-	if createdAt, ok := result["created_at"].(string); ok {
-		data.CreatedAt = types.StringValue(createdAt)
-	}
-	if updatedAt, ok := result["updated_at"].(string); ok {
-		data.UpdatedAt = types.StringValue(updatedAt)
-	}
-
-	// Handle vector_store_metadata
-	if metadata, ok := result["vector_store_metadata"].(map[string]interface{}); ok {
-		metaMap := make(map[string]attr.Value)
-		for k, v := range metadata {
-			if str, ok := v.(string); ok {
-				metaMap[k] = types.StringValue(str)
-			}
-		}
-		data.VectorStoreMetadata, _ = types.MapValue(types.StringType, metaMap)
-	} else {
-		data.VectorStoreMetadata, _ = types.MapValue(types.StringType, map[string]attr.Value{})
-	}
-
-	// Handle litellm_params
-	if params, ok := result["litellm_params"].(map[string]interface{}); ok {
-		paramsMap := make(map[string]attr.Value)
-		for k, v := range params {
-			if str, ok := v.(string); ok {
-				paramsMap[k] = types.StringValue(str)
-			}
-		}
-		data.LiteLLMParams, _ = types.MapValue(types.StringType, paramsMap)
-	} else {
-		data.LiteLLMParams, _ = types.MapValue(types.StringType, map[string]attr.Value{})
-	}
-
+	data.VectorStoreMetadata = metadata
+	data.LiteLLMParams = params
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/provider/read_test.go
+++ b/internal/provider/read_test.go
@@ -627,7 +627,7 @@ func TestReadVectorStore(t *testing.T) {
 
 	r := &VectorStoreResource{client: client}
 	data := &VectorStoreResourceModel{VectorStoreID: types.StringValue("vs-1")}
-	if err := r.readVectorStore(context.Background(), data); err != nil {
+	if err := r.readVectorStore(context.Background(), data, false, false); err != nil {
 		t.Fatalf("readVectorStore: %v", err)
 	}
 

--- a/internal/provider/resource_vector_store.go
+++ b/internal/provider/resource_vector_store.go
@@ -3,6 +3,9 @@ package provider
 import (
 	"context"
 	"fmt"
+	"reflect"
+	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -16,6 +19,9 @@ import (
 
 var _ resource.Resource = &VectorStoreResource{}
 var _ resource.ResourceWithImportState = &VectorStoreResource{}
+var _ resource.ResourceWithModifyPlan = &VectorStoreResource{}
+
+const vectorStoreImportedPrivateKey = "vector_store_imported_v1"
 
 func NewVectorStoreResource() resource.Resource {
 	return &VectorStoreResource{}
@@ -26,15 +32,19 @@ type VectorStoreResource struct {
 }
 
 type VectorStoreResourceModel struct {
-	ID                     types.String `tfsdk:"id"`
-	VectorStoreID          types.String `tfsdk:"vector_store_id"`
-	VectorStoreName        types.String `tfsdk:"vector_store_name"`
-	CustomLLMProvider      types.String `tfsdk:"custom_llm_provider"`
-	VectorStoreDescription types.String `tfsdk:"vector_store_description"`
-	VectorStoreMetadata    types.Map    `tfsdk:"vector_store_metadata"`
-	LiteLLMCredentialName  types.String `tfsdk:"litellm_credential_name"`
-	LiteLLMParams          types.Map    `tfsdk:"litellm_params"`
-	CreatedAt              types.String `tfsdk:"created_at"`
+	ID                               types.String `tfsdk:"id"`
+	VectorStoreID                    types.String `tfsdk:"vector_store_id"`
+	VectorStoreName                  types.String `tfsdk:"vector_store_name"`
+	CustomLLMProvider                types.String `tfsdk:"custom_llm_provider"`
+	VectorStoreDescription           types.String `tfsdk:"vector_store_description"`
+	VectorStoreMetadata              types.Map    `tfsdk:"vector_store_metadata"`
+	LiteLLMCredentialName            types.String `tfsdk:"litellm_credential_name"`
+	LiteLLMParams                    types.Map    `tfsdk:"litellm_params"`
+	CreatedAt                        types.String `tfsdk:"created_at"`
+	VectorStoreDescriptionConfigured types.Bool   `tfsdk:"vector_store_description_configured"`
+	VectorStoreMetadataConfigured    types.Bool   `tfsdk:"vector_store_metadata_configured"`
+	LiteLLMCredentialNameConfigured  types.Bool   `tfsdk:"litellm_credential_name_configured"`
+	LiteLLMParamsConfigured          types.Bool   `tfsdk:"litellm_params_configured"`
 }
 
 func (r *VectorStoreResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -70,6 +80,7 @@ func (r *VectorStoreResource) Schema(ctx context.Context, req resource.SchemaReq
 			"vector_store_description": schema.StringAttribute{
 				Description: "Description of the vector store.",
 				Optional:    true,
+				Computed:    true,
 			},
 			"vector_store_metadata": schema.MapAttribute{
 				Description: "Metadata associated with the vector store.",
@@ -78,13 +89,15 @@ func (r *VectorStoreResource) Schema(ctx context.Context, req resource.SchemaReq
 				ElementType: types.StringType,
 			},
 			"litellm_credential_name": schema.StringAttribute{
-				Description: "Name of the LiteLLM credential to use.",
-				Optional:    true,
-			},
-			"litellm_params": schema.MapAttribute{
-				Description: "Additional LiteLLM parameters.",
+				Description: "Name of the LiteLLM credential to use. Changes require replacement because LiteLLM v1.98 does not accept this field on update.",
 				Optional:    true,
 				Computed:    true,
+			},
+			"litellm_params": schema.MapAttribute{
+				Description: "Additional LiteLLM parameters. Changes require replacement because LiteLLM v1.98 does not accept this field on update.",
+				Optional:    true,
+				Computed:    true,
+				Sensitive:   true,
 				ElementType: types.StringType,
 			},
 			"created_at": schema.StringAttribute{
@@ -93,6 +106,22 @@ func (r *VectorStoreResource) Schema(ctx context.Context, req resource.SchemaReq
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
+			},
+			"vector_store_description_configured": schema.BoolAttribute{
+				Description: "Internal ownership marker for vector_store_description.",
+				Computed:    true,
+			},
+			"vector_store_metadata_configured": schema.BoolAttribute{
+				Description: "Internal ownership marker for vector_store_metadata.",
+				Computed:    true,
+			},
+			"litellm_credential_name_configured": schema.BoolAttribute{
+				Description: "Internal ownership marker for litellm_credential_name.",
+				Computed:    true,
+			},
+			"litellm_params_configured": schema.BoolAttribute{
+				Description: "Internal ownership marker for litellm_params.",
+				Computed:    true,
 			},
 		},
 	}
@@ -115,13 +144,99 @@ func (r *VectorStoreResource) Configure(ctx context.Context, req resource.Config
 	r.client = client
 }
 
-func (r *VectorStoreResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var data VectorStoreResourceModel
+func vectorStoreFieldConfigured(value types.Bool, fallback bool) bool {
+	if value.IsNull() || value.IsUnknown() {
+		return fallback
+	}
+	return value.ValueBool()
+}
 
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+func (r *VectorStoreResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.Plan.Raw.IsNull() || req.State.Raw.IsNull() {
+		return
+	}
+	var plan, state, config VectorStoreResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	descriptionConfigured := vectorStoreFieldConfigured(state.VectorStoreDescriptionConfigured, !state.VectorStoreDescription.IsNull() && !state.VectorStoreDescription.IsUnknown())
+	metadataConfigured := vectorStoreFieldConfigured(state.VectorStoreMetadataConfigured, !state.VectorStoreMetadata.IsNull() && !state.VectorStoreMetadata.IsUnknown())
+	credentialConfigured := vectorStoreFieldConfigured(state.LiteLLMCredentialNameConfigured, !state.LiteLLMCredentialName.IsNull() && !state.LiteLLMCredentialName.IsUnknown())
+	paramsConfigured := vectorStoreFieldConfigured(state.LiteLLMParamsConfigured, !state.LiteLLMParams.IsNull() && !state.LiteLLMParams.IsUnknown())
+
+	if config.VectorStoreDescription.IsNull() {
+		if descriptionConfigured {
+			plan.VectorStoreDescription = types.StringNull()
+		} else {
+			plan.VectorStoreDescription = state.VectorStoreDescription
+		}
+		plan.VectorStoreDescriptionConfigured = types.BoolValue(false)
+	} else if !config.VectorStoreDescription.IsUnknown() {
+		plan.VectorStoreDescriptionConfigured = types.BoolValue(true)
+	}
+
+	if config.VectorStoreMetadata.IsNull() {
+		if metadataConfigured {
+			plan.VectorStoreMetadata = types.MapNull(types.StringType)
+		} else {
+			plan.VectorStoreMetadata = state.VectorStoreMetadata
+		}
+	} else if !config.VectorStoreMetadata.IsUnknown() {
+		plan.VectorStoreMetadataConfigured = types.BoolValue(true)
+	}
+	if config.VectorStoreMetadata.IsNull() {
+		plan.VectorStoreMetadataConfigured = types.BoolValue(false)
+	}
+
+	if config.LiteLLMCredentialName.IsNull() {
+		if credentialConfigured && !state.LiteLLMCredentialName.IsNull() && !state.LiteLLMCredentialName.IsUnknown() {
+			plan.LiteLLMCredentialName = types.StringUnknown()
+			resp.RequiresReplace = append(resp.RequiresReplace, path.Root("litellm_credential_name"))
+		} else {
+			plan.LiteLLMCredentialName = state.LiteLLMCredentialName
+		}
+		plan.LiteLLMCredentialNameConfigured = types.BoolValue(false)
+	} else if !config.LiteLLMCredentialName.IsUnknown() {
+		plan.LiteLLMCredentialNameConfigured = types.BoolValue(true)
+		if !config.LiteLLMCredentialName.Equal(state.LiteLLMCredentialName) {
+			resp.RequiresReplace = append(resp.RequiresReplace, path.Root("litellm_credential_name"))
+		}
+	}
+
+	if config.LiteLLMParams.IsNull() {
+		if paramsConfigured && !state.LiteLLMParams.IsNull() && !state.LiteLLMParams.IsUnknown() {
+			plan.LiteLLMParams = types.MapUnknown(types.StringType)
+			resp.RequiresReplace = append(resp.RequiresReplace, path.Root("litellm_params"))
+		} else {
+			plan.LiteLLMParams = state.LiteLLMParams
+		}
+		plan.LiteLLMParamsConfigured = types.BoolValue(false)
+	} else if !config.LiteLLMParams.IsUnknown() {
+		plan.LiteLLMParamsConfigured = types.BoolValue(true)
+		if !config.LiteLLMParams.Equal(state.LiteLLMParams) {
+			resp.RequiresReplace = append(resp.RequiresReplace, path.Root("litellm_params"))
+		}
+	}
+
+	resp.Diagnostics.Append(resp.Plan.Set(ctx, &plan)...)
+}
+
+func (r *VectorStoreResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data, config VectorStoreResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	data.VectorStoreDescriptionConfigured = types.BoolValue(!config.VectorStoreDescription.IsNull() && !config.VectorStoreDescription.IsUnknown())
+	data.VectorStoreMetadataConfigured = types.BoolValue(!config.VectorStoreMetadata.IsNull() && !config.VectorStoreMetadata.IsUnknown())
+	data.LiteLLMCredentialNameConfigured = types.BoolValue(!config.LiteLLMCredentialName.IsNull() && !config.LiteLLMCredentialName.IsUnknown())
+	data.LiteLLMParamsConfigured = types.BoolValue(!config.LiteLLMParams.IsNull() && !config.LiteLLMParams.IsUnknown())
 
 	// Generate a UUID for vector_store_id if not already set
 	vsID := uuid.New().String()
@@ -132,14 +247,17 @@ func (r *VectorStoreResource) Create(ctx context.Context, req resource.CreateReq
 	vsReq["vector_store_id"] = vsID
 
 	var result map[string]interface{}
-	if err := r.client.DoRequestWithResponse(ctx, "POST", "/vector_store/new", vsReq, &result); err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create vector store: %s", err))
+	mutationErr := r.client.DoRequestWithResponse(ctx, "POST", "/vector_store/new", vsReq, &result)
+	if err := r.readVectorStoreAfterCreate(ctx, &data, data, 16); err != nil {
+		if mutationErr != nil {
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create or recover vector store after LiteLLM returned an error: %s", mutationErr))
+		} else {
+			resp.Diagnostics.AddError("Vector Store Create Not Confirmed", fmt.Sprintf("LiteLLM accepted the create but stable reads did not confirm the resource: %s", err))
+		}
 		return
 	}
-
-	// Read back for full state including the actual vector_store_id
-	if err := r.readVectorStore(ctx, &data); err != nil {
-		resp.Diagnostics.AddWarning("Read Error", fmt.Sprintf("Vector store created but failed to read back: %s", err))
+	if mutationErr != nil {
+		resp.Diagnostics.AddWarning("Vector Store Create Recovered", "LiteLLM returned an error after creation, but stable identity and configuration reads confirmed the created vector store.")
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -153,7 +271,13 @@ func (r *VectorStoreResource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
-	if err := r.readVectorStore(ctx, &data); err != nil {
+	importedMarker, privateDiags := req.Private.GetKey(ctx, vectorStoreImportedPrivateKey)
+	resp.Diagnostics.Append(privateDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	imported := string(importedMarker) == "true"
+	if err := r.readVectorStore(ctx, &data, imported, false); err != nil {
 		if IsNotFoundError(err) {
 			resp.State.RemoveResource(ctx)
 			return
@@ -163,15 +287,23 @@ func (r *VectorStoreResource) Read(ctx context.Context, req resource.ReadRequest
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	if imported && !resp.Diagnostics.HasError() && resp.Private != nil {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, vectorStoreImportedPrivateKey, nil)...)
+	}
 }
 
 func (r *VectorStoreResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var data VectorStoreResourceModel
+	var data, config VectorStoreResourceModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	data.VectorStoreDescriptionConfigured = types.BoolValue(!config.VectorStoreDescription.IsNull() && !config.VectorStoreDescription.IsUnknown())
+	data.VectorStoreMetadataConfigured = types.BoolValue(!config.VectorStoreMetadata.IsNull() && !config.VectorStoreMetadata.IsUnknown())
+	data.LiteLLMCredentialNameConfigured = types.BoolValue(!config.LiteLLMCredentialName.IsNull() && !config.LiteLLMCredentialName.IsUnknown())
+	data.LiteLLMParamsConfigured = types.BoolValue(!config.LiteLLMParams.IsNull() && !config.LiteLLMParams.IsUnknown())
 
 	var state VectorStoreResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
@@ -183,17 +315,23 @@ func (r *VectorStoreResource) Update(ctx context.Context, req resource.UpdateReq
 	data.ID = state.ID
 	data.VectorStoreID = state.VectorStoreID
 
-	vsReq := r.buildVectorStoreRequest(ctx, &data)
-	vsReq["vector_store_id"] = data.VectorStoreID.ValueString()
+	planned := data
+	vsReq := r.buildVectorStoreUpdateRequest(ctx, &data, &state)
+	mutationErr := r.client.DoRequestWithResponse(ctx, "POST", "/vector_store/update", vsReq, nil)
 
-	if err := r.client.DoRequestWithResponse(ctx, "POST", "/vector_store/update", vsReq, nil); err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update vector store: %s", err))
+	// The v1.98 endpoint can persist a mutation and then return an error while
+	// synchronizing its process-local registry. Recover only after stable reads
+	// prove the complete planned update.
+	if err := r.readVectorStoreAfterUpdate(ctx, &data, planned, state, 24); err != nil {
+		if mutationErr != nil {
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to confirm vector store update after LiteLLM returned an error: %s", mutationErr))
+		} else {
+			resp.Diagnostics.AddError("Vector Store Update Not Confirmed", fmt.Sprintf("LiteLLM accepted the update but stable fresh-worker reads did not return the planned values; Terraform retained prior state: %s", err))
+		}
 		return
 	}
-
-	// Read back for full state
-	if err := r.readVectorStore(ctx, &data); err != nil {
-		resp.Diagnostics.AddWarning("Read Error", fmt.Sprintf("Vector store updated but failed to read back: %s", err))
+	if mutationErr != nil {
+		resp.Diagnostics.AddWarning("Vector Store Update Recovered", "LiteLLM returned an error after the vector store mutation, but stable authoritative reads confirmed the complete planned state.")
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -217,16 +355,26 @@ func (r *VectorStoreResource) Delete(ctx context.Context, req resource.DeleteReq
 	}
 
 	if err := r.client.DoRequestWithResponse(ctx, "POST", "/vector_store/delete", deleteReq, nil); err != nil {
-		if !IsNotFoundError(err) {
-			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete vector store: %s", err))
+		if IsNotFoundError(err) {
 			return
 		}
+		probe := data
+		probeErr := r.readVectorStore(ctx, &probe, false, true)
+		if IsNotFoundError(probeErr) {
+			resp.Diagnostics.AddWarning("Vector Store Delete Recovered", "LiteLLM returned an error after deletion, but an authoritative fresh read confirmed the vector store is absent.")
+			return
+		}
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete vector store: %s", err))
+		return
 	}
 }
 
 func (r *VectorStoreResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("vector_store_id"), req.ID)...)
+	if resp.Private != nil {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, vectorStoreImportedPrivateKey, []byte("true"))...)
+	}
 }
 
 func (r *VectorStoreResource) buildVectorStoreRequest(ctx context.Context, data *VectorStoreResourceModel) map[string]interface{} {
@@ -236,11 +384,11 @@ func (r *VectorStoreResource) buildVectorStoreRequest(ctx context.Context, data 
 	}
 
 	// String fields - check IsNull, IsUnknown, and empty string
-	if !data.VectorStoreDescription.IsNull() && !data.VectorStoreDescription.IsUnknown() && data.VectorStoreDescription.ValueString() != "" {
+	if !data.VectorStoreDescription.IsNull() && !data.VectorStoreDescription.IsUnknown() {
 		vsReq["vector_store_description"] = data.VectorStoreDescription.ValueString()
 	}
 
-	if !data.LiteLLMCredentialName.IsNull() && !data.LiteLLMCredentialName.IsUnknown() && data.LiteLLMCredentialName.ValueString() != "" {
+	if !data.LiteLLMCredentialName.IsNull() && !data.LiteLLMCredentialName.IsUnknown() {
 		vsReq["litellm_credential_name"] = data.LiteLLMCredentialName.ValueString()
 	}
 
@@ -279,7 +427,142 @@ func (r *VectorStoreResource) buildVectorStoreRequest(ctx context.Context, data 
 	return vsReq
 }
 
-func (r *VectorStoreResource) readVectorStore(ctx context.Context, data *VectorStoreResourceModel) error {
+func (r *VectorStoreResource) buildVectorStoreUpdateRequest(ctx context.Context, data, prior *VectorStoreResourceModel) map[string]interface{} {
+	request := map[string]interface{}{
+		"vector_store_id":     data.VectorStoreID.ValueString(),
+		"vector_store_name":   data.VectorStoreName.ValueString(),
+		"custom_llm_provider": data.CustomLLMProvider.ValueString(),
+	}
+	if data.VectorStoreDescription.IsNull() {
+		if !prior.VectorStoreDescription.IsNull() && !prior.VectorStoreDescription.IsUnknown() {
+			request["vector_store_description"] = ""
+		}
+	} else if !data.VectorStoreDescription.IsUnknown() {
+		request["vector_store_description"] = data.VectorStoreDescription.ValueString()
+	}
+	if data.VectorStoreMetadata.IsNull() {
+		if !prior.VectorStoreMetadata.IsNull() && !prior.VectorStoreMetadata.IsUnknown() {
+			request["vector_store_metadata"] = map[string]string{}
+		}
+	} else if !data.VectorStoreMetadata.IsUnknown() {
+		metadata := map[string]string{}
+		data.VectorStoreMetadata.ElementsAs(ctx, &metadata, false)
+		request["vector_store_metadata"] = metadata
+	}
+	return request
+}
+
+func vectorStoreCreateMatches(planned, observed VectorStoreResourceModel) bool {
+	for _, pair := range [][2]attr.Value{
+		{planned.VectorStoreID, observed.VectorStoreID},
+		{planned.VectorStoreName, observed.VectorStoreName},
+		{planned.CustomLLMProvider, observed.CustomLLMProvider},
+		{planned.VectorStoreDescription, observed.VectorStoreDescription},
+		{planned.VectorStoreMetadata, observed.VectorStoreMetadata},
+		{planned.LiteLLMCredentialName, observed.LiteLLMCredentialName},
+		{planned.LiteLLMParams, observed.LiteLLMParams},
+	} {
+		if !pair[0].IsUnknown() && !pair[0].Equal(pair[1]) {
+			return false
+		}
+	}
+	return true
+}
+
+func (r *VectorStoreResource) readVectorStoreAfterCreate(ctx context.Context, data *VectorStoreResourceModel, planned VectorStoreResourceModel, attempts int) error {
+	stable := 0
+	var lastErr error
+	for attempt := 0; attempt < attempts; attempt++ {
+		candidate := planned
+		if err := r.readVectorStore(ctx, &candidate, false, true); err != nil {
+			lastErr = err
+			stable = 0
+		} else if !vectorStoreCreateMatches(planned, candidate) {
+			lastErr = fmt.Errorf("created vector store did not match its planned configuration")
+			stable = 0
+		} else {
+			stable++
+			if stable >= 2 {
+				*data = candidate
+				return nil
+			}
+		}
+		if attempt+1 < attempts {
+			timer := time.NewTimer(250 * time.Millisecond)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return ctx.Err()
+			case <-timer.C:
+			}
+		}
+	}
+	if lastErr == nil {
+		lastErr = fmt.Errorf("created vector store was not observed")
+	}
+	return lastErr
+}
+
+func vectorStoreChangedFieldsNotConverged(planned, prior, observed VectorStoreResourceModel) []string {
+	plannedValue, priorValue, observedValue := reflect.ValueOf(planned), reflect.ValueOf(prior), reflect.ValueOf(observed)
+	modelType := plannedValue.Type()
+	var stale []string
+	for i := 0; i < plannedValue.NumField(); i++ {
+		plannedAttr, plannedOK := plannedValue.Field(i).Interface().(attr.Value)
+		priorAttr, priorOK := priorValue.Field(i).Interface().(attr.Value)
+		observedAttr, observedOK := observedValue.Field(i).Interface().(attr.Value)
+		if !plannedOK || !priorOK || !observedOK || plannedAttr.IsUnknown() || plannedAttr.Equal(priorAttr) {
+			continue
+		}
+		if !plannedAttr.Equal(observedAttr) {
+			stale = append(stale, modelType.Field(i).Tag.Get("tfsdk"))
+		}
+	}
+	return stale
+}
+
+func (r *VectorStoreResource) readVectorStoreAfterUpdate(ctx context.Context, data *VectorStoreResourceModel, planned, prior VectorStoreResourceModel, attempts int) error {
+	stable := 0
+	var stale []string
+	for attempt := 0; attempt < attempts; attempt++ {
+		candidate := planned
+		if err := r.readVectorStore(ctx, &candidate, false, true); err != nil {
+			stale = []string{err.Error()}
+			stable = 0
+		} else if fields := vectorStoreChangedFieldsNotConverged(planned, prior, candidate); len(fields) > 0 {
+			stale = fields
+			stable = 0
+		} else {
+			stable++
+			if stable >= 2 {
+				*data = candidate
+				return nil
+			}
+		}
+		if attempt+1 < attempts {
+			timer := time.NewTimer(250 * time.Millisecond)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return ctx.Err()
+			case <-timer.C:
+			}
+		}
+	}
+	return fmt.Errorf("fields did not converge after %d reads: %s", attempts, strings.Join(stale, ", "))
+}
+
+func (r *VectorStoreResource) readVectorStore(ctx context.Context, data *VectorStoreResourceModel, imported, fresh bool) error {
+	descriptionConfigured := vectorStoreFieldConfigured(data.VectorStoreDescriptionConfigured, !imported && !data.VectorStoreDescription.IsNull() && !data.VectorStoreDescription.IsUnknown())
+	metadataConfigured := vectorStoreFieldConfigured(data.VectorStoreMetadataConfigured, !imported && !data.VectorStoreMetadata.IsNull() && !data.VectorStoreMetadata.IsUnknown())
+	credentialConfigured := vectorStoreFieldConfigured(data.LiteLLMCredentialNameConfigured, !imported && !data.LiteLLMCredentialName.IsNull() && !data.LiteLLMCredentialName.IsUnknown())
+	paramsConfigured := vectorStoreFieldConfigured(data.LiteLLMParamsConfigured, !imported && !data.LiteLLMParams.IsNull() && !data.LiteLLMParams.IsUnknown())
+	if imported {
+		descriptionConfigured, metadataConfigured, credentialConfigured, paramsConfigured = false, false, false, false
+	}
+	priorParams := data.LiteLLMParams
+	priorMetadata := data.VectorStoreMetadata
+
 	vectorStoreID := data.VectorStoreID.ValueString()
 	if vectorStoreID == "" {
 		vectorStoreID = data.ID.ValueString()
@@ -290,78 +573,68 @@ func (r *VectorStoreResource) readVectorStore(ctx context.Context, data *VectorS
 	}
 
 	var result map[string]interface{}
-	if err := r.client.DoRequestWithResponse(ctx, "POST", "/vector_store/info", infoReq, &result); err != nil {
+	var err error
+	if fresh {
+		err = r.client.doFreshRequestWithResponse(ctx, "POST", "/vector_store/info", infoReq, &result)
+	} else {
+		err = r.client.DoRequestWithResponse(ctx, "POST", "/vector_store/info", infoReq, &result)
+	}
+	if err != nil {
 		return err
 	}
 
-	// Unwrap nested response - API returns {"vector_store": {...}}
-	if nested, ok := result["vector_store"].(map[string]interface{}); ok {
-		result = nested
+	store, err := unwrapVectorStoreResponse(result, vectorStoreID)
+	if err != nil {
+		return err
 	}
+	name, nameOK := store["vector_store_name"].(string)
+	provider, providerOK := store["custom_llm_provider"].(string)
+	if !nameOK || name == "" || !providerOK || provider == "" {
+		return fmt.Errorf("vector store response is missing required name or provider identity")
+	}
+	data.VectorStoreID = types.StringValue(vectorStoreID)
+	data.ID = types.StringValue(vectorStoreID)
+	data.VectorStoreName = types.StringValue(name)
+	data.CustomLLMProvider = types.StringValue(provider)
 
-	// Update fields from response
-	if vsID, ok := result["vector_store_id"].(string); ok {
-		data.VectorStoreID = types.StringValue(vsID)
-		data.ID = types.StringValue(vsID)
+	if description, ok := store["vector_store_description"].(string); ok && (description != "" || descriptionConfigured) {
+		data.VectorStoreDescription = types.StringValue(description)
+	} else {
+		data.VectorStoreDescription = types.StringNull()
 	}
-	if vsName, ok := result["vector_store_name"].(string); ok {
-		data.VectorStoreName = types.StringValue(vsName)
+	if credential, ok := store["litellm_credential_name"].(string); ok && (credential != "" || credentialConfigured) {
+		data.LiteLLMCredentialName = types.StringValue(credential)
+	} else {
+		data.LiteLLMCredentialName = types.StringNull()
 	}
-	if provider, ok := result["custom_llm_provider"].(string); ok {
-		data.CustomLLMProvider = types.StringValue(provider)
-	}
-	if desc, ok := result["vector_store_description"].(string); ok {
-		data.VectorStoreDescription = types.StringValue(desc)
-	}
-	if credName, ok := result["litellm_credential_name"].(string); ok {
-		data.LiteLLMCredentialName = types.StringValue(credName)
-	}
-	if createdAt, ok := result["created_at"].(string); ok {
+	if createdAt, ok := store["created_at"].(string); ok && createdAt != "" {
 		data.CreatedAt = types.StringValue(createdAt)
-	}
-	// Handle vector_store_metadata - preserve null when API returns empty and config didn't specify
-	if metadata, ok := result["vector_store_metadata"].(map[string]interface{}); ok && len(metadata) > 0 {
-		metaMap := make(map[string]attr.Value)
-		for k, v := range metadata {
-			if str, ok := v.(string); ok {
-				metaMap[k] = types.StringValue(str)
-			}
-		}
-		data.VectorStoreMetadata, _ = types.MapValue(types.StringType, metaMap)
-	} else if data.VectorStoreMetadata.IsUnknown() {
-		data.VectorStoreMetadata, _ = types.MapValue(types.StringType, map[string]attr.Value{})
+	} else {
+		data.CreatedAt = types.StringNull()
 	}
 
-	// Handle litellm_params - filter out server-injected keys, only keep user-configured keys
-	if params, ok := result["litellm_params"].(map[string]interface{}); ok && len(params) > 0 {
-		// Build set of user-configured keys
-		userKeys := make(map[string]bool)
-		if !data.LiteLLMParams.IsNull() && !data.LiteLLMParams.IsUnknown() {
-			var existingParams map[string]string
-			data.LiteLLMParams.ElementsAs(ctx, &existingParams, false)
-			for k := range existingParams {
-				userKeys[k] = true
-			}
-		}
+	metadata, err := vectorStoreStringMap(store["vector_store_metadata"], priorMetadata, false, false, "vector_store_metadata")
+	if err != nil {
+		return err
+	}
+	if !metadataConfigured && len(metadata.Elements()) == 0 {
+		data.VectorStoreMetadata = types.MapNull(types.StringType)
+	} else {
+		data.VectorStoreMetadata = metadata
+	}
 
-		paramsMap := make(map[string]attr.Value)
-		for k, v := range params {
-			// Only include keys the user originally configured
-			if len(userKeys) > 0 && !userKeys[k] {
-				continue
-			}
-			if str, ok := v.(string); ok {
-				paramsMap[k] = types.StringValue(str)
-			}
-		}
-		if len(paramsMap) > 0 {
-			data.LiteLLMParams, _ = types.MapValue(types.StringType, paramsMap)
-		} else if data.LiteLLMParams.IsUnknown() {
-			data.LiteLLMParams = types.MapNull(types.StringType)
-		}
-	} else if data.LiteLLMParams.IsUnknown() {
+	params, err := vectorStoreStringMap(store["litellm_params"], priorParams, paramsConfigured, true, "litellm_params")
+	if err != nil {
+		return err
+	}
+	if !paramsConfigured && len(params.Elements()) == 0 {
 		data.LiteLLMParams = types.MapNull(types.StringType)
+	} else {
+		data.LiteLLMParams = params
 	}
-
+	data.VectorStoreDescriptionConfigured = types.BoolValue(descriptionConfigured)
+	data.VectorStoreMetadataConfigured = types.BoolValue(metadataConfigured)
+	data.LiteLLMCredentialNameConfigured = types.BoolValue(credentialConfigured)
+	data.LiteLLMParamsConfigured = types.BoolValue(paramsConfigured)
 	return nil
 }

--- a/internal/provider/vector_store_contract_test.go
+++ b/internal/provider/vector_store_contract_test.go
@@ -1,0 +1,131 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestVectorStoreUpdateRequestUsesOnlyV198UpdateFieldsAndClearSentinels(t *testing.T) {
+	t.Parallel()
+	resource := &VectorStoreResource{}
+	prior := VectorStoreResourceModel{
+		VectorStoreID:          types.StringValue("vs-1"),
+		VectorStoreName:        types.StringValue("before"),
+		CustomLLMProvider:      types.StringValue("bedrock"),
+		VectorStoreDescription: types.StringValue("description"),
+		VectorStoreMetadata: types.MapValueMust(types.StringType, map[string]attr.Value{
+			"environment": types.StringValue("prod"),
+		}),
+		LiteLLMCredentialName: types.StringValue("credential"),
+		LiteLLMParams: types.MapValueMust(types.StringType, map[string]attr.Value{
+			"api_key": types.StringValue("secret"),
+		}),
+	}
+	planned := prior
+	planned.VectorStoreName = types.StringValue("after")
+	planned.VectorStoreDescription = types.StringNull()
+	planned.VectorStoreMetadata = types.MapNull(types.StringType)
+	request := resource.buildVectorStoreUpdateRequest(context.Background(), &planned, &prior)
+	if request["vector_store_description"] != "" {
+		t.Fatalf("description clear sentinel = %#v", request["vector_store_description"])
+	}
+	metadata, ok := request["vector_store_metadata"].(map[string]string)
+	if !ok || len(metadata) != 0 {
+		t.Fatalf("metadata clear sentinel = %#v", request["vector_store_metadata"])
+	}
+	for _, unsupported := range []string{"litellm_credential_name", "litellm_params"} {
+		if _, present := request[unsupported]; present {
+			t.Errorf("unsupported update field %s was sent", unsupported)
+		}
+	}
+}
+
+func TestReadVectorStorePreservesOwnedMaskedParametersAndRejectsMaskedImport(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(writer).Encode(map[string]interface{}{
+			"vector_store": map[string]interface{}{
+				"vector_store_id":     "vs-1",
+				"vector_store_name":   "store",
+				"custom_llm_provider": "bedrock",
+				"litellm_params": map[string]interface{}{
+					"api_key": "REDACTED_BY_LITELM",
+					"nested":  map[string]interface{}{"api_key": "REDACTED_BY_LITELM", "region": "us-east-1"},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+	client := &Client{APIBase: server.URL, APIKey: "test", HTTPClient: server.Client()}
+	prior := types.MapValueMust(types.StringType, map[string]attr.Value{
+		"api_key": types.StringValue("secret"),
+		"nested":  types.StringValue(`{"api_key":"nested-secret","region":"us-east-1"}`),
+	})
+	data := &VectorStoreResourceModel{
+		VectorStoreID:           types.StringValue("vs-1"),
+		LiteLLMParams:           prior,
+		LiteLLMParamsConfigured: types.BoolValue(true),
+	}
+	if err := (&VectorStoreResource{client: client}).readVectorStore(context.Background(), data, false, false); err != nil {
+		t.Fatal(err)
+	}
+	if !data.LiteLLMParams.Equal(prior) {
+		t.Fatalf("masked parameters changed state: %#v", data.LiteLLMParams)
+	}
+
+	imported := &VectorStoreResourceModel{VectorStoreID: types.StringValue("vs-1"), LiteLLMParams: types.MapNull(types.StringType)}
+	if err := (&VectorStoreResource{client: client}).readVectorStore(context.Background(), imported, true, false); err == nil {
+		t.Fatal("masked import without prior values was accepted")
+	}
+}
+
+func TestVectorStoreStringMapPreservesOnlyMaskedLeaves(t *testing.T) {
+	t.Parallel()
+	prior := types.MapValueMust(types.StringType, map[string]attr.Value{
+		"nested": types.StringValue(`{"api_key":"secret","region":"us-east-1"}`),
+	})
+	value, err := vectorStoreStringMap(map[string]interface{}{
+		"nested": map[string]interface{}{"api_key": "REDACTED_BY_LITELM", "region": "us-west-2"},
+	}, prior, true, true, "litellm_params")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := value.Elements()["nested"].(types.String).ValueString()
+	if got != `{"api_key":"secret","region":"us-west-2"}` {
+		t.Fatalf("leaf-aware masked merge = %s", got)
+	}
+}
+
+func TestVectorStoreStringMapCanonicalizesStructuredValues(t *testing.T) {
+	t.Parallel()
+	value, err := vectorStoreStringMap(map[string]interface{}{
+		"nested": map[string]interface{}{"b": json.Number("2"), "a": true},
+	}, types.MapNull(types.StringType), false, false, "vector_store_metadata")
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := value.Elements()["nested"].(types.String).ValueString()
+	if text != `{"a":true,"b":2}` {
+		t.Fatalf("canonical nested value = %s", text)
+	}
+}
+
+func TestUnwrapVectorStoreResponseRejectsMissingMalformedAndMismatchedEnvelopes(t *testing.T) {
+	t.Parallel()
+	for _, result := range []map[string]interface{}{
+		{},
+		{"vector_store": "invalid"},
+		{"vector_store": map[string]interface{}{"vector_store_id": "other"}},
+	} {
+		if _, err := unwrapVectorStoreResponse(result, "vs-1"); err == nil {
+			t.Fatalf("invalid response accepted: %#v", result)
+		}
+	}
+}

--- a/internal/provider/vector_store_helpers.go
+++ b/internal/provider/vector_store_helpers.go
@@ -1,0 +1,153 @@
+package provider
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func nullableVectorStoreString(raw interface{}) types.String {
+	if text, ok := raw.(string); ok && text != "" {
+		return types.StringValue(text)
+	}
+	return types.StringNull()
+}
+
+func unwrapVectorStoreResponse(result map[string]interface{}, expectedID string) (map[string]interface{}, error) {
+	raw, present := result["vector_store"]
+	if !present || raw == nil {
+		return nil, fmt.Errorf("vector store response is missing the required vector_store object")
+	}
+	store, ok := raw.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("vector store response field %q must be an object", "vector_store")
+	}
+	id, ok := store["vector_store_id"].(string)
+	if !ok || id == "" {
+		return nil, fmt.Errorf("vector store response is missing a valid vector_store_id")
+	}
+	if expectedID != "" && id != expectedID {
+		return nil, fmt.Errorf("vector store response identity did not match the requested ID")
+	}
+	return store, nil
+}
+
+func vectorStoreObject(raw interface{}, field string) (map[string]interface{}, error) {
+	if raw == nil {
+		return map[string]interface{}{}, nil
+	}
+	if object, ok := raw.(map[string]interface{}); ok {
+		return object, nil
+	}
+	if text, ok := raw.(string); ok {
+		var object map[string]interface{}
+		if err := decodeJSONUseNumber([]byte(text), &object); err != nil || object == nil {
+			return nil, fmt.Errorf("vector store response field %q must be an object", field)
+		}
+		return object, nil
+	}
+	return nil, fmt.Errorf("vector store response field %q must be an object", field)
+}
+
+func restoreVectorStoreMaskedLeaves(remote, prior interface{}, field string) (interface{}, error) {
+	if text, ok := remote.(string); ok && isMaskedAPIString(text) {
+		if prior == nil {
+			return nil, fmt.Errorf("vector store response field %q contains a masked value without prior Terraform state", field)
+		}
+		return prior, nil
+	}
+	switch typed := remote.(type) {
+	case map[string]interface{}:
+		priorMap, ok := prior.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("vector store response field %q changed shape while masked", field)
+		}
+		result := make(map[string]interface{}, len(typed))
+		for key, child := range typed {
+			merged, err := restoreVectorStoreMaskedLeaves(child, priorMap[key], field+"."+key)
+			if err != nil {
+				return nil, err
+			}
+			result[key] = merged
+		}
+		return result, nil
+	case []interface{}:
+		priorList, ok := prior.([]interface{})
+		if !ok || len(priorList) != len(typed) {
+			return nil, fmt.Errorf("vector store response field %q changed shape while masked", field)
+		}
+		result := make([]interface{}, len(typed))
+		for index, child := range typed {
+			merged, err := restoreVectorStoreMaskedLeaves(child, priorList[index], fmt.Sprintf("%s[%d]", field, index))
+			if err != nil {
+				return nil, err
+			}
+			result[index] = merged
+		}
+		return result, nil
+	default:
+		return remote, nil
+	}
+}
+
+func vectorStoreStringMap(raw interface{}, prior types.Map, filterToPrior, rejectUnownedMasks bool, field string) (types.Map, error) {
+	object, err := vectorStoreObject(raw, field)
+	if err != nil {
+		return types.MapNull(types.StringType), err
+	}
+	priorValues := map[string]string{}
+	if !prior.IsNull() && !prior.IsUnknown() {
+		for key, value := range prior.Elements() {
+			if text, ok := value.(types.String); ok && !text.IsNull() && !text.IsUnknown() {
+				priorValues[key] = text.ValueString()
+			}
+		}
+	}
+
+	values := make(map[string]attr.Value)
+	for key, rawValue := range object {
+		priorValue, hasPrior := priorValues[key]
+		if filterToPrior && !hasPrior {
+			continue
+		}
+		masked := containsMaskedValue(rawValue)
+		if masked {
+			if !hasPrior {
+				if rejectUnownedMasks {
+					return types.MapNull(types.StringType), fmt.Errorf("vector store response field %q contains a masked value without prior Terraform state", field+"."+key)
+				}
+			} else if isJSONContainer(rawValue) {
+				var priorJSON interface{}
+				if err := decodeJSONUseNumber([]byte(priorValue), &priorJSON); err != nil {
+					return types.MapNull(types.StringType), fmt.Errorf("vector store response field %q changed shape while masked", field+"."+key)
+				}
+				merged, err := restoreVectorStoreMaskedLeaves(rawValue, priorJSON, field+"."+key)
+				if err != nil {
+					return types.MapNull(types.StringType), err
+				}
+				encoded, _ := json.Marshal(merged)
+				if jsonSemanticallyEqual(priorValue, string(encoded)) {
+					values[key] = types.StringValue(priorValue)
+				} else {
+					values[key] = types.StringValue(string(encoded))
+				}
+				continue
+			} else {
+				values[key] = types.StringValue(priorValue)
+				continue
+			}
+		}
+		value, ok := stringifyAPIValue(rawValue)
+		if !ok {
+			return types.MapNull(types.StringType), fmt.Errorf("vector store response field %q has an unsupported value", field+"."+key)
+		}
+		if hasPrior && jsonSemanticallyEqual(priorValue, value.(types.String).ValueString()) {
+			values[key] = types.StringValue(priorValue)
+		} else {
+			values[key] = value
+		}
+	}
+	return types.MapValueMust(types.StringType, values), nil
+}

--- a/internal/provider/vector_store_protocol_test.go
+++ b/internal/provider/vector_store_protocol_test.go
@@ -1,0 +1,165 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func TestVectorStoreCreateRecoversFromPostMutationErrorProtocol(t *testing.T) {
+	ctx := context.Background()
+	var createdID string
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		switch request.URL.Path {
+		case "/vector_store/new":
+			var body map[string]interface{}
+			if err := json.NewDecoder(request.Body).Decode(&body); err != nil {
+				http.Error(writer, "invalid", http.StatusBadRequest)
+				return
+			}
+			createdID, _ = body["vector_store_id"].(string)
+			http.Error(writer, "simulated response loss", http.StatusInternalServerError)
+		case "/vector_store/info":
+			if createdID == "" {
+				http.NotFound(writer, request)
+				return
+			}
+			_, _ = fmt.Fprintf(writer, `{"vector_store":{"vector_store_id":%q,"vector_store_name":"created","custom_llm_provider":"bedrock","litellm_params":{}}}`, createdID)
+		default:
+			http.NotFound(writer, request)
+		}
+	}))
+	defer server.Close()
+
+	protocolServer, schemas := configuredImportProtocolServer(t, ctx, server.URL)
+	const typeName = "litellm_vector_store"
+	schema := schemas.ResourceSchemas[typeName]
+	configValues := map[string]interface{}{"vector_store_name": "created", "custom_llm_provider": "bedrock"}
+	proposedValues := map[string]interface{}{}
+	for key, value := range configValues {
+		proposedValues[key] = value
+	}
+	for _, key := range []string{"id", "vector_store_id", "vector_store_description", "vector_store_metadata", "litellm_credential_name", "litellm_params", "created_at", "vector_store_description_configured", "vector_store_metadata_configured", "litellm_credential_name_configured", "litellm_params_configured"} {
+		proposedValues[key] = tftypes.UnknownValue
+	}
+	config := accessGroupProtocolDynamicValue(t, schema, organizationProjectProtocolValue(t, schema, configValues))
+	proposed := accessGroupProtocolDynamicValue(t, schema, organizationProjectProtocolValue(t, schema, proposedValues))
+	nullState := accessGroupProtocolDynamicValue(t, schema, tftypes.NewValue(schema.ValueType(), nil))
+	planned, err := protocolServer.PlanResourceChange(ctx, &tfprotov6.PlanResourceChangeRequest{TypeName: typeName, Config: config, PriorState: nullState, ProposedNewState: proposed})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(planned.Diagnostics) {
+		t.Fatalf("create plan: err=%v diagnostics=%v", err, planned.Diagnostics)
+	}
+	applied, err := protocolServer.ApplyResourceChange(ctx, &tfprotov6.ApplyResourceChangeRequest{TypeName: typeName, Config: config, PriorState: nullState, PlannedState: planned.PlannedState, PlannedPrivate: planned.PlannedPrivate})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(applied.Diagnostics) || createdID == "" {
+		t.Fatalf("recovered create: err=%v diagnostics=%v id=%q", err, applied.Diagnostics, createdID)
+	}
+	attributes := protocolAttributeMap(t, schema, applied.NewState)
+	var id string
+	if err := attributes["id"].As(&id); err != nil || id != createdID {
+		t.Fatalf("recovered ID=%q err=%v, want %q", id, err, createdID)
+	}
+}
+
+func TestVectorStoreImportOwnershipAndCreateOnlyReplacementProtocol(t *testing.T) {
+	ctx := context.Background()
+	var updates atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		switch request.URL.Path {
+		case "/vector_store/info":
+			_, _ = fmt.Fprint(writer, `{"vector_store":{"vector_store_id":"vs-import","vector_store_name":"store","custom_llm_provider":"bedrock","vector_store_description":"description","vector_store_metadata":{"environment":"prod"},"litellm_credential_name":"credential","litellm_params":{"api_base":"https://example.invalid"},"created_at":"2026-01-01T00:00:00Z"}}`)
+		case "/vector_store/update":
+			updates.Add(1)
+			var body map[string]interface{}
+			if err := json.NewDecoder(request.Body).Decode(&body); err != nil {
+				http.Error(writer, "invalid", http.StatusBadRequest)
+				return
+			}
+			for _, unsupported := range []string{"litellm_credential_name", "litellm_params"} {
+				if _, present := body[unsupported]; present {
+					t.Errorf("unsupported update field %s was sent", unsupported)
+				}
+			}
+			http.Error(writer, "simulated post-mutation registry failure", http.StatusInternalServerError)
+		default:
+			http.NotFound(writer, request)
+		}
+	}))
+	defer server.Close()
+
+	protocolServer, schemas := configuredImportProtocolServer(t, ctx, server.URL)
+	const typeName = "litellm_vector_store"
+	schema := schemas.ResourceSchemas[typeName]
+	imported, err := protocolServer.ImportResourceState(ctx, &tfprotov6.ImportResourceStateRequest{TypeName: typeName, ID: "vs-import"})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(imported.Diagnostics) || len(imported.ImportedResources) != 1 {
+		t.Fatalf("import: err=%v diagnostics=%v", err, imported.Diagnostics)
+	}
+	read, err := protocolServer.ReadResource(ctx, &tfprotov6.ReadResourceRequest{
+		TypeName: typeName, CurrentState: imported.ImportedResources[0].State, Private: imported.ImportedResources[0].Private,
+	})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(read.Diagnostics) {
+		t.Fatalf("read: err=%v diagnostics=%v", err, read.Diagnostics)
+	}
+
+	baseConfig := map[string]interface{}{"vector_store_name": "store", "custom_llm_provider": "bedrock"}
+	plan := func(values map[string]interface{}, proposed, prior *tfprotov6.DynamicValue, private []byte) *tfprotov6.PlanResourceChangeResponse {
+		t.Helper()
+		config := accessGroupProtocolDynamicValue(t, schema, organizationProjectProtocolValue(t, schema, values))
+		response, planErr := protocolServer.PlanResourceChange(ctx, &tfprotov6.PlanResourceChangeRequest{
+			TypeName: typeName, Config: config, PriorState: prior, ProposedNewState: proposed, PriorPrivate: private,
+		})
+		if planErr != nil {
+			t.Fatal(planErr)
+		}
+		return response
+	}
+
+	omitted := plan(baseConfig, read.NewState, read.NewState, read.Private)
+	if accessGroupProtocolDiagnosticsHaveError(omitted.Diagnostics) || len(omitted.RequiresReplace) != 0 || organizationProjectProtocolPlannedAction(t, schema, read.NewState, omitted) != organizationProjectProtocolActionNoOp {
+		t.Fatalf("import omission: diagnostics=%v replace=%v action=%s", omitted.Diagnostics, omitted.RequiresReplace, organizationProjectProtocolPlannedAction(t, schema, read.NewState, omitted))
+	}
+
+	ownedConfig := map[string]interface{}{
+		"vector_store_name": "store", "custom_llm_provider": "bedrock",
+		"vector_store_description": "description",
+		"vector_store_metadata":    map[string]tftypes.Value{"environment": tftypes.NewValue(tftypes.String, "prod")},
+		"litellm_credential_name":  "credential",
+		"litellm_params":           map[string]tftypes.Value{"api_base": tftypes.NewValue(tftypes.String, "https://example.invalid")},
+	}
+	owned := plan(ownedConfig, read.NewState, read.NewState, read.Private)
+	if accessGroupProtocolDiagnosticsHaveError(owned.Diagnostics) || len(owned.RequiresReplace) != 0 || organizationProjectProtocolPlannedAction(t, schema, read.NewState, owned) != organizationProjectProtocolActionUpdate {
+		t.Fatalf("equal ownership transition: diagnostics=%v replace=%v action=%s", owned.Diagnostics, owned.RequiresReplace, organizationProjectProtocolPlannedAction(t, schema, read.NewState, owned))
+	}
+	config := accessGroupProtocolDynamicValue(t, schema, organizationProjectProtocolValue(t, schema, ownedConfig))
+	applied, err := protocolServer.ApplyResourceChange(ctx, &tfprotov6.ApplyResourceChangeRequest{
+		TypeName: typeName, Config: config, PriorState: read.NewState, PlannedState: owned.PlannedState, PlannedPrivate: owned.PlannedPrivate,
+	})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(applied.Diagnostics) || updates.Load() != 1 {
+		t.Fatalf("ownership apply: err=%v diagnostics=%v updates=%d", err, applied.Diagnostics, updates.Load())
+	}
+
+	removal := plan(baseConfig, applied.NewState, applied.NewState, applied.Private)
+	if accessGroupProtocolDiagnosticsHaveError(removal.Diagnostics) || len(removal.RequiresReplace) < 2 || organizationProjectProtocolPlannedAction(t, schema, applied.NewState, removal) != organizationProjectProtocolActionReplace {
+		t.Fatalf("owned create-only removal: diagnostics=%v replace=%v action=%s", removal.Diagnostics, removal.RequiresReplace, organizationProjectProtocolPlannedAction(t, schema, applied.NewState, removal))
+	}
+
+	dataSourceSchema := schemas.DataSourceSchemas[typeName]
+	dataSourceConfig := accessGroupProtocolDynamicValue(t, dataSourceSchema, organizationProjectProtocolValue(t, dataSourceSchema, map[string]interface{}{"vector_store_id": "vs-import"}))
+	dataSource, err := protocolServer.ReadDataSource(ctx, &tfprotov6.ReadDataSourceRequest{TypeName: typeName, Config: dataSourceConfig})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(dataSource.Diagnostics) {
+		t.Fatalf("data source read: err=%v diagnostics=%v", err, dataSource.Diagnostics)
+	}
+	attributes := protocolAttributeMap(t, dataSourceSchema, dataSource.State)
+	var name string
+	if err := attributes["vector_store_name"].As(&name); err != nil || name != "store" {
+		t.Fatalf("nested data source name = %q, err=%v", name, err)
+	}
+}


### PR DESCRIPTION
### Summary

Closes #191. Vector-store lifecycle handling now follows LiteLLM v1.98's actual request and response contracts instead of sending fields the update model silently ignores or writing redaction markers into Terraform state.

`litellm_credential_name` and `litellm_params` are create-only and use replacement for real changes or removal. Description and metadata updates remain in place, with endpoint-proven empty-string and empty-map clears. Imported optional fields remain unmanaged until explicitly configured; configured-equal adoption records ownership without replacing the store.

Resource and data-source reads strictly unwrap the nested `vector_store` envelope and verify identity. `litellm_params` is sensitive, preserves only recognized masked leaves from prior owned state, retains visible unmasked drift, canonicalizes nested response values, and rejects masked imports that have no recoverable prior value.

### Compatibility

Resource addresses, import IDs, schema version 0, and existing `map(string)` public types are preserved. Optional+Computed ownership bridges are additive. Heterogeneous request objects remain outside this change; nested API values are represented as canonical JSON strings rather than changing the established Terraform map type.

### Recovery behavior

Create and update operations require two stable fresh-worker reads. This safely recovers generated-ID creates and complete updates when v1.98 persists a database mutation but reports a process-local registry synchronization error. Unconfirmed operations retain prior state, and delete errors succeed only after a fresh read confirms absence.

### Validation

Validated create, nested data-source reads, name updates, description/metadata set-to-clear, masked parameter preservation, sensitive-log redaction, parameter replacement, masked-import rejection, no-drift plans, and destroy against LiteLLM v1.98. Protocol coverage also exercises configured-equal import ownership, create-only removal replacement, post-mutation error recovery, malformed envelopes, exact update JSON, structured values, and masked nested drift.

The complete live provider matrix passed **23 resources / 0 drift / 0 failures**. Repeated focused tests and the full Go, race, and vet suites passed.

### Review focus

Please focus on create-only ownership transitions, leaf-level masked-value reconciliation, and the bounded recovery path for v1.98 registry synchronization failures.

### Checklist

- [x] Backward-compatible state types and import IDs preserved
- [x] Focused lifecycle, masking, envelope, replacement, and recovery tests added
- [x] Live LiteLLM v1.98 validation completed
- [x] Registry resource and data-source documentation updated
- [x] Full test, race, vet, repeated protocol, and no-drift suites passed

### Diff size

**Docs** — 2 files · `+28 / -6`

Documents create-only fields, clear semantics, import ownership, masking, recovery, state security, and feature/license gates.

**Implementation** — 3 files · `+548 / -141`

Reworks vector-store planning, lifecycle recovery, strict envelope decoding, masked-map reconciliation, and the data-source contract. Most additions replace permissive field-by-field decoding and unsupported generic update payloads.

**Tests** — 3 files · `+297 / -1`

Adds Terraform protocol coverage and focused wire, masking, structured-value, import, replacement, recovery, and malformed-response tests.
