### PR TITLE
fix(guardrail): enforce v1.98 registry and masking contract

### DIFF
--- a/docs/data-sources/guardrail.md
+++ b/docs/data-sources/guardrail.md
@@ -31,7 +31,13 @@ output "guardrail_info" {
 * `guardrail` - The guardrail integration type (e.g., "aporia", "bedrock", "lakera").
 * `mode` - When to apply the guardrail (e.g., "pre_call", "post_call", "during_call", or a JSON array of modes).
 * `default_on` - Whether the guardrail is enabled by default for all requests.
-* `litellm_params` - JSON string containing additional provider-specific parameters.
+* `litellm_params` - Sensitive JSON string containing additional provider-specific parameters. LiteLLM v1.98 returns credential-bearing values as masked placeholders; this data source does not recover plaintext.
 * `guardrail_info` - JSON string containing additional guardrail metadata.
 * `created_at` - Creation timestamp.
 * `updated_at` - Last update timestamp.
+
+## Security and Access
+
+Sensitivity propagates through Terraform expressions. Mark outputs that expose `litellm_params` as sensitive. Masked values are inventory metadata, not usable credentials, and configured plaintext is not available to a read-only data source.
+
+LiteLLM requires authentication for guardrail reads. In v1.98, the single-info route does not apply the v2 list route's team/status filtering, so restrict provider credentials and guardrail-ID access accordingly. This data source does not bypass LiteLLM authorization or access its database directly.

--- a/docs/data-sources/guardrails.md
+++ b/docs/data-sources/guardrails.md
@@ -1,6 +1,6 @@
 # litellm_guardrails Data Source
 
-Retrieves a list of all LiteLLM guardrail configurations.
+Retrieves the LiteLLM v1.98 guardrail registry through `GET /v2/guardrails/list`. This includes active database-backed guardrails visible to the caller and initialized config-file guardrails, with database identities taking precedence over duplicates.
 
 ## Example Usage
 
@@ -41,6 +41,14 @@ This data source has no required arguments.
   * `guardrail` - The guardrail integration type.
   * `mode` - When to apply the guardrail.
   * `default_on` - Whether the guardrail is enabled by default.
-  * `litellm_params` - JSON string of provider-specific configuration.
+  * `litellm_params` - Sensitive JSON string of provider-specific configuration. Credential-bearing values are LiteLLM-masked inventory values, not plaintext credentials.
   * `created_at` - Creation timestamp.
   * `updated_at` - Last update timestamp.
+
+## Inventory Scope and Security
+
+The provider intentionally uses the v2 registry endpoint so resources created through `litellm_guardrail` appear in this inventory. LiteLLM's legacy `GET /guardrails/list` endpoint is a config-file-only view and is not used by this data source. LiteLLM v1.98 exposes no pagination or filter parameters for the v2 route; the provider performs one strict snapshot read and deterministically sorts it by ID and name.
+
+Visibility depends on LiteLLM authorization: administrators can see the complete active registry, while other roles can be limited to global and team-visible guardrails. The provider remains HTTP API-only.
+
+Because nested `litellm_params` is sensitive, outputs containing complete guardrail objects may also need `sensitive = true`. LiteLLM masks sensitive parameter keys before returning list results.

--- a/docs/resources/guardrail.md
+++ b/docs/resources/guardrail.md
@@ -62,8 +62,8 @@ The following arguments are supported:
 
 - `guardrail_id` - (String, ForceNew) The unique identifier for the guardrail. If not provided, one will be generated automatically. Changing this forces creation of a new resource.
 - `default_on` - (Bool) Whether this guardrail is enabled by default for all requests.
-- `litellm_params` - (String) A JSON-encoded string containing provider-specific parameters. This field stores only additional configuration specific to the guardrail provider (it does not include `guardrail`, `mode`, or `default_on`, which are top-level attributes). Top-level API defaults are excluded during read-back. Within configured objects and arrays, null fields added by LiteLLM are ignored unless they were explicitly configured; non-null additions and missing or changed configured values remain visible as drift.
-- `guardrail_info` - (String) A JSON-encoded string containing additional metadata or information about the guardrail.
+- `litellm_params` - (Sensitive String) A JSON-encoded object containing provider-specific parameters. This field stores only additional configuration specific to the guardrail provider (it does not include `guardrail`, `mode`, or `default_on`, which are top-level attributes). Objects are validated with exact JSON-number decoding, and semantically equivalent API responses preserve the configured Terraform spelling. Top-level API defaults are excluded during read-back. Within configured objects and arrays, null fields added by LiteLLM are ignored unless they were explicitly configured; non-null additions and missing or changed configured values remain visible as drift. LiteLLM-masked string leaves preserve the corresponding prior Terraform-owned plaintext, while visible sibling changes remain authoritative.
+- `guardrail_info` - (String) A JSON-encoded object containing additional metadata or information about the guardrail. Objects are validated before any API request; semantically equivalent read-back preserves the configured Terraform spelling.
 
 ## Attribute Reference
 
@@ -79,6 +79,8 @@ Guardrails can be imported using their guardrail ID:
 ```shell
 terraform import litellm_guardrail.example <guardrail-id>
 ```
+
+LiteLLM v1.98 masks credential-bearing `litellm_params` on information reads. Terraform cannot recover plaintext that was never in prior state, so import fails safely when the remote object contains masked parameters. Recreate the guardrail under Terraform ownership or remove/rotate the sensitive remote parameter before importing; a redaction marker is never stored as if it were the credential.
 
 ## Guardrail Modes
 
@@ -105,9 +107,11 @@ Validates complete responses. Use for:
 - PII redaction
 - Fact checking
 
-## Notes
+## Security and API Behavior
 
 - The `guardrail`, `mode`, and `default_on` fields are top-level attributes, not nested inside `litellm_params`.
-- The `litellm_params` field is for provider-specific configuration only (e.g., Bedrock guardrail identifiers, API keys).
-- Multiple guardrails can be combined for defense in depth.
-- Test guardrails thoroughly before enabling in production.
+- The `litellm_params` field is for provider-specific configuration only (for example, Bedrock identifiers and API keys).
+- `Sensitive` hides values from ordinary Terraform output, but configured plaintext remains in Terraform state and plan files. Protect those artifacts and mark any enclosing outputs sensitive.
+- LiteLLM v1.98 masks sensitive keys on GET/list responses as `*****` or a two-character-prefix, four-asterisk, two-character-suffix value. The provider recognizes only these exact markers; ordinary strings containing asterisks remain visible as drift.
+- Guardrail reads and writes require authentication. LiteLLM v1.98 restricts create, update, and delete to `PROXY_ADMIN`; v2 list visibility is role/team filtered by LiteLLM. Guardrail CRUD itself is not Enterprise-license gated, but database-backed management requires LiteLLM database support.
+- Multiple guardrails can be combined for defense in depth. Test guardrails thoroughly before enabling them in production.

--- a/internal/provider/datasource_guardrail.go
+++ b/internal/provider/datasource_guardrail.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -68,6 +67,7 @@ func (d *GuardrailDataSource) Schema(ctx context.Context, req datasource.SchemaR
 			"litellm_params": schema.StringAttribute{
 				Description: "JSON string containing additional provider-specific parameters.",
 				Computed:    true,
+				Sensitive:   true,
 			},
 			"guardrail_info": schema.StringAttribute{
 				Description: "JSON string containing additional metadata.",
@@ -104,7 +104,6 @@ func (d *GuardrailDataSource) Configure(ctx context.Context, req datasource.Conf
 
 func (d *GuardrailDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	var data GuardrailDataSourceModel
-
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -112,64 +111,75 @@ func (d *GuardrailDataSource) Read(ctx context.Context, req datasource.ReadReque
 
 	guardrailID := data.GuardrailID.ValueString()
 	endpoint := fmt.Sprintf("/guardrails/%s/info", guardrailID)
-
-	var result map[string]interface{}
-	if err := d.client.DoRequestWithResponse(ctx, "GET", endpoint, nil, &result); err != nil {
+	var raw map[string]interface{}
+	if err := d.client.DoRequestWithResponse(ctx, "GET", endpoint, nil, &raw); err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read guardrail: %s", err))
 		return
 	}
-
-	// Populate the data model
-	data.ID = types.StringValue(guardrailID)
-
-	if name, ok := result["guardrail_name"].(string); ok {
-		data.GuardrailName = types.StringValue(name)
+	observed, err := decodeGuardrailAPIObject(raw, guardrailID, true)
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
 	}
-	if createdAt, ok := result["created_at"].(string); ok {
-		data.CreatedAt = types.StringValue(createdAt)
-	}
-	if updatedAt, ok := result["updated_at"].(string); ok {
-		data.UpdatedAt = types.StringValue(updatedAt)
+	if observed.Params == nil {
+		resp.Diagnostics.AddError("Invalid API Response", "Guardrail response omitted required litellm_params")
+		return
 	}
 
-	// Handle litellm_params
-	if litellmParams, ok := result["litellm_params"].(map[string]interface{}); ok {
-		if guardrail, ok := litellmParams["guardrail"].(string); ok {
-			data.Guardrail = types.StringValue(guardrail)
+	data.ID = types.StringValue(observed.ID)
+	data.GuardrailID = types.StringValue(observed.ID)
+	data.GuardrailName = types.StringValue(observed.Name)
+	data.Guardrail = types.StringNull()
+	data.Mode = types.StringNull()
+	data.DefaultOn = types.BoolNull()
+	data.LitellmParams = types.StringNull()
+	data.GuardrailInfo = types.StringNull()
+	data.CreatedAt = types.StringNull()
+	data.UpdatedAt = types.StringNull()
+	if observed.CreatedAt != nil {
+		data.CreatedAt = types.StringValue(*observed.CreatedAt)
+	}
+	if observed.UpdatedAt != nil {
+		data.UpdatedAt = types.StringValue(*observed.UpdatedAt)
+	}
+	if observed.Params != nil {
+		guardrail, ok := observed.Params["guardrail"].(string)
+		if !ok || guardrail == "" {
+			resp.Diagnostics.AddError("Invalid API Response", "Guardrail response omitted required litellm_params.guardrail")
+			return
 		}
-		if defaultOn, ok := litellmParams["default_on"].(bool); ok {
+		data.Guardrail = types.StringValue(guardrail)
+		mode, present, err := guardrailModeFromAPI(observed.Params)
+		if err != nil || !present {
+			resp.Diagnostics.AddError("Invalid API Response", "Guardrail response omitted or returned invalid litellm_params.mode")
+			return
+		}
+		data.Mode = types.StringValue(mode)
+		if value, exists := observed.Params["default_on"]; exists && value != nil {
+			defaultOn, ok := value.(bool)
+			if !ok {
+				resp.Diagnostics.AddError("Invalid API Response", "Guardrail response returned invalid litellm_params.default_on")
+				return
+			}
 			data.DefaultOn = types.BoolValue(defaultOn)
 		}
-
-		// Handle mode (can be string or array)
-		if mode, ok := litellmParams["mode"].(string); ok {
-			data.Mode = types.StringValue(mode)
-		} else if modeArray, ok := litellmParams["mode"].([]interface{}); ok {
-			if jsonBytes, err := json.Marshal(modeArray); err == nil {
-				data.Mode = types.StringValue(string(jsonBytes))
+		additional := guardrailAdditionalParams(observed.Params)
+		if len(additional) > 0 {
+			encoded, err := canonicalGuardrailJSONObject(additional, "litellm_params")
+			if err != nil {
+				resp.Diagnostics.AddError("Invalid API Response", err.Error())
+				return
 			}
-		}
-
-		// Store other litellm_params as JSON
-		otherParams := make(map[string]interface{})
-		for k, v := range litellmParams {
-			if k != "guardrail" && k != "mode" && k != "default_on" {
-				otherParams[k] = v
-			}
-		}
-		if len(otherParams) > 0 {
-			if jsonBytes, err := json.Marshal(otherParams); err == nil {
-				data.LitellmParams = types.StringValue(string(jsonBytes))
-			}
+			data.LitellmParams = types.StringValue(encoded)
 		}
 	}
-
-	// Handle guardrail_info
-	if guardrailInfo, ok := result["guardrail_info"].(map[string]interface{}); ok && len(guardrailInfo) > 0 {
-		if jsonBytes, err := json.Marshal(guardrailInfo); err == nil {
-			data.GuardrailInfo = types.StringValue(string(jsonBytes))
+	if observed.Info != nil {
+		encoded, err := canonicalGuardrailJSONObject(observed.Info, "guardrail_info")
+		if err != nil {
+			resp.Diagnostics.AddError("Invalid API Response", err.Error())
+			return
 		}
+		data.GuardrailInfo = types.StringValue(encoded)
 	}
-
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/provider/datasource_guardrails_list.go
+++ b/internal/provider/datasource_guardrails_list.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"sort"
 
@@ -77,6 +76,7 @@ func (d *GuardrailsListDataSource) Schema(ctx context.Context, req datasource.Sc
 						"litellm_params": schema.StringAttribute{
 							Description: "JSON string containing additional provider-specific parameters.",
 							Computed:    true,
+							Sensitive:   true,
 						},
 						"created_at": schema.StringAttribute{
 							Description: "Timestamp when the guardrail was created.",
@@ -110,6 +110,73 @@ func (d *GuardrailsListDataSource) Configure(ctx context.Context, req datasource
 	d.client = client
 }
 
+func guardrailListItemFromAPI(raw map[string]interface{}) (GuardrailListItemModel, error) {
+	var item GuardrailListItemModel
+	observed, err := decodeGuardrailAPIObject(raw, "", true)
+	if err != nil {
+		return item, err
+	}
+	if observed.Params == nil {
+		return item, fmt.Errorf("guardrail response omitted required litellm_params")
+	}
+	guardrail, ok := observed.Params["guardrail"].(string)
+	if !ok || guardrail == "" {
+		return item, fmt.Errorf("guardrail response omitted required litellm_params.guardrail")
+	}
+	mode, present, err := guardrailModeFromAPI(observed.Params)
+	if err != nil || !present {
+		return item, fmt.Errorf("guardrail response omitted or returned invalid litellm_params.mode")
+	}
+
+	item.GuardrailID = types.StringValue(observed.ID)
+	item.GuardrailName = types.StringValue(observed.Name)
+	item.Guardrail = types.StringValue(guardrail)
+	item.Mode = types.StringValue(mode)
+	item.DefaultOn = types.BoolNull()
+	item.LitellmParams = types.StringNull()
+	item.CreatedAt = types.StringNull()
+	item.UpdatedAt = types.StringNull()
+	if value, exists := observed.Params["default_on"]; exists && value != nil {
+		defaultOn, ok := value.(bool)
+		if !ok {
+			return item, fmt.Errorf("guardrail response returned invalid litellm_params.default_on")
+		}
+		item.DefaultOn = types.BoolValue(defaultOn)
+	}
+	additional := guardrailAdditionalParams(observed.Params)
+	if len(additional) > 0 {
+		encoded, err := canonicalGuardrailJSONObject(additional, "litellm_params")
+		if err != nil {
+			return item, err
+		}
+		item.LitellmParams = types.StringValue(encoded)
+	}
+	if observed.CreatedAt != nil {
+		item.CreatedAt = types.StringValue(*observed.CreatedAt)
+	}
+	if observed.UpdatedAt != nil {
+		item.UpdatedAt = types.StringValue(*observed.UpdatedAt)
+	}
+	return item, nil
+}
+
+func fetchGuardrailListItems(ctx context.Context, client *Client) ([]GuardrailListItemModel, error) {
+	const endpoint = "/v2/guardrails/list"
+	results, err := fetchEnvelopeListObjects(ctx, client, endpoint, "guardrails", "guardrail item")
+	if err != nil {
+		return nil, err
+	}
+	guardrails := make([]GuardrailListItemModel, 0, len(results))
+	for _, result := range results {
+		guardrail, err := guardrailListItemFromAPI(result)
+		if err != nil {
+			return nil, err
+		}
+		guardrails = append(guardrails, guardrail)
+	}
+	return guardrails, nil
+}
+
 func (d *GuardrailsListDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	var data GuardrailsListDataSourceModel
 
@@ -118,64 +185,10 @@ func (d *GuardrailsListDataSource) Read(ctx context.Context, req datasource.Read
 		return
 	}
 
-	results, err := fetchEnvelopeListObjects(ctx, d.client, "/guardrails/list", "guardrails", "guardrail item")
+	guardrails, err := fetchGuardrailListItems(ctx, d.client)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to list guardrails: %s", err))
 		return
-	}
-	guardrails := make([]GuardrailListItemModel, 0, len(results))
-	for _, result := range results {
-		guardrail := GuardrailListItemModel{}
-
-		if guardrailID, ok := result["guardrail_id"].(string); ok {
-			guardrail.GuardrailID = types.StringValue(guardrailID)
-		}
-		if name, ok := result["guardrail_name"].(string); ok && name != "" {
-			guardrail.GuardrailName = types.StringValue(name)
-		} else {
-			resp.Diagnostics.AddError("Invalid API Response", "/guardrails/list returned a guardrail object without guardrail_name")
-			return
-		}
-		if createdAt, ok := result["created_at"].(string); ok {
-			guardrail.CreatedAt = types.StringValue(createdAt)
-		}
-		if updatedAt, ok := result["updated_at"].(string); ok {
-			guardrail.UpdatedAt = types.StringValue(updatedAt)
-		}
-
-		// Handle litellm_params
-		if litellmParams, ok := result["litellm_params"].(map[string]interface{}); ok {
-			if g, ok := litellmParams["guardrail"].(string); ok {
-				guardrail.Guardrail = types.StringValue(g)
-			}
-			if defaultOn, ok := litellmParams["default_on"].(bool); ok {
-				guardrail.DefaultOn = types.BoolValue(defaultOn)
-			}
-
-			// Handle mode
-			if mode, ok := litellmParams["mode"].(string); ok {
-				guardrail.Mode = types.StringValue(mode)
-			} else if modeArray, ok := litellmParams["mode"].([]interface{}); ok {
-				if jsonBytes, err := json.Marshal(modeArray); err == nil {
-					guardrail.Mode = types.StringValue(string(jsonBytes))
-				}
-			}
-
-			// Store other litellm_params as JSON
-			otherParams := make(map[string]interface{})
-			for k, v := range litellmParams {
-				if k != "guardrail" && k != "mode" && k != "default_on" {
-					otherParams[k] = v
-				}
-			}
-			if len(otherParams) > 0 {
-				if jsonBytes, err := json.Marshal(otherParams); err == nil {
-					guardrail.LitellmParams = types.StringValue(string(jsonBytes))
-				}
-			}
-		}
-
-		guardrails = append(guardrails, guardrail)
 	}
 	sort.SliceStable(guardrails, func(i, j int) bool {
 		leftID := guardrails[i].GuardrailID.ValueString()

--- a/internal/provider/guardrail_contract_test.go
+++ b/internal/provider/guardrail_contract_test.go
@@ -1,0 +1,212 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	datasourceschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	resourceschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func guardrailAPIResponse() map[string]interface{} {
+	return map[string]interface{}{
+		"guardrail_id":   "guardrail-1",
+		"guardrail_name": "managed",
+		"created_at":     "2026-08-25T00:00:00Z",
+		"updated_at":     nil,
+		"litellm_params": map[string]interface{}{
+			"guardrail":  "bedrock",
+			"mode":       []interface{}{"pre_call", "post_call"},
+			"default_on": true,
+			"api_key":    "se****et",
+			"nested": map[string]interface{}{
+				"token":  "ne****et",
+				"region": "us-west-2",
+				"unset":  nil,
+			},
+		},
+		"guardrail_info": map[string]interface{}{"description": "managed"},
+	}
+}
+
+func TestGuardrailSensitiveSchemas(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	var resourceResponse resource.SchemaResponse
+	(&GuardrailResource{}).Schema(ctx, resource.SchemaRequest{}, &resourceResponse)
+	resourceAttribute := resourceResponse.Schema.Attributes["litellm_params"].(resourceschema.StringAttribute)
+	if !resourceAttribute.Sensitive {
+		t.Fatal("resource litellm_params is not sensitive")
+	}
+	var singleResponse datasource.SchemaResponse
+	(&GuardrailDataSource{}).Schema(ctx, datasource.SchemaRequest{}, &singleResponse)
+	if !singleResponse.Schema.Attributes["litellm_params"].(datasourceschema.StringAttribute).Sensitive {
+		t.Fatal("single guardrail data source litellm_params is not sensitive")
+	}
+	var listResponse datasource.SchemaResponse
+	(&GuardrailsListDataSource{}).Schema(ctx, datasource.SchemaRequest{}, &listResponse)
+	listAttribute := listResponse.Schema.Attributes["guardrails"].(datasourceschema.ListNestedAttribute)
+	if !listAttribute.NestedObject.Attributes["litellm_params"].(datasourceschema.StringAttribute).Sensitive {
+		t.Fatal("guardrail list litellm_params is not sensitive")
+	}
+	if _, exists := listAttribute.NestedObject.Attributes["guardrail_info"]; exists {
+		t.Fatal("guardrail list public item shape changed unexpectedly")
+	}
+}
+
+func TestGuardrailSemanticReconciliationPreservesConfiguredJSONSpelling(t *testing.T) {
+	t.Parallel()
+	prior := "{\n  \"large\": 9007199254740993,\n  \"name\": \"value\"\n}"
+	observed, err := reconcileOwnedGuardrailParams(map[string]interface{}{
+		"large": json.Number("9007199254740993"), "name": "value",
+	}, prior)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if observed != prior {
+		t.Fatalf("semantic reconciliation rewrote configured JSON: %q", observed)
+	}
+}
+
+func TestGuardrailMaskRecognitionIsExact(t *testing.T) {
+	t.Parallel()
+	for _, value := range []string{"*****", "ab****yz"} {
+		if !isGuardrailMaskedAPIString(value) {
+			t.Fatalf("LiteLLM marker %q was not recognized", value)
+		}
+	}
+	for _, value := range []string{"****", "prefix****suffix", "ordinary"} {
+		if isGuardrailMaskedAPIString(value) {
+			t.Fatalf("ordinary value %q was treated as a mask", value)
+		}
+	}
+}
+
+func TestReadGuardrailPreservesOwnedMaskedLeavesAndVisibleDrift(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(writer).Encode(guardrailAPIResponse())
+	}))
+	defer server.Close()
+
+	data := GuardrailResourceModel{
+		ID:            types.StringValue("guardrail-1"),
+		GuardrailID:   types.StringValue("guardrail-1"),
+		GuardrailName: types.StringValue("managed"),
+		Guardrail:     types.StringValue("bedrock"),
+		Mode:          types.StringValue(`["pre_call","post_call"]`),
+		DefaultOn:     types.BoolValue(true),
+		LitellmParams: types.StringValue(`{"api_key":"secret","nested":{"region":"us-east-1","token":"nested-secret"}}`),
+	}
+	resource := &GuardrailResource{client: &Client{APIBase: server.URL, APIKey: "test", HTTPClient: server.Client()}}
+	if err := resource.readGuardrail(context.Background(), &data, false); err != nil {
+		t.Fatal(err)
+	}
+	want := `{"api_key":"secret","nested":{"region":"us-west-2","token":"nested-secret"}}`
+	if got := data.LitellmParams.ValueString(); got != want {
+		t.Fatalf("masked reconciliation = %s, want %s", got, want)
+	}
+}
+
+func TestReadGuardrailPreservesExplicitEmptyObjects(t *testing.T) {
+	t.Parallel()
+	response := map[string]interface{}{
+		"guardrail_id": "guardrail-1", "guardrail_name": "managed",
+		"litellm_params": map[string]interface{}{"guardrail": "bedrock", "mode": "pre_call"},
+		"guardrail_info": map[string]interface{}{},
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(writer).Encode(response)
+	}))
+	defer server.Close()
+	data := GuardrailResourceModel{
+		ID: types.StringValue("guardrail-1"), GuardrailID: types.StringValue("guardrail-1"),
+		LitellmParams: types.StringValue(`{}`), GuardrailInfo: types.StringValue(`{}`),
+	}
+	resource := &GuardrailResource{client: &Client{APIBase: server.URL, APIKey: "test", HTTPClient: server.Client()}}
+	if err := resource.readGuardrail(context.Background(), &data, false); err != nil {
+		t.Fatal(err)
+	}
+	if data.LitellmParams.ValueString() != `{}` || data.GuardrailInfo.ValueString() != `{}` {
+		t.Fatalf("empty object semantics changed: params=%q info=%q", data.LitellmParams.ValueString(), data.GuardrailInfo.ValueString())
+	}
+}
+
+func TestReadGuardrailRejectsMaskedImportWithoutPriorState(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(writer).Encode(guardrailAPIResponse())
+	}))
+	defer server.Close()
+	data := GuardrailResourceModel{ID: types.StringValue("guardrail-1"), GuardrailID: types.StringValue("guardrail-1")}
+	resource := &GuardrailResource{client: &Client{APIBase: server.URL, APIKey: "test", HTTPClient: server.Client()}}
+	if err := resource.readGuardrail(context.Background(), &data, true); err == nil {
+		t.Fatal("masked import succeeded without prior Terraform state")
+	}
+}
+
+func TestGuardrailV2ListCreateParityAndStrictShape(t *testing.T) {
+	t.Parallel()
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		requests++
+		if request.URL.RawQuery != "" {
+			t.Errorf("v1.98 list does not accept pagination/filter query: %s", request.URL.RawQuery)
+		}
+		if request.URL.Path != "/v2/guardrails/list" {
+			http.NotFound(writer, request)
+			return
+		}
+		writer.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(writer).Encode(map[string]interface{}{"guardrails": []interface{}{guardrailAPIResponse()}})
+	}))
+	defer server.Close()
+	client := &Client{APIBase: server.URL, APIKey: "test", HTTPClient: server.Client()}
+	items, err := fetchGuardrailListItems(context.Background(), client)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if requests != 1 || len(items) != 1 || items[0].GuardrailID.ValueString() != "guardrail-1" {
+		t.Fatalf("v2 list parity: requests=%d items=%#v", requests, items)
+	}
+	if got := items[0].LitellmParams.ValueString(); got == "" || !jsonContainsMaskedValue(got) {
+		t.Fatalf("list did not retain masked sensitive projection: %q", got)
+	}
+
+	malformed := guardrailAPIResponse()
+	malformed["litellm_params"] = []interface{}{}
+	if _, err := guardrailListItemFromAPI(malformed); err == nil {
+		t.Fatal("malformed litellm_params shape was accepted")
+	}
+}
+
+func TestGuardrailV2ListRejectsMalformedEnvelopes(t *testing.T) {
+	t.Parallel()
+	for name, body := range map[string]string{
+		"missing": `{"items":[]}`,
+		"null":    `{"guardrails":null}`,
+		"object":  `{"guardrails":{}}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				writer.Header().Set("Content-Type", "application/json")
+				_, _ = writer.Write([]byte(body))
+			}))
+			defer server.Close()
+			client := &Client{APIBase: server.URL, APIKey: "test", HTTPClient: server.Client()}
+			if _, err := fetchGuardrailListItems(context.Background(), client); err == nil {
+				t.Fatalf("malformed envelope %s was accepted", body)
+			}
+		})
+	}
+}

--- a/internal/provider/guardrail_helpers.go
+++ b/internal/provider/guardrail_helpers.go
@@ -1,0 +1,231 @@
+package provider
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+var guardrailReservedParams = map[string]struct{}{
+	"guardrail":  {},
+	"mode":       {},
+	"default_on": {},
+}
+
+type guardrailAPIObject struct {
+	ID        string
+	Name      string
+	Params    map[string]interface{}
+	Info      map[string]interface{}
+	CreatedAt *string
+	UpdatedAt *string
+}
+
+func optionalAPIString(object map[string]interface{}, field string) (*string, error) {
+	value, exists := object[field]
+	if !exists || value == nil {
+		return nil, nil
+	}
+	text, ok := value.(string)
+	if !ok {
+		return nil, fmt.Errorf("guardrail response field %q must be a string or null", field)
+	}
+	return &text, nil
+}
+
+func decodeGuardrailAPIObject(object map[string]interface{}, expectedID string, requireID bool) (guardrailAPIObject, error) {
+	var result guardrailAPIObject
+	id, err := optionalAPIString(object, "guardrail_id")
+	if err != nil {
+		return result, err
+	}
+	if id != nil {
+		result.ID = *id
+	}
+	if requireID && result.ID == "" {
+		return result, fmt.Errorf("guardrail response omitted a non-empty guardrail_id")
+	}
+	if expectedID != "" && result.ID != expectedID {
+		return result, fmt.Errorf("guardrail response identity did not match the requested guardrail")
+	}
+
+	name, err := optionalAPIString(object, "guardrail_name")
+	if err != nil {
+		return result, err
+	}
+	if name == nil || *name == "" {
+		return result, fmt.Errorf("guardrail response omitted a non-empty guardrail_name")
+	}
+	result.Name = *name
+
+	if raw, exists := object["litellm_params"]; exists && raw != nil {
+		params, ok := raw.(map[string]interface{})
+		if !ok {
+			return result, fmt.Errorf("guardrail response field %q must be an object or null", "litellm_params")
+		}
+		result.Params = params
+	}
+	if raw, exists := object["guardrail_info"]; exists && raw != nil {
+		info, ok := raw.(map[string]interface{})
+		if !ok {
+			return result, fmt.Errorf("guardrail response field %q must be an object or null", "guardrail_info")
+		}
+		result.Info = info
+	}
+	result.CreatedAt, err = optionalAPIString(object, "created_at")
+	if err != nil {
+		return result, err
+	}
+	result.UpdatedAt, err = optionalAPIString(object, "updated_at")
+	if err != nil {
+		return result, err
+	}
+	return result, nil
+}
+
+func guardrailModeFromAPI(params map[string]interface{}) (string, bool, error) {
+	value, exists := params["mode"]
+	if !exists || value == nil {
+		return "", false, nil
+	}
+	if text, ok := value.(string); ok {
+		if text == "" {
+			return "", false, fmt.Errorf("guardrail response field %q must be non-empty", "litellm_params.mode")
+		}
+		return text, true, nil
+	}
+	items, ok := value.([]interface{})
+	if !ok || len(items) == 0 {
+		return "", false, fmt.Errorf("guardrail response field %q must be a string or non-empty string array", "litellm_params.mode")
+	}
+	for _, item := range items {
+		if text, ok := item.(string); !ok || text == "" {
+			return "", false, fmt.Errorf("guardrail response field %q must contain only non-empty strings", "litellm_params.mode")
+		}
+	}
+	encoded, err := json.Marshal(items)
+	if err != nil {
+		return "", false, fmt.Errorf("guardrail response field %q could not be encoded", "litellm_params.mode")
+	}
+	return string(encoded), true, nil
+}
+
+func guardrailAdditionalParams(params map[string]interface{}) map[string]interface{} {
+	additional := make(map[string]interface{})
+	for key, value := range params {
+		if _, reserved := guardrailReservedParams[key]; !reserved {
+			additional[key] = value
+		}
+	}
+	return additional
+}
+
+func canonicalGuardrailJSONObject(object map[string]interface{}, field string) (string, error) {
+	encoded, err := json.Marshal(object)
+	if err != nil {
+		return "", fmt.Errorf("guardrail response field %q could not be encoded", field)
+	}
+	return string(encoded), nil
+}
+
+func isGuardrailMaskedAPIString(value string) bool {
+	return value == "*****" || liteLLMCredentialMask.MatchString(value)
+}
+
+func containsGuardrailMaskedValue(value interface{}) bool {
+	switch typed := value.(type) {
+	case string:
+		return isGuardrailMaskedAPIString(typed)
+	case map[string]interface{}:
+		for _, child := range typed {
+			if containsGuardrailMaskedValue(child) {
+				return true
+			}
+		}
+	case []interface{}:
+		for _, child := range typed {
+			if containsGuardrailMaskedValue(child) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func restoreGuardrailMaskedLeaves(remote, prior interface{}, field string) (interface{}, error) {
+	if !containsGuardrailMaskedValue(remote) {
+		return remote, nil
+	}
+	if text, ok := remote.(string); ok && isGuardrailMaskedAPIString(text) {
+		priorText, ok := prior.(string)
+		if !ok {
+			return nil, fmt.Errorf("guardrail response field %q contains a masked value without corresponding prior plaintext state", field)
+		}
+		if isGuardrailMaskedAPIString(priorText) {
+			return nil, fmt.Errorf("guardrail response field %q cannot recover plaintext from a previously stored masked value", field)
+		}
+		return priorText, nil
+	}
+	switch typed := remote.(type) {
+	case map[string]interface{}:
+		priorObject, ok := prior.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("guardrail response field %q changed shape while masked", field)
+		}
+		result := make(map[string]interface{}, len(typed))
+		for key, child := range typed {
+			restored, err := restoreGuardrailMaskedLeaves(child, priorObject[key], field+"."+key)
+			if err != nil {
+				return nil, err
+			}
+			result[key] = restored
+		}
+		return result, nil
+	case []interface{}:
+		priorArray, ok := prior.([]interface{})
+		if !ok || len(priorArray) != len(typed) {
+			return nil, fmt.Errorf("guardrail response field %q changed shape while masked", field)
+		}
+		result := make([]interface{}, len(typed))
+		for index, child := range typed {
+			restored, err := restoreGuardrailMaskedLeaves(child, priorArray[index], fmt.Sprintf("%s[%d]", field, index))
+			if err != nil {
+				return nil, err
+			}
+			result[index] = restored
+		}
+		return result, nil
+	default:
+		return remote, nil
+	}
+}
+
+func reconcileOwnedGuardrailParams(apiParams map[string]interface{}, priorJSON string) (string, error) {
+	configured, err := decodeRequestJSONObject(priorJSON, "litellm_params")
+	if err != nil {
+		return "", err
+	}
+	reconciled := make(map[string]interface{})
+	for key, configuredValue := range configured {
+		if _, reserved := guardrailReservedParams[key]; reserved {
+			continue
+		}
+		apiValue, exists := apiParams[key]
+		if !exists {
+			continue
+		}
+		apiValue = removeUnconfiguredGuardrailNulls(apiValue, configuredValue)
+		apiValue, err = restoreGuardrailMaskedLeaves(apiValue, configuredValue, "litellm_params."+key)
+		if err != nil {
+			return "", err
+		}
+		reconciled[key] = apiValue
+	}
+	observed, err := canonicalGuardrailJSONObject(reconciled, "litellm_params")
+	if err != nil {
+		return "", err
+	}
+	if jsonSemanticallyEqual(priorJSON, observed) {
+		return priorJSON, nil
+	}
+	return observed, nil
+}

--- a/internal/provider/guardrail_protocol_test.go
+++ b/internal/provider/guardrail_protocol_test.go
@@ -1,0 +1,95 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+)
+
+func TestGuardrailUnmaskedImportOmissionIsStableProtocol(t *testing.T) {
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		if request.URL.Path != "/guardrails/guardrail-import/info" {
+			http.NotFound(writer, request)
+			return
+		}
+		_, _ = fmt.Fprint(writer, `{"guardrail_id":"guardrail-import","guardrail_name":"managed","litellm_params":{"guardrail":"bedrock","mode":"pre_call","default_on":true,"guardrailIdentifier":"remote-default"}}`)
+	}))
+	defer server.Close()
+
+	protocolServer, schemas := configuredImportProtocolServer(t, ctx, server.URL)
+	const typeName = "litellm_guardrail"
+	schema := schemas.ResourceSchemas[typeName]
+	imported, err := protocolServer.ImportResourceState(ctx, &tfprotov6.ImportResourceStateRequest{TypeName: typeName, ID: "guardrail-import"})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(imported.Diagnostics) || len(imported.ImportedResources) != 1 {
+		t.Fatalf("import: err=%v diagnostics=%v", err, imported.Diagnostics)
+	}
+	read, err := protocolServer.ReadResource(ctx, &tfprotov6.ReadResourceRequest{TypeName: typeName, CurrentState: imported.ImportedResources[0].State, Private: imported.ImportedResources[0].Private})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(read.Diagnostics) {
+		t.Fatalf("read: err=%v diagnostics=%v", err, read.Diagnostics)
+	}
+	configValue := organizationProjectProtocolValue(t, schema, map[string]interface{}{
+		"guardrail_name": "managed", "guardrail": "bedrock", "mode": "pre_call",
+	})
+	config := accessGroupProtocolDynamicValue(t, schema, configValue)
+	planned, err := protocolServer.PlanResourceChange(ctx, &tfprotov6.PlanResourceChangeRequest{
+		TypeName: typeName, Config: config, PriorState: read.NewState, ProposedNewState: read.NewState, PriorPrivate: read.Private,
+	})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(planned.Diagnostics) || organizationProjectProtocolPlannedAction(t, schema, read.NewState, planned) != organizationProjectProtocolActionNoOp {
+		t.Fatalf("stable omitted import: err=%v diagnostics=%v action=%s", err, planned.Diagnostics, organizationProjectProtocolPlannedAction(t, schema, read.NewState, planned))
+	}
+}
+
+func TestGuardrailSingleDataSourceRejectsNullParamsProtocol(t *testing.T) {
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(writer, `{"guardrail_id":"guardrail-null","guardrail_name":"malformed","litellm_params":null}`)
+	}))
+	defer server.Close()
+	protocolServer, schemas := configuredImportProtocolServer(t, ctx, server.URL)
+	const typeName = "litellm_guardrail"
+	schema := schemas.DataSourceSchemas[typeName]
+	config := accessGroupProtocolDynamicValue(t, schema, organizationProjectProtocolValue(t, schema, map[string]interface{}{"guardrail_id": "guardrail-null"}))
+	read, err := protocolServer.ReadDataSource(ctx, &tfprotov6.ReadDataSourceRequest{TypeName: typeName, Config: config})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !accessGroupProtocolDiagnosticsHaveError(read.Diagnostics) {
+		t.Fatalf("null litellm_params unexpectedly succeeded: diagnostics=%v", read.Diagnostics)
+	}
+}
+
+func TestGuardrailMaskedImportFailsClosedProtocol(t *testing.T) {
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		if request.URL.Path != "/guardrails/guardrail-import/info" {
+			http.NotFound(writer, request)
+			return
+		}
+		_, _ = fmt.Fprint(writer, `{"guardrail_id":"guardrail-import","guardrail_name":"managed","litellm_params":{"guardrail":"bedrock","mode":"pre_call","api_key":"se****et"}}`)
+	}))
+	defer server.Close()
+
+	protocolServer, _ := configuredImportProtocolServer(t, ctx, server.URL)
+	const typeName = "litellm_guardrail"
+	imported, err := protocolServer.ImportResourceState(ctx, &tfprotov6.ImportResourceStateRequest{TypeName: typeName, ID: "guardrail-import"})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(imported.Diagnostics) || len(imported.ImportedResources) != 1 {
+		t.Fatalf("import: err=%v diagnostics=%v", err, imported.Diagnostics)
+	}
+	read, err := protocolServer.ReadResource(ctx, &tfprotov6.ReadResourceRequest{
+		TypeName: typeName, CurrentState: imported.ImportedResources[0].State, Private: imported.ImportedResources[0].Private,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !accessGroupProtocolDiagnosticsHaveError(read.Diagnostics) {
+		t.Fatalf("masked import unexpectedly succeeded: diagnostics=%v", read.Diagnostics)
+	}
+}

--- a/internal/provider/json_request_precision_test.go
+++ b/internal/provider/json_request_precision_test.go
@@ -65,6 +65,12 @@ func TestJSONRequestBuildersPreserveExactNumbersAndRejectInvalidJSON(t *testing.
 	if _, err := (&GuardrailResource{}).buildGuardrailRequest(ctx, &GuardrailResourceModel{GuardrailName: types.StringValue("g"), Guardrail: types.StringValue("x"), Mode: types.StringValue("[bad")}); err == nil {
 		t.Fatal("guardrail accepted invalid mode JSON")
 	}
+	if _, err := (&GuardrailResource{}).buildGuardrailRequest(ctx, &GuardrailResourceModel{GuardrailName: types.StringValue("g"), Guardrail: types.StringValue("x"), Mode: types.StringValue("pre_call"), LitellmParams: types.StringValue("")}); err == nil {
+		t.Fatal("guardrail silently omitted empty litellm_params JSON")
+	}
+	if _, err := (&GuardrailResource{}).buildGuardrailRequest(ctx, &GuardrailResourceModel{GuardrailName: types.StringValue("g"), Guardrail: types.StringValue("x"), Mode: types.StringValue("pre_call"), LitellmParams: types.StringValue(`{"mode":"post_call"}`)}); err == nil {
+		t.Fatal("guardrail litellm_params overrode a dedicated attribute")
+	}
 	if _, err := (&GuardrailResource{}).buildGuardrailRequest(ctx, &GuardrailResourceModel{GuardrailName: types.StringValue("g"), Guardrail: types.StringValue("x"), Mode: types.StringValue("pre_call"), GuardrailInfo: types.StringValue(invalid)}); err == nil {
 		t.Fatal("guardrail accepted invalid info JSON")
 	}

--- a/internal/provider/read_test.go
+++ b/internal/provider/read_test.go
@@ -250,7 +250,7 @@ func TestReadGuardrail(t *testing.T) {
 		GuardrailID: types.StringValue("g-1"),
 		DefaultOn:   types.BoolValue(false),
 	}
-	if err := r.readGuardrail(context.Background(), data); err != nil {
+	if err := r.readGuardrail(context.Background(), data, false); err != nil {
 		t.Fatalf("readGuardrail: %v", err)
 	}
 

--- a/internal/provider/resource_guardrail.go
+++ b/internal/provider/resource_guardrail.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -17,6 +16,8 @@ import (
 
 var _ resource.Resource = &GuardrailResource{}
 var _ resource.ResourceWithImportState = &GuardrailResource{}
+
+const guardrailImportedPrivateKey = "guardrail_imported_v1"
 
 func NewGuardrailResource() resource.Resource {
 	return &GuardrailResource{}
@@ -82,6 +83,7 @@ func (r *GuardrailResource) Schema(ctx context.Context, req resource.SchemaReque
 			"litellm_params": schema.StringAttribute{
 				Description: "JSON object string containing additional provider-specific parameters for the guardrail.",
 				Optional:    true,
+				Sensitive:   true,
 				Validators:  []validator.String{jsonShapeStringValidator{shape: '{'}},
 			},
 			"guardrail_info": schema.StringAttribute{
@@ -148,9 +150,19 @@ func (r *GuardrailResource) Create(ctx context.Context, req resource.CreateReque
 		}
 	}
 
-	// Read back for full state
-	if err := r.readGuardrail(ctx, &data); err != nil {
-		resp.Diagnostics.AddWarning("Read Error", fmt.Sprintf("Guardrail created but failed to read back: %s", err))
+	if data.GuardrailID.IsNull() || data.GuardrailID.IsUnknown() || data.GuardrailID.ValueString() == "" {
+		resp.Diagnostics.AddError("Invalid API Response", "LiteLLM accepted the guardrail create but did not return a recoverable guardrail_id.")
+		return
+	}
+	// Read back before committing full state; info responses apply LiteLLM's
+	// masking and are the authoritative contract for subsequent refreshes.
+	if err := r.readGuardrail(ctx, &data, false); err != nil {
+		if data.CreatedAt.IsUnknown() {
+			data.CreatedAt = types.StringNull()
+		}
+		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		resp.Diagnostics.AddError("Guardrail Create Not Confirmed", fmt.Sprintf("LiteLLM created the guardrail, but authoritative read-back failed: %s", err))
+		return
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -164,7 +176,13 @@ func (r *GuardrailResource) Read(ctx context.Context, req resource.ReadRequest, 
 		return
 	}
 
-	if err := r.readGuardrail(ctx, &data); err != nil {
+	importedMarker, privateDiags := req.Private.GetKey(ctx, guardrailImportedPrivateKey)
+	resp.Diagnostics.Append(privateDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	imported := string(importedMarker) == "true"
+	if err := r.readGuardrail(ctx, &data, imported); err != nil {
 		if IsNotFoundError(err) {
 			resp.State.RemoveResource(ctx)
 			return
@@ -174,6 +192,9 @@ func (r *GuardrailResource) Read(ctx context.Context, req resource.ReadRequest, 
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	if imported && !resp.Diagnostics.HasError() && resp.Private != nil {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, guardrailImportedPrivateKey, nil)...)
+	}
 }
 
 func (r *GuardrailResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
@@ -206,9 +227,11 @@ func (r *GuardrailResource) Update(ctx context.Context, req resource.UpdateReque
 		return
 	}
 
-	// Read back for full state
-	if err := r.readGuardrail(ctx, &data); err != nil {
-		resp.Diagnostics.AddWarning("Read Error", fmt.Sprintf("Guardrail updated but failed to read back: %s", err))
+	// Never publish the planned value after an unconfirmed response; retaining
+	// prior state makes a failed or partially applied update safely retryable.
+	if err := r.readGuardrail(ctx, &data, false); err != nil {
+		resp.Diagnostics.AddError("Guardrail Update Not Confirmed", fmt.Sprintf("LiteLLM accepted the guardrail update, but authoritative read-back failed: %s", err))
+		return
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -234,6 +257,9 @@ func (r *GuardrailResource) Delete(ctx context.Context, req resource.DeleteReque
 func (r *GuardrailResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("guardrail_id"), req.ID)...)
+	if resp.Private != nil {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, guardrailImportedPrivateKey, []byte("true"))...)
+	}
 }
 
 func (r *GuardrailResource) buildGuardrailRequest(ctx context.Context, data *GuardrailResourceModel) (map[string]interface{}, error) {
@@ -259,13 +285,18 @@ func (r *GuardrailResource) buildGuardrailRequest(ctx context.Context, data *Gua
 	}
 
 	// Merge additional litellm_params if provided
-	if !data.LitellmParams.IsNull() && !data.LitellmParams.IsUnknown() && data.LitellmParams.ValueString() != "" {
+	if !data.LitellmParams.IsNull() && !data.LitellmParams.IsUnknown() {
 		additionalParams, err := decodeRequestJSONObject(data.LitellmParams.ValueString(), "litellm_params")
 		if err != nil {
 			return nil, err
 		}
-		for k, v := range additionalParams {
-			litellmParams[k] = v
+		for key := range additionalParams {
+			if _, reserved := guardrailReservedParams[key]; reserved {
+				return nil, fmt.Errorf("invalid litellm_params: %q must be configured through its dedicated guardrail attribute", key)
+			}
+		}
+		for key, value := range additionalParams {
+			litellmParams[key] = value
 		}
 	}
 
@@ -279,7 +310,7 @@ func (r *GuardrailResource) buildGuardrailRequest(ctx context.Context, data *Gua
 		guardrail["guardrail_id"] = data.GuardrailID.ValueString()
 	}
 
-	if !data.GuardrailInfo.IsNull() && !data.GuardrailInfo.IsUnknown() && data.GuardrailInfo.ValueString() != "" {
+	if !data.GuardrailInfo.IsNull() && !data.GuardrailInfo.IsUnknown() {
 		guardrailInfo, err := decodeRequestJSONObject(data.GuardrailInfo.ValueString(), "guardrail_info")
 		if err != nil {
 			return nil, err
@@ -325,86 +356,86 @@ func removeUnconfiguredGuardrailNulls(apiValue, configuredValue interface{}) int
 	}
 }
 
-func (r *GuardrailResource) readGuardrail(ctx context.Context, data *GuardrailResourceModel) error {
+func (r *GuardrailResource) readGuardrail(ctx context.Context, data *GuardrailResourceModel, imported bool) error {
 	guardrailID := data.GuardrailID.ValueString()
 	if guardrailID == "" {
 		guardrailID = data.ID.ValueString()
 	}
+	if guardrailID == "" {
+		return fmt.Errorf("guardrail state omitted its identity")
+	}
 
 	endpoint := fmt.Sprintf("/guardrails/%s/info", guardrailID)
-
-	var result map[string]interface{}
-	if err := r.client.DoRequestWithResponse(ctx, "GET", endpoint, nil, &result); err != nil {
+	var raw map[string]interface{}
+	if err := r.client.DoRequestWithResponse(ctx, "GET", endpoint, nil, &raw); err != nil {
 		return err
 	}
-
-	// Update fields from response
-	if id, ok := result["guardrail_id"].(string); ok {
-		data.GuardrailID = types.StringValue(id)
-		data.ID = types.StringValue(id)
+	observed, err := decodeGuardrailAPIObject(raw, guardrailID, true)
+	if err != nil {
+		return err
 	}
-	if name, ok := result["guardrail_name"].(string); ok {
-		data.GuardrailName = types.StringValue(name)
+	if observed.Params == nil {
+		return fmt.Errorf("guardrail response omitted required litellm_params")
 	}
-	if createdAt, ok := result["created_at"].(string); ok {
-		data.CreatedAt = types.StringValue(createdAt)
+	guardrail, ok := observed.Params["guardrail"].(string)
+	if !ok || guardrail == "" {
+		return fmt.Errorf("guardrail response omitted required litellm_params.guardrail")
 	}
-	// Handle litellm_params
-	if litellmParams, ok := result["litellm_params"].(map[string]interface{}); ok {
-		if guardrail, ok := litellmParams["guardrail"].(string); ok {
-			data.Guardrail = types.StringValue(guardrail)
-		}
-		// Only set default_on if the user configured it or it was unknown
-		if defaultOn, ok := litellmParams["default_on"].(bool); ok {
-			if !data.DefaultOn.IsNull() || data.DefaultOn.IsUnknown() {
-				data.DefaultOn = types.BoolValue(defaultOn)
-			}
-		}
+	mode, ok, err := guardrailModeFromAPI(observed.Params)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("guardrail response omitted required litellm_params.mode")
+	}
 
-		// Handle mode (can be string or array)
-		if mode, ok := litellmParams["mode"].(string); ok {
-			data.Mode = types.StringValue(mode)
-		} else if modeArray, ok := litellmParams["mode"].([]interface{}); ok {
-			if jsonBytes, err := json.Marshal(modeArray); err == nil {
-				data.Mode = types.StringValue(string(jsonBytes))
-			}
-		}
+	additional := guardrailAdditionalParams(observed.Params)
+	if imported && containsGuardrailMaskedValue(additional) {
+		return fmt.Errorf("guardrail import cannot recover masked litellm_params without prior Terraform state")
+	}
 
-		// Store other litellm_params as JSON (excluding guardrail, mode, default_on).
-		// Only update if the user originally configured litellm_params to avoid
-		// adopting the API's massive default parameter set. Top-level API defaults
-		// remain excluded. Within configured structures, remove only null object
-		// fields that the user omitted; retain explicit nulls and non-null additions
-		// so real server-side drift remains visible.
-		if !data.LitellmParams.IsNull() && !data.LitellmParams.IsUnknown() {
-			userParams, err := decodeRequestJSONObject(data.LitellmParams.ValueString(), "litellm_params")
+	data.ID = types.StringValue(observed.ID)
+	data.GuardrailID = types.StringValue(observed.ID)
+	data.GuardrailName = types.StringValue(observed.Name)
+	data.Guardrail = types.StringValue(guardrail)
+	data.Mode = types.StringValue(mode)
+	if observed.CreatedAt == nil {
+		data.CreatedAt = types.StringNull()
+	} else {
+		data.CreatedAt = types.StringValue(*observed.CreatedAt)
+	}
+	if defaultOn, exists := observed.Params["default_on"]; exists && defaultOn != nil {
+		value, valid := defaultOn.(bool)
+		if !valid {
+			return fmt.Errorf("guardrail response field %q must be a boolean or null", "litellm_params.default_on")
+		}
+		if !data.DefaultOn.IsNull() || data.DefaultOn.IsUnknown() {
+			data.DefaultOn = types.BoolValue(value)
+		}
+	} else if !data.DefaultOn.IsNull() || data.DefaultOn.IsUnknown() {
+		data.DefaultOn = types.BoolNull()
+	}
+
+	if !data.LitellmParams.IsNull() && !data.LitellmParams.IsUnknown() {
+		reconciled, err := reconcileOwnedGuardrailParams(observed.Params, data.LitellmParams.ValueString())
+		if err != nil {
+			return err
+		}
+		data.LitellmParams = types.StringValue(reconciled)
+	}
+
+	if !data.GuardrailInfo.IsNull() || data.GuardrailInfo.IsUnknown() {
+		if observed.Info != nil {
+			encoded, err := canonicalGuardrailJSONObject(observed.Info, "guardrail_info")
 			if err != nil {
 				return err
 			}
-			otherParams := make(map[string]interface{})
-			for k, configuredValue := range userParams {
-				if k != "guardrail" && k != "mode" && k != "default_on" {
-					if apiValue, exists := litellmParams[k]; exists {
-						otherParams[k] = removeUnconfiguredGuardrailNulls(apiValue, configuredValue)
-					}
-				}
+			if !jsonSemanticallyEqual(data.GuardrailInfo.ValueString(), encoded) {
+				data.GuardrailInfo = types.StringValue(encoded)
 			}
-			if len(otherParams) > 0 {
-				jsonBytes, err := json.Marshal(otherParams)
-				if err != nil {
-					return fmt.Errorf("invalid litellm_params response: cannot encode JSON")
-				}
-				data.LitellmParams = types.StringValue(string(jsonBytes))
-			}
+		} else {
+			data.GuardrailInfo = types.StringNull()
 		}
 	}
-
-	// Handle guardrail_info
-	if guardrailInfo, ok := result["guardrail_info"].(map[string]interface{}); ok && len(guardrailInfo) > 0 {
-		if jsonBytes, err := json.Marshal(guardrailInfo); err == nil {
-			data.GuardrailInfo = types.StringValue(string(jsonBytes))
-		}
-	}
-
 	return nil
 }

--- a/internal/provider/resource_guardrail_test.go
+++ b/internal/provider/resource_guardrail_test.go
@@ -111,7 +111,7 @@ func TestReadGuardrailFiltersNestedNullDefaults(t *testing.T) {
 		LitellmParams: types.StringValue(configured),
 	}
 
-	if err := resource.readGuardrail(context.Background(), &data); err != nil {
+	if err := resource.readGuardrail(context.Background(), &data, false); err != nil {
 		t.Fatalf("readGuardrail returned error: %v", err)
 	}
 	if got := data.LitellmParams.ValueString(); got != configured {
@@ -125,7 +125,8 @@ func TestReadGuardrailPreservesRealNestedDrift(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		writer.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(writer).Encode(map[string]interface{}{
-			"guardrail_id": "guardrail-1",
+			"guardrail_id":   "guardrail-1",
+			"guardrail_name": "test",
 			"litellm_params": map[string]interface{}{
 				"guardrail": "tool_permission",
 				"mode":      "post_call",
@@ -149,7 +150,7 @@ func TestReadGuardrailPreservesRealNestedDrift(t *testing.T) {
 		GuardrailID:   types.StringValue("guardrail-1"),
 		LitellmParams: types.StringValue(`{"rules":[{"decision":"allow","id":"allow_bash","tool_name":"Bash"}]}`),
 	}
-	if err := resource.readGuardrail(context.Background(), &data); err != nil {
+	if err := resource.readGuardrail(context.Background(), &data, false); err != nil {
 		t.Fatalf("readGuardrail returned error: %v", err)
 	}
 	want := `{"rules":[{"decision":"deny","id":"allow_bash","tool_name":"Bash"}]}`

--- a/internal_testing/datasources/guardrails_list.tf
+++ b/internal_testing/datasources/guardrails_list.tf
@@ -4,5 +4,6 @@ data "litellm_guardrails" "all" {
 }
 
 output "ds_guardrails_list" {
-  value = data.litellm_guardrails.all
+  value     = data.litellm_guardrails.all
+  sensitive = true
 }

--- a/internal_testing/resources/guardrail_minimal.tf
+++ b/internal_testing/resources/guardrail_minimal.tf
@@ -7,6 +7,21 @@ resource "litellm_guardrail" "minimal" {
   mode           = "pre_call"
 }
 
+data "litellm_guardrail" "minimal" {
+  guardrail_id = litellm_guardrail.minimal.id
+}
+
+data "litellm_guardrails" "registry" {
+  depends_on = [litellm_guardrail.minimal]
+
+  lifecycle {
+    postcondition {
+      condition     = contains([for guardrail in self.guardrails : guardrail.guardrail_id], litellm_guardrail.minimal.id)
+      error_message = "The v2 guardrail registry omitted the Terraform-managed guardrail."
+    }
+  }
+}
+
 output "guardrail_minimal_id" {
   value = litellm_guardrail.minimal.id
 }


### PR DESCRIPTION
### Summary

Closes #193. Guardrail inventory now reads LiteLLM v1.98's registry endpoint instead of the legacy config-only route, and guardrail parameter handling no longer replaces Terraform-owned credentials with masked API values.

`litellm_params` is sensitive on the resource and both data-source surfaces. Resource refresh preserves only exact LiteLLM v1.98 mask leaves (`*****` or two characters + four asterisks + two characters), retains visible sibling drift, keeps #125's nested-null normalization, and fails closed when import has no prior plaintext. Previously stored masks and structural ambiguity are not accepted as credentials.

Resource, single, and list reads share strict identity/type/mode/timestamp/JSON decoding. Malformed responses fail instead of retaining stale values. JSON objects are validated with exact-number decoding; semantic read-back preserves configured spelling, avoiding both formatting drift and Terraform Optional-only plan rewrites. Reserved `guardrail`, `mode`, and `default_on` keys cannot override their dedicated attributes.

### Registry behavior

`litellm_guardrails` now uses exact `GET /v2/guardrails/list`. In v1.98 this is one unpaginated, role-filtered registry snapshot containing visible active DB guardrails plus initialized config guardrails, with DB identities taking precedence. The legacy `/guardrails/list` remains a config-only LiteLLM view and is intentionally not used.

### Compatibility

Resource/data-source names, schema version 0, IDs, import format, existing attributes, JSON string types, and the existing list item object shape are preserved. Sensitivity is a security-hardening schema flag; enclosing outputs may now require `sensitive = true`. Semantically equal configured JSON keeps its prior spelling, so existing state does not receive formatting-only updates.

### Failure safety

Create requires a recoverable ID and authoritative masked-info read-back before committing full state. Failed update read-back retains prior state for safe retry. Masked imports fail rather than writing redaction markers into state.

### Validation

Validated against LiteLLM v1.98:

- create → single read → v2 list parity;
- exact v1.98 top-level and nested masking with sensitive log redaction;
- update, secret removal, and no-drift plans;
- masked import rejection and unmasked omitted-field import with zero drift;
- non-canonical valid JSON with zero drift;
- destroy;
- malformed envelope/item/parameter shapes, exact marker recognition, reserved keys, explicit empty objects, nested nulls, visible drift, exact integers, and import provenance in focused/protocol tests.

Full Go, race, vet, repeated focused tests, Terraform formatting, and `git diff --check` passed. The live provider matrix passed **23 resources / 0 drift / 0 failures**. Independent review initially found four issues; all were corrected, and focused re-review returned **SHIP** with no findings.

### Review focus

Please focus on exact mask recognition, imported-state provenance, strict v2 list projection, semantic JSON reconciliation without plan rewriting, and prior-state retention after unconfirmed updates.

### Checklist

- [x] Existing schema-v0 public types, IDs, list item shape, and imports preserved
- [x] Resource/single/list sensitive handling covered
- [x] V2 registry and malformed response coverage added
- [x] Masking, import, nested-null, exact-number, and no-drift tests added
- [x] Live LiteLLM v1.98 lifecycle and full 23-resource matrix passed
- [x] Registry documentation and acceptance fixtures updated
- [x] Independent focused review: SHIP

### Diff size

**Docs** — 3 files · `+27 / -9`

Documents v2 inventory scope, sensitivity/state implications, exact masking, imports, roles, and API-only behavior.

**Implementation** — 4 files · `+458 / -173`

Adds shared strict guardrail decoding/reconciliation and rewrites resource/single/list handling around the v1.98 contracts.

**Tests and acceptance fixtures** — 7 files · `+335 / -5`

Adds focused/protocol masking, import, JSON, envelope, list parity, malformed response, and live acceptance coverage.
