### PR TITLE
fix(prompt): scope lifecycle by environment and version

### DIFF
--- a/docs/data-sources/prompt.md
+++ b/docs/data-sources/prompt.md
@@ -6,7 +6,9 @@ Retrieves information about a specific LiteLLM prompt configuration.
 
 ```hcl
 data "litellm_prompt" "existing" {
-  prompt_id = "my-prompt"
+  prompt_id  = "my-prompt"
+  environment = "production"
+  # version = 2 # Optional; omission selects the latest version.
 }
 
 output "prompt_info" {
@@ -20,7 +22,9 @@ output "prompt_info" {
 
 ## Argument Reference
 
-* `prompt_id` - (Required) The prompt ID to look up.
+* `prompt_id` - (Required) The base prompt ID to look up.
+* `environment` - (Optional) Prompt environment. Defaults to `development`.
+* `version` - (Optional) Positive version to retrieve. Omit it to select the latest version deterministically within the environment.
 
 ## Attribute Reference
 
@@ -33,3 +37,9 @@ output "prompt_info" {
 * `ignore_prompt_manager_optional_params` - If true, ignore optional params from the prompt manager.
 * `dotprompt_content` - Content for dotprompt integration.
 * `prompt_type` - Type of prompt: "config" or "db".
+* `environment` - Environment returned for the selected prompt.
+* `version` - Selected positive version.
+* `created_at` - Creation timestamp of the selected version.
+* `updated_at` - Last-update timestamp of the selected version.
+
+The data source always sends an explicit environment query. Version-specific lookup uses LiteLLM's versioned prompt ID syntax while preserving `prompt_id` as the base ID in Terraform state.

--- a/docs/data-sources/prompts.md
+++ b/docs/data-sources/prompts.md
@@ -7,6 +7,10 @@ Retrieves a list of all LiteLLM prompt configurations.
 ```hcl
 data "litellm_prompts" "all" {}
 
+data "litellm_prompts" "production" {
+  environment = "production"
+}
+
 output "prompt_count" {
   value = length(data.litellm_prompts.all.prompts)
 }
@@ -32,14 +36,26 @@ output "langfuse_prompt_ids" {
 
 This data source has no required arguments.
 
+* `environment` - (Optional) Restricts the inventory to one environment. Omission preserves LiteLLM's unscoped latest-prompt inventory.
+
 ## Attribute Reference
 
 * `id` - Placeholder identifier.
 * `prompts` - List of prompt objects, each containing:
-  * `prompt_id` - The prompt ID.
+  * `prompt_id` - The base prompt ID.
+  * `environment` - Prompt environment.
+  * `version` - Latest version represented by the item, when LiteLLM supplies version history.
+  * `created_at` - Creation timestamp of the represented version.
+  * `updated_at` - Last-update timestamp of the represented version.
   * `prompt_integration` - The prompt integration provider.
   * `api_base` - Base URL for the prompt provider API.
   * `provider_specific_query_params` - JSON string of provider-specific query parameters.
   * `ignore_prompt_manager_model` - If true, ignore the model in prompt manager.
   * `ignore_prompt_manager_optional_params` - If true, ignore optional params.
   * `prompt_type` - Type of prompt: "config" or "db".
+
+## Environment Filtering
+
+LiteLLM v1.98's process-local prompt registry can collapse equal base IDs and version numbers across environments. When `environment` is configured, the provider discovers visible base IDs and resolves each through the authoritative environment-scoped single-info endpoint, bounded to 200 candidates. This restores deterministic latest-version inventory for same-name cross-environment prompts. Without a filter, the data source preserves LiteLLM's unscoped registry view and may reflect that upstream collision behavior.
+
+The v1.98 list route is unpaginated. Reads require an admin-view role; unauthorized LiteLLM callers may receive an empty list.

--- a/docs/resources/prompt.md
+++ b/docs/resources/prompt.md
@@ -18,6 +18,7 @@ resource "litellm_prompt" "minimal" {
 ```hcl
 resource "litellm_prompt" "full" {
   prompt_id          = "customer-support"
+  environment        = "production"
   prompt_integration = "dotprompt"
   prompt_type        = "db"
 
@@ -68,8 +69,9 @@ The following arguments are supported:
 
 ### Optional
 
+* `environment` - (Optional, ForceNew) Environment-scoped ownership dimension. Defaults to `"development"`. Changing it replaces the resource without deleting versions in any other environment.
 * `dotprompt_content` - (Optional) The dotprompt-formatted content for the prompt. Supports YAML frontmatter for model configuration and Mustache-style `{{variable}}` template syntax.
-* `prompt_type` - (Optional) The prompt definition location. LiteLLM v1.98 accepts exactly `"config"` or `"db"`.
+* `prompt_type` - (Optional) The prompt definition location. LiteLLM v1.98 accepts `"config"` or `"db"`; API-managed creates use `"db"` when omitted. The provider rejects new `config` creates because v1.98 cannot update or delete them, while existing/imported config prompts remain readable.
 * `api_base` - (Optional) API base URL for the prompt manager endpoint.
 * `api_key` - (Optional, Sensitive) API key for authenticating with the prompt manager endpoint.
 * `provider_specific_query_params` - (Optional) Provider-specific query parameters to pass through.
@@ -80,19 +82,44 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The identifier of the prompt.
+* `id` - The base prompt identifier. This remains equal to `prompt_id` for backward compatibility; the full managed identity is the pair `(prompt_id, environment)`.
+* `version` - The latest positive version owned in this environment. Each successful update appends a new version.
+* `created_at` - Creation timestamp of the selected latest version.
+* `updated_at` - Last-update timestamp of the selected latest version.
 
 ## Import
 
-Prompts can be imported using the prompt ID:
+Prompts can be imported with a collision-safe environment-qualified ID:
 
 ```shell
-terraform import litellm_prompt.example <prompt-id>
+# prompt_id = "my-prompt", environment = "production"
+terraform import litellm_prompt.example v1.bXktcHJvbXB0.cHJvZHVjdGlvbg
 ```
+
+The grammar is `v1.<base64url(prompt_id)>.<base64url(environment)>`, without padding. Historical bare prompt IDs remain accepted and import the `development` environment:
+
+```shell
+terraform import litellm_prompt.example my-prompt
+```
+
+If a historical prompt ID itself has the exact canonical-looking `v1.<part>.<part>` shape, disambiguate it with `legacy.<base64url(prompt_id)>`; for example, `v1.YQ.Yg` is imported as `legacy.djEuWVEuWWc`.
+
+## Environment and Version Ownership
+
+A `litellm_prompt` resource represents the mutable latest logical prompt for one `(prompt_id, environment)` pair. Create first verifies that the scoped identity is absent (existing prompts must be imported), then `POST` creates version 1 in that environment, and each Terraform update uses LiteLLM's full `PUT` contract to append the next version. Refresh always selects the latest version with an explicit environment query. Terraform does not model immutable individual versions because LiteLLM v1.98 cannot delete one version: environment-scoped DELETE removes the complete version history for that logical prompt.
+
+Before a full-version update, the provider reads the current scoped prompt and refuses to proceed if non-null integration parameters are not represented by the schema or if the remote prompt has an API key that Terraform does not own. This prevents imported credentials or integration-specific fields from being silently dropped by LiteLLM's full `PUT`. Configure `api_key` explicitly before updating an imported credential-bearing prompt; prompts with other unmodeled parameters remain read/import-only until schema support is added.
+
+Destroy always sends `?environment=...` and confirms that scoped identity is absent. It never intentionally sends LiteLLM's dangerous unscoped delete, which would remove every environment. If v1.98 returns 404 because a worker lost its process-local registry key while the DB row remains, the provider reinitializes the exact scoped DB prompt with a no-content-change PATCH, retries DELETE once, and still requires an absence read before removing state.
+
+LiteLLM v1.98's process-local prompt registry keys omit environment and can collide when two environments use the same base ID/version. The provider uses explicit environment-scoped info reads and version inventory to recover deterministic API state, but applications should still validate runtime prompt resolution across workers.
 
 ## Notes
 
-* Prompt IDs must be unique within the LiteLLM instance.
+* Prompt IDs are unique only within an environment/version tuple, not globally.
+* Existing configurations that omit `environment` continue to own `development`, and `id` remains the base `prompt_id`.
+* `prompt_type = "config"` is accepted by LiteLLM but config prompts cannot be updated or deleted through v1.98 management APIs. Existing config prompts are therefore read/import-only and destroy safely retains state when LiteLLM refuses deletion; use `db` (the default) for managed resources.
+* Prompt writes require LiteLLM `proxy_admin`; reads require an admin-view role. Prompt management is not Enterprise-license gated but database-backed writes require LiteLLM database support.
 * Use heredoc syntax (`<<-EOT`) for multi-line dotprompt content.
 * Dotprompt content supports YAML frontmatter (between `---` delimiters) for specifying model and parameter defaults.
 * Template variables use Mustache-style `{{variable}}` syntax within the prompt body.

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -234,8 +234,10 @@ resource "litellm_tag" "cost_center_rd" {
 # =============================================================================
 
 resource "litellm_prompt" "support_agent" {
-  prompt_id   = "customer-support-agent"
-  prompt_type = "db"
+  prompt_id          = "customer-support-agent"
+  environment        = "production"
+  prompt_integration = "dotprompt"
+  prompt_type        = "db"
 
   dotprompt_content = <<-EOT
     You are a helpful customer support agent for Enterprise Corp.
@@ -251,8 +253,10 @@ resource "litellm_prompt" "support_agent" {
 }
 
 resource "litellm_prompt" "code_assistant" {
-  prompt_id   = "code-assistant"
-  prompt_type = "db"
+  prompt_id          = "code-assistant"
+  environment        = "production"
+  prompt_integration = "dotprompt"
+  prompt_type        = "db"
 
   dotprompt_content = <<-EOT
     You are an expert software developer assistant.

--- a/internal/provider/build_request_test.go
+++ b/internal/provider/build_request_test.go
@@ -339,7 +339,7 @@ func TestBuildPromptRequest(t *testing.T) {
 		t.Errorf("ignore_prompt_manager_model = %v", params["ignore_prompt_manager_model"])
 	}
 	info, ok := req["prompt_info"].(map[string]interface{})
-	if !ok || info["prompt_type"] != "chat" {
+	if !ok || info["prompt_type"] != "chat" || info["environment"] != defaultPromptEnvironment {
 		t.Errorf("prompt_info = %#v", req["prompt_info"])
 	}
 }

--- a/internal/provider/datasource_prompt.go
+++ b/internal/provider/datasource_prompt.go
@@ -6,8 +6,11 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -31,6 +34,10 @@ type PromptDataSourceModel struct {
 	IgnorePromptManagerOptionalParams types.Bool   `tfsdk:"ignore_prompt_manager_optional_params"`
 	DotpromptContent                  types.String `tfsdk:"dotprompt_content"`
 	PromptType                        types.String `tfsdk:"prompt_type"`
+	Environment                       types.String `tfsdk:"environment"`
+	Version                           types.Int64  `tfsdk:"version"`
+	CreatedAt                         types.String `tfsdk:"created_at"`
+	UpdatedAt                         types.String `tfsdk:"updated_at"`
 }
 
 func (d *PromptDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -46,8 +53,24 @@ func (d *PromptDataSource) Schema(ctx context.Context, req datasource.SchemaRequ
 				Computed:    true,
 			},
 			"prompt_id": schema.StringAttribute{
-				Description: "The prompt ID to look up.",
+				Description: "The base prompt ID to look up.",
 				Required:    true,
+			},
+			"environment": schema.StringAttribute{
+				Description: "Prompt environment. Defaults to development.",
+				Optional:    true,
+				Computed:    true,
+				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(1),
+				},
+			},
+			"version": schema.Int64Attribute{
+				Description: "Specific prompt version. When omitted, the latest version in the environment is selected.",
+				Optional:    true,
+				Computed:    true,
+				Validators: []validator.Int64{
+					int64validator.AtLeast(1),
+				},
 			},
 			"prompt_integration": schema.StringAttribute{
 				Description: "The prompt integration provider.",
@@ -75,6 +98,14 @@ func (d *PromptDataSource) Schema(ctx context.Context, req datasource.SchemaRequ
 			},
 			"prompt_type": schema.StringAttribute{
 				Description: "Type of prompt: 'config' or 'db'.",
+				Computed:    true,
+			},
+			"created_at": schema.StringAttribute{
+				Description: "Creation timestamp of the selected version.",
+				Computed:    true,
+			},
+			"updated_at": schema.StringAttribute{
+				Description: "Last-update timestamp of the selected version.",
 				Computed:    true,
 			},
 		},
@@ -107,47 +138,93 @@ func (d *PromptDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 	}
 
 	promptID := data.PromptID.ValueString()
-	endpoint := fmt.Sprintf("/prompts/%s", promptID)
+	environment := promptEnvironment(data.Environment.ValueString())
+	var requestedVersion *int64
+	if !data.Version.IsNull() && !data.Version.IsUnknown() {
+		value := data.Version.ValueInt64()
+		if value <= 0 {
+			resp.Diagnostics.AddError("Invalid Prompt Version", "version must be a positive integer")
+			return
+		}
+		requestedVersion = &value
+	}
+	endpoint := promptEndpoint(promptID, environment, requestedVersion)
 
 	var rawResult map[string]interface{}
 	if err := readPromptDataSourceWithRetry(ctx, d.client, endpoint, &rawResult, 8); err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read prompt: %s", err))
 		return
 	}
-	result := parsePromptResult(rawResult)
-
-	// Populate the data model
-	data.ID = types.StringValue(promptID)
-
-	// Handle litellm_params
-	if litellmParams, ok := result["litellm_params"].(map[string]interface{}); ok {
-		if integration, ok := litellmParams["prompt_integration"].(string); ok {
-			data.PromptIntegration = types.StringValue(integration)
-		}
-		if apiBase, ok := litellmParams["api_base"].(string); ok {
-			data.APIBase = types.StringValue(apiBase)
-		}
-		if ignoreModel, ok := litellmParams["ignore_prompt_manager_model"].(bool); ok {
-			data.IgnorePromptManagerModel = types.BoolValue(ignoreModel)
-		}
-		if ignoreParams, ok := litellmParams["ignore_prompt_manager_optional_params"].(bool); ok {
-			data.IgnorePromptManagerOptionalParams = types.BoolValue(ignoreParams)
-		}
-		if dotprompt, ok := litellmParams["dotprompt_content"].(string); ok {
-			data.DotpromptContent = types.StringValue(dotprompt)
-		}
-		if providerParams, ok := litellmParams["provider_specific_query_params"].(map[string]interface{}); ok {
-			if jsonBytes, err := json.Marshal(providerParams); err == nil {
-				data.ProviderSpecificQueryParams = types.StringValue(string(jsonBytes))
-			}
-		}
+	observed, err := promptObject(rawResult, true, promptID, environment)
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
+	}
+	if !observed.HasVersion || (requestedVersion != nil && observed.Version != *requestedVersion) {
+		resp.Diagnostics.AddError("Invalid API Response", "Prompt response omitted or mismatched the selected version")
+		return
+	}
+	integration, ok := observed.Params["prompt_integration"].(string)
+	if !ok || integration == "" {
+		resp.Diagnostics.AddError("Invalid API Response", "Prompt response omitted required litellm_params.prompt_integration")
+		return
 	}
 
-	// Handle prompt_info
-	if promptInfo, ok := result["prompt_info"].(map[string]interface{}); ok {
-		if promptType, ok := promptInfo["prompt_type"].(string); ok {
-			data.PromptType = types.StringValue(promptType)
+	data.ID = types.StringValue(observed.PromptID)
+	data.PromptID = types.StringValue(observed.PromptID)
+	data.Environment = types.StringValue(observed.Environment)
+	data.Version = types.Int64Value(observed.Version)
+	data.PromptIntegration = types.StringValue(integration)
+	data.APIBase, err = promptStringFromAPI(observed.Params, "api_base")
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
+	}
+	data.DotpromptContent, err = promptStringFromAPI(observed.Params, "dotprompt_content")
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
+	}
+	data.IgnorePromptManagerModel, err = promptBoolFromAPI(observed.Params, "ignore_prompt_manager_model")
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
+	}
+	data.IgnorePromptManagerOptionalParams, err = promptBoolFromAPI(observed.Params, "ignore_prompt_manager_optional_params")
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
+	}
+	data.ProviderSpecificQueryParams = types.StringNull()
+	if value, exists := observed.Params["provider_specific_query_params"]; exists && value != nil {
+		object, valid := value.(map[string]interface{})
+		if !valid {
+			resp.Diagnostics.AddError("Invalid API Response", "Prompt response returned invalid provider_specific_query_params")
+			return
 		}
+		encoded, marshalErr := json.Marshal(object)
+		if marshalErr != nil {
+			resp.Diagnostics.AddError("Invalid API Response", "Prompt response provider_specific_query_params could not be encoded")
+			return
+		}
+		data.ProviderSpecificQueryParams = types.StringValue(string(encoded))
+	}
+	data.PromptType = types.StringNull()
+	if value, exists := observed.Info["prompt_type"]; exists && value != nil {
+		promptType, valid := value.(string)
+		if !valid {
+			resp.Diagnostics.AddError("Invalid API Response", "Prompt response returned invalid prompt_info.prompt_type")
+			return
+		}
+		data.PromptType = types.StringValue(promptType)
+	}
+	data.CreatedAt = types.StringNull()
+	data.UpdatedAt = types.StringNull()
+	if observed.CreatedAt != nil {
+		data.CreatedAt = types.StringValue(*observed.CreatedAt)
+	}
+	if observed.UpdatedAt != nil {
+		data.UpdatedAt = types.StringValue(*observed.UpdatedAt)
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -164,7 +241,7 @@ func readPromptDataSourceWithRetry(ctx context.Context, client *Client, endpoint
 			return nil
 		}
 
-		if !IsNotFoundError(err) {
+		if !isPromptAbsentError(err) {
 			return err
 		}
 

--- a/internal/provider/datasource_prompts_list.go
+++ b/internal/provider/datasource_prompts_list.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -22,8 +24,9 @@ type PromptsListDataSource struct {
 }
 
 type PromptsListDataSourceModel struct {
-	ID      types.String          `tfsdk:"id"`
-	Prompts []PromptListItemModel `tfsdk:"prompts"`
+	ID          types.String          `tfsdk:"id"`
+	Environment types.String          `tfsdk:"environment"`
+	Prompts     []PromptListItemModel `tfsdk:"prompts"`
 }
 
 type PromptListItemModel struct {
@@ -34,6 +37,10 @@ type PromptListItemModel struct {
 	IgnorePromptManagerModel          types.Bool   `tfsdk:"ignore_prompt_manager_model"`
 	IgnorePromptManagerOptionalParams types.Bool   `tfsdk:"ignore_prompt_manager_optional_params"`
 	PromptType                        types.String `tfsdk:"prompt_type"`
+	Environment                       types.String `tfsdk:"environment"`
+	Version                           types.Int64  `tfsdk:"version"`
+	CreatedAt                         types.String `tfsdk:"created_at"`
+	UpdatedAt                         types.String `tfsdk:"updated_at"`
 }
 
 func (d *PromptsListDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -48,6 +55,13 @@ func (d *PromptsListDataSource) Schema(ctx context.Context, req datasource.Schem
 				Description: "Placeholder identifier for this data source.",
 				Computed:    true,
 			},
+			"environment": schema.StringAttribute{
+				Description: "Optional environment filter. When omitted, LiteLLM returns its unscoped latest-prompt inventory.",
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(1),
+				},
+			},
 			"prompts": schema.ListNestedAttribute{
 				Description: "List of prompts.",
 				Computed:    true,
@@ -55,6 +69,22 @@ func (d *PromptsListDataSource) Schema(ctx context.Context, req datasource.Schem
 					Attributes: map[string]schema.Attribute{
 						"prompt_id": schema.StringAttribute{
 							Description: "The prompt ID.",
+							Computed:    true,
+						},
+						"environment": schema.StringAttribute{
+							Description: "Prompt environment.",
+							Computed:    true,
+						},
+						"version": schema.Int64Attribute{
+							Description: "Latest version represented by this item when LiteLLM returns one.",
+							Computed:    true,
+						},
+						"created_at": schema.StringAttribute{
+							Description: "Creation timestamp of this version.",
+							Computed:    true,
+						},
+						"updated_at": schema.StringAttribute{
+							Description: "Last-update timestamp of this version.",
 							Computed:    true,
 						},
 						"prompt_integration": schema.StringAttribute{
@@ -105,6 +135,130 @@ func (d *PromptsListDataSource) Configure(ctx context.Context, req datasource.Co
 	d.client = client
 }
 
+func promptListItemFromAPI(raw map[string]interface{}, expectedEnvironment string) (PromptListItemModel, error) {
+	var item PromptListItemModel
+	observed, err := promptObject(raw, false, "", expectedEnvironment)
+	if err != nil {
+		return item, err
+	}
+	integration, ok := observed.Params["prompt_integration"].(string)
+	if !ok || integration == "" {
+		return item, fmt.Errorf("prompt response omitted required litellm_params.prompt_integration")
+	}
+	item.PromptID = types.StringValue(observed.PromptID)
+	item.PromptIntegration = types.StringValue(integration)
+	item.Environment = types.StringValue(observed.Environment)
+	item.Version = types.Int64Null()
+	item.CreatedAt = types.StringNull()
+	item.UpdatedAt = types.StringNull()
+	item.PromptType = types.StringNull()
+	item.ProviderSpecificQueryParams = types.StringNull()
+	if observed.HasVersion {
+		item.Version = types.Int64Value(observed.Version)
+	}
+	if observed.CreatedAt != nil {
+		item.CreatedAt = types.StringValue(*observed.CreatedAt)
+	}
+	if observed.UpdatedAt != nil {
+		item.UpdatedAt = types.StringValue(*observed.UpdatedAt)
+	}
+	item.APIBase, err = promptStringFromAPI(observed.Params, "api_base")
+	if err != nil {
+		return item, err
+	}
+	item.IgnorePromptManagerModel, err = promptBoolFromAPI(observed.Params, "ignore_prompt_manager_model")
+	if err != nil {
+		return item, err
+	}
+	item.IgnorePromptManagerOptionalParams, err = promptBoolFromAPI(observed.Params, "ignore_prompt_manager_optional_params")
+	if err != nil {
+		return item, err
+	}
+	if value, exists := observed.Params["provider_specific_query_params"]; exists && value != nil {
+		object, valid := value.(map[string]interface{})
+		if !valid {
+			return item, fmt.Errorf("prompt response returned invalid provider_specific_query_params")
+		}
+		encoded, marshalErr := json.Marshal(object)
+		if marshalErr != nil {
+			return item, fmt.Errorf("prompt response provider_specific_query_params could not be encoded")
+		}
+		item.ProviderSpecificQueryParams = types.StringValue(string(encoded))
+	}
+	if value, exists := observed.Info["prompt_type"]; exists && value != nil {
+		promptType, valid := value.(string)
+		if !valid {
+			return item, fmt.Errorf("prompt response returned invalid prompt_info.prompt_type")
+		}
+		item.PromptType = types.StringValue(promptType)
+	}
+	return item, nil
+}
+
+func fetchPromptListItems(ctx context.Context, client *Client, environment string, configured bool) ([]PromptListItemModel, error) {
+	if !configured {
+		results, err := fetchEnvelopeListObjects(ctx, client, "/prompts/list", "prompts", "prompt item")
+		if err != nil {
+			return nil, err
+		}
+		items := make([]PromptListItemModel, 0, len(results))
+		for _, result := range results {
+			item, err := promptListItemFromAPI(result, "")
+			if err != nil {
+				return nil, err
+			}
+			items = append(items, item)
+		}
+		return items, nil
+	}
+
+	// v1.98's process-local registry keys omit environment, so its filtered list
+	// can lose one side of a same-ID cross-environment collision. Discover base
+	// IDs from both snapshots, then use the authoritative environment-scoped
+	// versions route for each logical prompt.
+	candidates := make(map[string]struct{})
+	for _, endpoint := range []string{"/prompts/list", promptListEndpoint(environment, true)} {
+		results, err := fetchEnvelopeListObjects(ctx, client, endpoint, "prompts", "prompt item")
+		if err != nil {
+			return nil, err
+		}
+		for _, result := range results {
+			promptID, ok := result["prompt_id"].(string)
+			if !ok || promptID == "" {
+				return nil, fmt.Errorf("prompt list response omitted a non-empty prompt_id")
+			}
+			candidates[promptID] = struct{}{}
+		}
+	}
+	if len(candidates) > 200 {
+		return nil, fmt.Errorf("prompt inventory exceeded the bounded environment-enrichment limit")
+	}
+	items := make([]PromptListItemModel, 0, len(candidates))
+	for promptID := range candidates {
+		var raw map[string]interface{}
+		err := client.DoRequestWithResponse(ctx, "GET", promptEndpoint(promptID, environment, nil), nil, &raw)
+		if err != nil {
+			if isPromptAbsentError(err) {
+				continue
+			}
+			return nil, err
+		}
+		spec, ok := raw["prompt_spec"].(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("prompt response omitted required prompt_spec")
+		}
+		item, err := promptListItemFromAPI(spec, promptEnvironment(environment))
+		if err != nil {
+			return nil, err
+		}
+		if item.PromptID.ValueString() != promptID {
+			return nil, fmt.Errorf("prompt info response identity did not match the requested prompt")
+		}
+		items = append(items, item)
+	}
+	return items, nil
+}
+
 func (d *PromptsListDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	var data PromptsListDataSourceModel
 
@@ -113,54 +267,23 @@ func (d *PromptsListDataSource) Read(ctx context.Context, req datasource.ReadReq
 		return
 	}
 
-	results, err := fetchEnvelopeListObjects(ctx, d.client, "/prompts/list", "prompts", "prompt item")
+	environmentConfigured := !data.Environment.IsNull() && !data.Environment.IsUnknown()
+	environment := data.Environment.ValueString()
+	prompts, err := fetchPromptListItems(ctx, d.client, environment, environmentConfigured)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to list prompts: %s", err))
 		return
 	}
-	prompts := make([]PromptListItemModel, 0, len(results))
-	for _, result := range results {
-		prompt := PromptListItemModel{}
-
-		if promptID, ok := result["prompt_id"].(string); ok && promptID != "" {
-			prompt.PromptID = types.StringValue(promptID)
-		} else {
-			resp.Diagnostics.AddError("Invalid API Response", "/prompts/list returned a prompt object without prompt_id")
-			return
-		}
-
-		// Handle litellm_params
-		if litellmParams, ok := result["litellm_params"].(map[string]interface{}); ok {
-			if integration, ok := litellmParams["prompt_integration"].(string); ok {
-				prompt.PromptIntegration = types.StringValue(integration)
-			}
-			if apiBase, ok := litellmParams["api_base"].(string); ok {
-				prompt.APIBase = types.StringValue(apiBase)
-			}
-			if ignoreModel, ok := litellmParams["ignore_prompt_manager_model"].(bool); ok {
-				prompt.IgnorePromptManagerModel = types.BoolValue(ignoreModel)
-			}
-			if ignoreParams, ok := litellmParams["ignore_prompt_manager_optional_params"].(bool); ok {
-				prompt.IgnorePromptManagerOptionalParams = types.BoolValue(ignoreParams)
-			}
-			if providerParams, ok := litellmParams["provider_specific_query_params"].(map[string]interface{}); ok {
-				if jsonBytes, err := json.Marshal(providerParams); err == nil {
-					prompt.ProviderSpecificQueryParams = types.StringValue(string(jsonBytes))
-				}
-			}
-		}
-
-		// Handle prompt_info
-		if promptInfo, ok := result["prompt_info"].(map[string]interface{}); ok {
-			if promptType, ok := promptInfo["prompt_type"].(string); ok {
-				prompt.PromptType = types.StringValue(promptType)
-			}
-		}
-
-		prompts = append(prompts, prompt)
-	}
 	sort.SliceStable(prompts, func(i, j int) bool {
-		return prompts[i].PromptID.ValueString() < prompts[j].PromptID.ValueString()
+		leftEnvironment, rightEnvironment := prompts[i].Environment.ValueString(), prompts[j].Environment.ValueString()
+		if leftEnvironment != rightEnvironment {
+			return leftEnvironment < rightEnvironment
+		}
+		leftID, rightID := prompts[i].PromptID.ValueString(), prompts[j].PromptID.ValueString()
+		if leftID != rightID {
+			return leftID < rightID
+		}
+		return prompts[i].Version.ValueInt64() < prompts[j].Version.ValueInt64()
 	})
 
 	data.ID = types.StringValue("prompts")

--- a/internal/provider/prompt_contract_test.go
+++ b/internal/provider/prompt_contract_test.go
@@ -1,0 +1,263 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	resourceschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func promptTestSpec(promptID, environment string, version int64, content string) map[string]interface{} {
+	return map[string]interface{}{
+		"prompt_id": promptID, "environment": environment, "version": version,
+		"created_at": "2026-08-25T00:00:00Z", "updated_at": nil,
+		"litellm_params": map[string]interface{}{
+			"prompt_integration": "dotprompt", "dotprompt_content": content,
+			"ignore_prompt_manager_model": false,
+		},
+		"prompt_info": map[string]interface{}{"prompt_type": "db", "environment": environment},
+	}
+}
+
+func TestPromptImportIDRoundTripAndLegacyCompatibility(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct{ promptID, environment string }{
+		{"prompt:with/slash.v2", "staging/us east"},
+		{"v1.looks.canonical", "production"},
+		{"ümlaut", "环境"},
+	} {
+		encoded := promptImportID(test.promptID, test.environment)
+		promptID, environment, err := parsePromptImportID(encoded)
+		if err != nil || promptID != test.promptID || environment != test.environment {
+			t.Fatalf("round trip %q: prompt=%q environment=%q err=%v", encoded, promptID, environment, err)
+		}
+	}
+	promptID, environment, err := parsePromptImportID("legacy-prompt")
+	if err != nil || promptID != "legacy-prompt" || environment != defaultPromptEnvironment {
+		t.Fatalf("legacy import: prompt=%q environment=%q err=%v", promptID, environment, err)
+	}
+	ambiguous := "v1.YQ.Yg"
+	promptID, environment, err = parsePromptImportID(legacyPromptImportID(ambiguous))
+	if err != nil || promptID != ambiguous || environment != defaultPromptEnvironment {
+		t.Fatalf("escaped legacy import: prompt=%q environment=%q err=%v", promptID, environment, err)
+	}
+	for _, malformed := range []string{"", "v1.***.eA", "legacy.***"} {
+		if _, _, err := parsePromptImportID(malformed); err == nil {
+			t.Fatalf("malformed import ID %q was accepted", malformed)
+		}
+	}
+}
+
+func TestPromptScopedExistenceRequiresAuthoritativeVersionResult(t *testing.T) {
+	t.Parallel()
+	for name, versionsStatus := range map[string]struct {
+		status int
+		exists bool
+		err    bool
+	}{
+		"absent 404":    {http.StatusNotFound, false, false},
+		"ambiguous 400": {http.StatusBadRequest, false, true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				writer.Header().Set("Content-Type", "application/json")
+				if request.URL.Path == "/prompts/prompt" && request.URL.Query().Get("environment") == "production" {
+					http.Error(writer, "ambiguous info absence", http.StatusBadRequest)
+					return
+				}
+				if request.URL.Path == "/prompts/prompt/versions" {
+					http.Error(writer, "versions result", versionsStatus.status)
+					return
+				}
+				http.NotFound(writer, request)
+			}))
+			defer server.Close()
+			client := &Client{APIBase: server.URL, APIKey: "test", HTTPClient: server.Client()}
+			exists, err := promptScopedExists(context.Background(), client, "prompt", "production")
+			if exists != versionsStatus.exists || (err != nil) != versionsStatus.err {
+				t.Fatalf("exists=%t err=%v", exists, err)
+			}
+		})
+	}
+}
+
+func TestPromptEndpointsAlwaysScopeEnvironment(t *testing.T) {
+	t.Parallel()
+	endpoint := promptEndpoint("prompt/with spaces", "prod/east", nil)
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsed.Query().Get("environment") != "prod/east" || parsed.EscapedPath() != "/prompts/prompt%2Fwith%20spaces" {
+		t.Fatalf("scoped endpoint = %s", endpoint)
+	}
+	version := int64(7)
+	versionEndpoint := promptEndpoint("prompt", "production", &version)
+	if versionEndpoint != "/prompts/prompt.v7?environment=production" {
+		t.Fatalf("version endpoint = %s", versionEndpoint)
+	}
+	if got := promptVersionsEndpoint("prompt", "production"); got != "/prompts/prompt/versions?environment=production" {
+		t.Fatalf("versions endpoint = %s", got)
+	}
+}
+
+func TestBuildPromptRequestAlwaysIncludesEnvironment(t *testing.T) {
+	t.Parallel()
+	request, err := (&PromptResource{}).buildPromptRequest(context.Background(), &PromptResourceModel{
+		PromptID: types.StringValue("prompt"), PromptIntegration: types.StringValue("dotprompt"), Environment: types.StringValue("staging"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	info, ok := request["prompt_info"].(map[string]interface{})
+	if !ok || info["environment"] != "staging" || info["prompt_type"] != "db" {
+		t.Fatalf("prompt_info = %#v", request["prompt_info"])
+	}
+}
+
+func TestPromptAuthoritativeConfigTypeIsReadOnly(t *testing.T) {
+	t.Parallel()
+	for name, info := range map[string]map[string]interface{}{
+		"config":     {"prompt_type": "config"},
+		"missing":    {},
+		"null":       {"prompt_type": nil},
+		"wrong type": {"prompt_type": true},
+		"unknown":    {"prompt_type": "other"},
+	} {
+		if err := validateMutablePromptInfo(info); err == nil {
+			t.Fatalf("%s prompt info was treated as mutable", name)
+		}
+	}
+	if err := validateMutablePromptInfo(map[string]interface{}{"prompt_type": "db"}); err != nil {
+		t.Fatalf("database prompt rejected: %v", err)
+	}
+}
+
+func TestPromptUpdateCoverageRejectsDestructiveImportedUpdates(t *testing.T) {
+	t.Parallel()
+	base := PromptResourceModel{APIKey: types.StringNull()}
+	if err := validatePromptUpdateCoverage(map[string]interface{}{"prompt_integration": "dotprompt", "custom_secret": "value"}, &base, &base); err == nil {
+		t.Fatal("unmodeled remote parameter was silently dropped")
+	}
+	if err := validatePromptUpdateCoverage(map[string]interface{}{"prompt_integration": "dotprompt", "api_key": "masked-or-remote"}, &base, &base); err == nil {
+		t.Fatal("unowned remote API key was silently dropped")
+	}
+	configured := base
+	configured.APIKey = types.StringValue("configured")
+	if err := validatePromptUpdateCoverage(map[string]interface{}{"prompt_integration": "dotprompt", "api_key": "remote"}, &configured, &base); err != nil {
+		t.Fatalf("configured API key update rejected: %v", err)
+	}
+	removed, prior := base, base
+	prior.APIKey = types.StringValue("prior-owned")
+	if err := validatePromptUpdateCoverage(map[string]interface{}{"prompt_integration": "dotprompt", "api_key": "remote"}, &removed, &prior); err != nil {
+		t.Fatalf("owned API key removal rejected: %v", err)
+	}
+}
+
+func TestPromptObjectStrictEnvironmentVersionIdentity(t *testing.T) {
+	t.Parallel()
+	wrapped := map[string]interface{}{"prompt_spec": promptTestSpec("prompt", "production", 3, "content")}
+	observed, err := promptObject(wrapped, true, "prompt", "production")
+	if err != nil || !observed.HasVersion || observed.Version != 3 {
+		t.Fatalf("observed=%#v err=%v", observed, err)
+	}
+	for name, mutate := range map[string]func(map[string]interface{}){
+		"identity":            func(value map[string]interface{}) { value["prompt_id"] = "other" },
+		"environment":         func(value map[string]interface{}) { value["environment"] = "development" },
+		"missing environment": func(value map[string]interface{}) { delete(value, "environment") },
+		"conflicting environment": func(value map[string]interface{}) {
+			value["prompt_info"].(map[string]interface{})["environment"] = "development"
+		},
+		"version": func(value map[string]interface{}) { value["version"] = json.Number("0") },
+		"params":  func(value map[string]interface{}) { value["litellm_params"] = []interface{}{} },
+	} {
+		t.Run(name, func(t *testing.T) {
+			value := promptTestSpec("prompt", "production", 3, "content")
+			mutate(value)
+			if _, err := promptObject(map[string]interface{}{"prompt_spec": value}, true, "prompt", "production"); err == nil {
+				t.Fatal("malformed prompt response was accepted")
+			}
+		})
+	}
+}
+
+func TestPromptEnvironmentFilteredListRecoversRegistryCollision(t *testing.T) {
+	t.Parallel()
+	requests := map[string]int{}
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		requests[request.URL.RequestURI()]++
+		writer.Header().Set("Content-Type", "application/json")
+		switch request.URL.RequestURI() {
+		case "/prompts/list":
+			_ = json.NewEncoder(writer).Encode(map[string]interface{}{"prompts": []interface{}{promptTestSpec("same", "development", 2, "development")}})
+		case "/prompts/list?environment=production":
+			_ = json.NewEncoder(writer).Encode(map[string]interface{}{"prompts": []interface{}{}})
+		case "/prompts/same?environment=production":
+			_ = json.NewEncoder(writer).Encode(map[string]interface{}{"prompt_spec": promptTestSpec("same", "production", 1, "production")})
+		default:
+			http.NotFound(writer, request)
+		}
+	}))
+	defer server.Close()
+	client := &Client{APIBase: server.URL, APIKey: "test", HTTPClient: server.Client()}
+	items, err := fetchPromptListItems(context.Background(), client, "production", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 1 || items[0].Environment.ValueString() != "production" || items[0].Version.ValueInt64() != 1 {
+		t.Fatalf("collision recovery items=%#v", items)
+	}
+	if requests["/prompts/same?environment=production"] != 1 {
+		t.Fatalf("scoped info requests=%#v", requests)
+	}
+}
+
+func TestPromptEnvironmentFilteredListEnrichmentIsBounded(t *testing.T) {
+	t.Parallel()
+	prompts := make([]interface{}, 201)
+	for index := range prompts {
+		prompts[index] = promptTestSpec(fmt.Sprintf("prompt-%03d", index), "development", 1, "content")
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		if request.URL.RequestURI() == "/prompts/list" {
+			_ = json.NewEncoder(writer).Encode(map[string]interface{}{"prompts": prompts})
+			return
+		}
+		if request.URL.RequestURI() == "/prompts/list?environment=production" {
+			_ = json.NewEncoder(writer).Encode(map[string]interface{}{"prompts": []interface{}{}})
+			return
+		}
+		http.NotFound(writer, request)
+	}))
+	defer server.Close()
+	client := &Client{APIBase: server.URL, APIKey: "test", HTTPClient: server.Client()}
+	if _, err := fetchPromptListItems(context.Background(), client, "production", true); err == nil {
+		t.Fatal("over-limit prompt enrichment was accepted")
+	}
+}
+
+func TestPromptResourceSchemaRemainsV0WithAdditiveIdentityFields(t *testing.T) {
+	t.Parallel()
+	var response resource.SchemaResponse
+	(&PromptResource{}).Schema(context.Background(), resource.SchemaRequest{}, &response)
+	if response.Schema.Version != 0 {
+		t.Fatalf("schema version = %d", response.Schema.Version)
+	}
+	for name := range map[string]struct{}{"environment": {}, "version": {}, "created_at": {}, "updated_at": {}} {
+		if _, exists := response.Schema.Attributes[name]; !exists {
+			t.Fatalf("missing additive attribute %s", name)
+		}
+	}
+	if _, ok := response.Schema.Attributes["prompt_id"].(resourceschema.StringAttribute); !ok {
+		t.Fatal("prompt_id public type changed")
+	}
+}

--- a/internal/provider/prompt_helpers.go
+++ b/internal/provider/prompt_helpers.go
@@ -1,0 +1,234 @@
+package provider
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"unicode/utf8"
+)
+
+const (
+	defaultPromptEnvironment = "development"
+	promptImportVersion      = "v1"
+	promptLegacyImportPrefix = "legacy."
+)
+
+type promptAPIObject struct {
+	PromptID    string
+	Environment string
+	Version     int64
+	HasVersion  bool
+	CreatedAt   *string
+	UpdatedAt   *string
+	Params      map[string]interface{}
+	Info        map[string]interface{}
+}
+
+func promptImportID(promptID, environment string) string {
+	return promptImportVersion + "." +
+		base64.RawURLEncoding.EncodeToString([]byte(promptID)) + "." +
+		base64.RawURLEncoding.EncodeToString([]byte(environment))
+}
+
+func legacyPromptImportID(promptID string) string {
+	return promptLegacyImportPrefix + base64.RawURLEncoding.EncodeToString([]byte(promptID))
+}
+
+func parsePromptImportID(value string) (promptID, environment string, err error) {
+	if strings.HasPrefix(value, promptLegacyImportPrefix) {
+		encoded := strings.TrimPrefix(value, promptLegacyImportPrefix)
+		decoded, decodeErr := base64.RawURLEncoding.DecodeString(encoded)
+		if decodeErr != nil || len(decoded) == 0 || !utf8.Valid(decoded) || legacyPromptImportID(string(decoded)) != value {
+			return "", "", fmt.Errorf("invalid escaped legacy prompt import ID")
+		}
+		return string(decoded), defaultPromptEnvironment, nil
+	}
+	parts := strings.Split(value, ".")
+	if len(parts) == 3 && parts[0] == promptImportVersion {
+		promptBytes, promptErr := base64.RawURLEncoding.DecodeString(parts[1])
+		environmentBytes, environmentErr := base64.RawURLEncoding.DecodeString(parts[2])
+		if promptErr != nil || environmentErr != nil || len(promptBytes) == 0 || len(environmentBytes) == 0 || !utf8.Valid(promptBytes) || !utf8.Valid(environmentBytes) {
+			return "", "", fmt.Errorf("invalid prompt import ID")
+		}
+		promptID, environment = string(promptBytes), string(environmentBytes)
+		if promptImportID(promptID, environment) != value {
+			return "", "", fmt.Errorf("invalid non-canonical prompt import ID")
+		}
+		return promptID, environment, nil
+	}
+	if value == "" {
+		return "", "", fmt.Errorf("prompt import ID must not be empty")
+	}
+	return value, defaultPromptEnvironment, nil
+}
+
+func isPromptAbsentError(err error) bool {
+	return IsNotFoundError(err) || IsAPIErrorStatus(err, http.StatusBadRequest)
+}
+
+func promptScopedExists(ctx context.Context, client *Client, promptID, environment string) (bool, error) {
+	var info map[string]interface{}
+	err := client.DoRequestWithResponse(ctx, http.MethodGet, promptEndpoint(promptID, environment, nil), nil, &info)
+	if err == nil {
+		return true, nil
+	}
+	if !IsAPIErrorStatus(err, http.StatusBadRequest) && !IsAPIErrorStatus(err, http.StatusNotFound) {
+		return false, err
+	}
+	// v1.98 uses 400 both for ordinary absence and for authorization/visibility
+	// failures. The scoped versions route is the bounded authoritative DB check:
+	// only a successful empty envelope proves that Create may use this identity.
+	versions, versionsErr := fetchEnvelopeListObjects(ctx, client, promptVersionsEndpoint(promptID, environment), "prompts", "prompt version item")
+	if versionsErr != nil {
+		// Unlike info, v1.98's versions route uses 404 for an absent scoped
+		// history. Other 4xx responses remain ambiguous and fail closed.
+		if IsAPIErrorStatus(versionsErr, http.StatusNotFound) {
+			return false, nil
+		}
+		return false, versionsErr
+	}
+	return len(versions) > 0, nil
+}
+
+func promptEnvironment(value string) string {
+	if value == "" {
+		return defaultPromptEnvironment
+	}
+	return value
+}
+
+func promptPath(promptID string, version *int64) string {
+	lookupID := promptID
+	if version != nil {
+		lookupID = fmt.Sprintf("%s.v%d", promptID, *version)
+	}
+	return fmt.Sprintf("/prompts/%s", url.PathEscape(lookupID))
+}
+
+func promptEndpoint(promptID, environment string, version *int64) string {
+	query := url.Values{}
+	query.Set("environment", promptEnvironment(environment))
+	return promptPath(promptID, version) + "?" + query.Encode()
+}
+
+func promptVersionsEndpoint(promptID, environment string) string {
+	query := url.Values{}
+	query.Set("environment", promptEnvironment(environment))
+	return promptPath(promptID, nil) + "/versions?" + query.Encode()
+}
+
+func promptListEndpoint(environment string, configured bool) string {
+	if !configured {
+		return "/prompts/list"
+	}
+	query := url.Values{}
+	query.Set("environment", promptEnvironment(environment))
+	return "/prompts/list?" + query.Encode()
+}
+
+func optionalPromptAPIString(object map[string]interface{}, field string) (*string, error) {
+	value, exists := object[field]
+	if !exists || value == nil {
+		return nil, nil
+	}
+	text, ok := value.(string)
+	if !ok {
+		return nil, fmt.Errorf("prompt response field %q must be a string or null", field)
+	}
+	return &text, nil
+}
+
+func promptObject(raw map[string]interface{}, wrapped bool, expectedPromptID, expectedEnvironment string) (promptAPIObject, error) {
+	var result promptAPIObject
+	object := raw
+	if wrapped {
+		value, exists := raw["prompt_spec"]
+		if !exists || value == nil {
+			return result, fmt.Errorf("prompt response omitted required prompt_spec")
+		}
+		var ok bool
+		object, ok = value.(map[string]interface{})
+		if !ok {
+			return result, fmt.Errorf("prompt response field %q must be an object", "prompt_spec")
+		}
+	}
+
+	promptID, ok := object["prompt_id"].(string)
+	if !ok || promptID == "" {
+		return result, fmt.Errorf("prompt response omitted a non-empty prompt_id")
+	}
+	if expectedPromptID != "" && promptID != expectedPromptID {
+		return result, fmt.Errorf("prompt response identity did not match the requested prompt")
+	}
+	result.PromptID = promptID
+
+	params, ok := object["litellm_params"].(map[string]interface{})
+	if !ok || params == nil {
+		return result, fmt.Errorf("prompt response field %q must be an object", "litellm_params")
+	}
+	result.Params = params
+	if rawInfo, exists := object["prompt_info"]; exists && rawInfo != nil {
+		info, valid := rawInfo.(map[string]interface{})
+		if !valid {
+			return result, fmt.Errorf("prompt response field %q must be an object or null", "prompt_info")
+		}
+		result.Info = info
+	}
+
+	environment := ""
+	topEnvironmentPresent := false
+	if value, exists := object["environment"]; exists && value != nil {
+		var valid bool
+		environment, valid = value.(string)
+		if !valid || environment == "" {
+			return result, fmt.Errorf("prompt response field %q must be a non-empty string or null", "environment")
+		}
+		topEnvironmentPresent = true
+	}
+	infoEnvironment := ""
+	if result.Info != nil {
+		if value, exists := result.Info["environment"]; exists && value != nil {
+			var valid bool
+			infoEnvironment, valid = value.(string)
+			if !valid || infoEnvironment == "" {
+				return result, fmt.Errorf("prompt response field %q must be a non-empty string or null", "prompt_info.environment")
+			}
+		}
+	}
+	if topEnvironmentPresent && infoEnvironment != "" && environment != infoEnvironment {
+		return result, fmt.Errorf("prompt response returned conflicting environment identities")
+	}
+	if expectedEnvironment != "" && !topEnvironmentPresent {
+		return result, fmt.Errorf("prompt response omitted required top-level environment identity")
+	}
+	if environment == "" {
+		environment = infoEnvironment
+	}
+	environment = promptEnvironment(environment)
+	if expectedEnvironment != "" && environment != promptEnvironment(expectedEnvironment) {
+		return result, fmt.Errorf("prompt response environment did not match the requested environment")
+	}
+	result.Environment = environment
+
+	if value, exists := object["version"]; exists && value != nil {
+		version, versionErr := exactInt64FromAPI(value)
+		if versionErr != nil || version <= 0 {
+			return result, fmt.Errorf("prompt response field %q must be a positive integer", "version")
+		}
+		result.Version = version
+		result.HasVersion = true
+	}
+	var timestampErr error
+	result.CreatedAt, timestampErr = optionalPromptAPIString(object, "created_at")
+	if timestampErr != nil {
+		return result, timestampErr
+	}
+	result.UpdatedAt, timestampErr = optionalPromptAPIString(object, "updated_at")
+	if timestampErr != nil {
+		return result, timestampErr
+	}
+	return result, nil
+}

--- a/internal/provider/prompt_protocol_test.go
+++ b/internal/provider/prompt_protocol_test.go
@@ -1,0 +1,340 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func TestPromptCreateAcceptsAuthoritativeAbsentScopedIdentityProtocol(t *testing.T) {
+	ctx := context.Background()
+	var posts atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		switch {
+		case request.Method == http.MethodPost && request.URL.Path == "/prompts":
+			posts.Add(1)
+			_, _ = fmt.Fprint(writer, `{"prompt_id":"new-prompt","environment":"production","version":1,"litellm_params":{"prompt_integration":"dotprompt"},"prompt_info":{"prompt_type":"db","environment":"production"}}`)
+		case request.URL.RequestURI() == "/prompts/new-prompt?environment=production" && posts.Load() == 0:
+			http.Error(writer, "prompt absent", http.StatusBadRequest)
+		case request.URL.RequestURI() == "/prompts/new-prompt/versions?environment=production":
+			http.Error(writer, "no versions", http.StatusNotFound)
+		case request.URL.RequestURI() == "/prompts/new-prompt?environment=production":
+			_, _ = fmt.Fprint(writer, `{"prompt_spec":{"prompt_id":"new-prompt","environment":"production","version":1,"created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z","litellm_params":{"prompt_integration":"dotprompt"},"prompt_info":{"prompt_type":"db","environment":"production"}}}`)
+		default:
+			http.NotFound(writer, request)
+		}
+	}))
+	defer server.Close()
+	protocolServer, schemas := configuredImportProtocolServer(t, ctx, server.URL)
+	const typeName = "litellm_prompt"
+	schema := schemas.ResourceSchemas[typeName]
+	configValues := map[string]interface{}{"prompt_id": "new-prompt", "environment": "production", "prompt_integration": "dotprompt", "prompt_type": "db"}
+	proposedValues := map[string]interface{}{}
+	for key, value := range configValues {
+		proposedValues[key] = value
+	}
+	for _, key := range []string{"id", "version", "created_at", "updated_at"} {
+		proposedValues[key] = tftypes.UnknownValue
+	}
+	config := accessGroupProtocolDynamicValue(t, schema, organizationProjectProtocolValue(t, schema, configValues))
+	proposed := accessGroupProtocolDynamicValue(t, schema, organizationProjectProtocolValue(t, schema, proposedValues))
+	nullState := accessGroupProtocolDynamicValue(t, schema, tftypes.NewValue(schema.ValueType(), nil))
+	planned, err := protocolServer.PlanResourceChange(ctx, &tfprotov6.PlanResourceChangeRequest{TypeName: typeName, Config: config, PriorState: nullState, ProposedNewState: proposed})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(planned.Diagnostics) {
+		t.Fatalf("plan: err=%v diagnostics=%v", err, planned.Diagnostics)
+	}
+	applied, err := protocolServer.ApplyResourceChange(ctx, &tfprotov6.ApplyResourceChangeRequest{TypeName: typeName, Config: config, PriorState: nullState, PlannedState: planned.PlannedState, PlannedPrivate: planned.PlannedPrivate})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(applied.Diagnostics) || posts.Load() != 1 {
+		t.Fatalf("create: err=%v diagnostics=%v posts=%d", err, applied.Diagnostics, posts.Load())
+	}
+}
+
+func TestPromptCreateRefusesExistingScopedIdentityProtocol(t *testing.T) {
+	ctx := context.Background()
+	var posts atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		if request.Method == http.MethodPost {
+			posts.Add(1)
+			_, _ = fmt.Fprint(writer, `{}`)
+			return
+		}
+		if request.URL.RequestURI() == "/prompts/existing?environment=production" {
+			http.Error(writer, "ambiguous hidden/not-found response", http.StatusBadRequest)
+			return
+		}
+		if request.URL.RequestURI() == "/prompts/existing/versions?environment=production" {
+			_, _ = fmt.Fprint(writer, `{"prompts":[{"prompt_id":"existing","environment":"production","version":1,"litellm_params":{"prompt_integration":"dotprompt"},"prompt_info":{"prompt_type":"db","environment":"production"}}]}`)
+			return
+		}
+		http.NotFound(writer, request)
+	}))
+	defer server.Close()
+	protocolServer, schemas := configuredImportProtocolServer(t, ctx, server.URL)
+	const typeName = "litellm_prompt"
+	schema := schemas.ResourceSchemas[typeName]
+	configValues := map[string]interface{}{"prompt_id": "existing", "environment": "production", "prompt_integration": "dotprompt", "prompt_type": "db"}
+	proposedValues := map[string]interface{}{}
+	for key, value := range configValues {
+		proposedValues[key] = value
+	}
+	for _, key := range []string{"id", "version", "created_at", "updated_at"} {
+		proposedValues[key] = tftypes.UnknownValue
+	}
+	config := accessGroupProtocolDynamicValue(t, schema, organizationProjectProtocolValue(t, schema, configValues))
+	proposed := accessGroupProtocolDynamicValue(t, schema, organizationProjectProtocolValue(t, schema, proposedValues))
+	nullState := accessGroupProtocolDynamicValue(t, schema, tftypes.NewValue(schema.ValueType(), nil))
+	planned, err := protocolServer.PlanResourceChange(ctx, &tfprotov6.PlanResourceChangeRequest{TypeName: typeName, Config: config, PriorState: nullState, ProposedNewState: proposed})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(planned.Diagnostics) {
+		t.Fatalf("plan: err=%v diagnostics=%v", err, planned.Diagnostics)
+	}
+	applied, err := protocolServer.ApplyResourceChange(ctx, &tfprotov6.ApplyResourceChangeRequest{TypeName: typeName, Config: config, PriorState: nullState, PlannedState: planned.PlannedState, PlannedPrivate: planned.PlannedPrivate})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !accessGroupProtocolDiagnosticsHaveError(applied.Diagnostics) || posts.Load() != 0 {
+		t.Fatalf("existing prompt was mutated: diagnostics=%v posts=%d", applied.Diagnostics, posts.Load())
+	}
+}
+
+func TestPromptConfigCreateIsRejectedBeforeAPIProtocol(t *testing.T) {
+	ctx := context.Background()
+	protocolServer, schemas := configuredImportProtocolServer(t, ctx, "http://127.0.0.1:1")
+	const typeName = "litellm_prompt"
+	schema := schemas.ResourceSchemas[typeName]
+	configValues := map[string]interface{}{
+		"prompt_id": "config-prompt", "environment": "development",
+		"prompt_integration": "dotprompt", "prompt_type": "config",
+	}
+	proposedValues := map[string]interface{}{}
+	for key, value := range configValues {
+		proposedValues[key] = value
+	}
+	for _, key := range []string{"id", "version", "created_at", "updated_at"} {
+		proposedValues[key] = tftypes.UnknownValue
+	}
+	config := accessGroupProtocolDynamicValue(t, schema, organizationProjectProtocolValue(t, schema, configValues))
+	proposed := accessGroupProtocolDynamicValue(t, schema, organizationProjectProtocolValue(t, schema, proposedValues))
+	nullState := accessGroupProtocolDynamicValue(t, schema, tftypes.NewValue(schema.ValueType(), nil))
+	planned, err := protocolServer.PlanResourceChange(ctx, &tfprotov6.PlanResourceChangeRequest{TypeName: typeName, Config: config, PriorState: nullState, ProposedNewState: proposed})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(planned.Diagnostics) {
+		t.Fatalf("plan: err=%v diagnostics=%v", err, planned.Diagnostics)
+	}
+	applied, err := protocolServer.ApplyResourceChange(ctx, &tfprotov6.ApplyResourceChangeRequest{TypeName: typeName, Config: config, PriorState: nullState, PlannedState: planned.PlannedState, PlannedPrivate: planned.PlannedPrivate})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !accessGroupProtocolDiagnosticsHaveError(applied.Diagnostics) {
+		t.Fatal("config prompt create reached the API")
+	}
+}
+
+func TestPromptDeleteRecoversMissingRegistryWithScopedPatchProtocol(t *testing.T) {
+	ctx := context.Background()
+	var deletes, patches atomic.Int64
+	var gone atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		if request.URL.RequestURI() != "/prompts/managed?environment=production" {
+			http.NotFound(writer, request)
+			return
+		}
+		switch request.Method {
+		case http.MethodDelete:
+			if deletes.Add(1) == 1 {
+				http.Error(writer, "registry key missing", http.StatusNotFound)
+				return
+			}
+			gone.Store(true)
+			_, _ = fmt.Fprint(writer, `{}`)
+		case http.MethodPatch:
+			patches.Add(1)
+			_, _ = fmt.Fprint(writer, `{}`)
+		case http.MethodGet:
+			if gone.Load() {
+				http.Error(writer, "prompt absent", http.StatusBadRequest)
+				return
+			}
+			_, _ = fmt.Fprint(writer, `{"prompt_spec":{"prompt_id":"managed","environment":"production","version":1,"litellm_params":{"prompt_integration":"dotprompt"},"prompt_info":{"prompt_type":"db","environment":"production"}}}`)
+		}
+	}))
+	defer server.Close()
+	protocolServer, schemas := configuredImportProtocolServer(t, ctx, server.URL)
+	const typeName = "litellm_prompt"
+	schema := schemas.ResourceSchemas[typeName]
+	stateValues := map[string]interface{}{"id": "managed", "prompt_id": "managed", "environment": "production", "version": int64(1), "prompt_integration": "dotprompt", "prompt_type": "db"}
+	state := accessGroupProtocolDynamicValue(t, schema, organizationProjectProtocolValue(t, schema, stateValues))
+	nullState := accessGroupProtocolDynamicValue(t, schema, tftypes.NewValue(schema.ValueType(), nil))
+	planned, err := protocolServer.PlanResourceChange(ctx, &tfprotov6.PlanResourceChangeRequest{TypeName: typeName, Config: nullState, PriorState: state, ProposedNewState: nullState})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(planned.Diagnostics) {
+		t.Fatalf("destroy plan: err=%v diagnostics=%v", err, planned.Diagnostics)
+	}
+	applied, err := protocolServer.ApplyResourceChange(ctx, &tfprotov6.ApplyResourceChangeRequest{TypeName: typeName, Config: nullState, PriorState: state, PlannedState: planned.PlannedState, PlannedPrivate: planned.PlannedPrivate})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(applied.Diagnostics) || deletes.Load() != 2 || patches.Load() != 1 {
+		t.Fatalf("recovered delete: err=%v diagnostics=%v deletes=%d patches=%d", err, applied.Diagnostics, deletes.Load(), patches.Load())
+	}
+}
+
+func TestPromptDeleteErrorsRequireScopedAbsenceConfirmation(t *testing.T) {
+	ctx := context.Background()
+	for _, status := range []int{http.StatusBadRequest, http.StatusNotFound} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				writer.Header().Set("Content-Type", "application/json")
+				if request.URL.RequestURI() != "/prompts/managed?environment=production" {
+					http.NotFound(writer, request)
+					return
+				}
+				if request.Method == http.MethodDelete {
+					http.Error(writer, "simulated registry/config refusal", status)
+					return
+				}
+				_, _ = fmt.Fprint(writer, `{"prompt_spec":{"prompt_id":"managed","environment":"production","version":1,"litellm_params":{"prompt_integration":"dotprompt"},"prompt_info":{"prompt_type":"db","environment":"production"}}}`)
+			}))
+			defer server.Close()
+			protocolServer, schemas := configuredImportProtocolServer(t, ctx, server.URL)
+			const typeName = "litellm_prompt"
+			schema := schemas.ResourceSchemas[typeName]
+			stateValues := map[string]interface{}{
+				"id": "managed", "prompt_id": "managed", "environment": "production",
+				"version": int64(1), "prompt_integration": "dotprompt", "prompt_type": "db",
+			}
+			state := accessGroupProtocolDynamicValue(t, schema, organizationProjectProtocolValue(t, schema, stateValues))
+			nullState := accessGroupProtocolDynamicValue(t, schema, tftypes.NewValue(schema.ValueType(), nil))
+			planned, err := protocolServer.PlanResourceChange(ctx, &tfprotov6.PlanResourceChangeRequest{TypeName: typeName, Config: nullState, PriorState: state, ProposedNewState: nullState})
+			if err != nil || accessGroupProtocolDiagnosticsHaveError(planned.Diagnostics) {
+				t.Fatalf("destroy plan: err=%v diagnostics=%v", err, planned.Diagnostics)
+			}
+			applied, err := protocolServer.ApplyResourceChange(ctx, &tfprotov6.ApplyResourceChangeRequest{TypeName: typeName, Config: nullState, PriorState: state, PlannedState: planned.PlannedState, PlannedPrivate: planned.PlannedPrivate})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !accessGroupProtocolDiagnosticsHaveError(applied.Diagnostics) {
+				t.Fatalf("DELETE %d discarded state despite surviving scoped prompt", status)
+			}
+		})
+	}
+}
+
+func TestPromptLegacyStateRefreshesToDevelopmentWithoutReplacement(t *testing.T) {
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		if request.URL.RequestURI() != "/prompts/legacy?environment=development" {
+			http.NotFound(writer, request)
+			return
+		}
+		_, _ = fmt.Fprint(writer, `{"prompt_spec":{"prompt_id":"legacy","environment":"development","version":4,"created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-02T00:00:00Z","litellm_params":{"prompt_integration":"dotprompt","dotprompt_content":"content","ignore_prompt_manager_model":false,"ignore_prompt_manager_optional_params":false},"prompt_info":{"prompt_type":"db","environment":"development"}}}`)
+	}))
+	defer server.Close()
+
+	protocolServer, schemas := configuredImportProtocolServer(t, ctx, server.URL)
+	const typeName = "litellm_prompt"
+	schema := schemas.ResourceSchemas[typeName]
+	legacyValues := map[string]interface{}{
+		"id": "legacy", "prompt_id": "legacy", "prompt_integration": "dotprompt",
+		"dotprompt_content": "content", "prompt_type": "db",
+		"ignore_prompt_manager_model": false, "ignore_prompt_manager_optional_params": false,
+	}
+	legacyState := accessGroupProtocolDynamicValue(t, schema, organizationProjectProtocolValue(t, schema, legacyValues))
+	read, err := protocolServer.ReadResource(ctx, &tfprotov6.ReadResourceRequest{TypeName: typeName, CurrentState: legacyState})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(read.Diagnostics) {
+		t.Fatalf("legacy read: err=%v diagnostics=%v", err, read.Diagnostics)
+	}
+	attributes := protocolAttributeMap(t, schema, read.NewState)
+	var environment string
+	if err := attributes["environment"].As(&environment); err != nil {
+		t.Fatal(err)
+	}
+	version := protocolInt64(t, attributes["version"])
+	if environment != defaultPromptEnvironment || version != 4 {
+		t.Fatalf("migrated environment=%q version=%d", environment, version)
+	}
+	configValues := map[string]interface{}{
+		"prompt_id": "legacy", "prompt_integration": "dotprompt", "dotprompt_content": "content",
+		"prompt_type": "db", "ignore_prompt_manager_model": false, "ignore_prompt_manager_optional_params": false,
+	}
+	config := accessGroupProtocolDynamicValue(t, schema, organizationProjectProtocolValue(t, schema, configValues))
+	planned, err := protocolServer.PlanResourceChange(ctx, &tfprotov6.PlanResourceChangeRequest{
+		TypeName: typeName, Config: config, PriorState: read.NewState, ProposedNewState: read.NewState,
+	})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(planned.Diagnostics) || len(planned.RequiresReplace) != 0 || organizationProjectProtocolPlannedAction(t, schema, read.NewState, planned) != organizationProjectProtocolActionNoOp {
+		t.Fatalf("legacy plan: err=%v diagnostics=%v replace=%v action=%s", err, planned.Diagnostics, planned.RequiresReplace, organizationProjectProtocolPlannedAction(t, schema, read.NewState, planned))
+	}
+}
+
+func TestPromptImportAdoptsConfiguredDefaultsWithoutDrift(t *testing.T) {
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		if request.URL.RequestURI() != "/prompts/imported?environment=production" {
+			http.NotFound(writer, request)
+			return
+		}
+		_, _ = fmt.Fprint(writer, `{"prompt_spec":{"prompt_id":"imported","environment":"production","version":2,"created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-02T00:00:00Z","litellm_params":{"prompt_integration":"dotprompt","dotprompt_content":"content","ignore_prompt_manager_model":false,"ignore_prompt_manager_optional_params":false},"prompt_info":{"prompt_type":"db","environment":"production"}}}`)
+	}))
+	defer server.Close()
+	protocolServer, schemas := configuredImportProtocolServer(t, ctx, server.URL)
+	const typeName = "litellm_prompt"
+	schema := schemas.ResourceSchemas[typeName]
+	imported, err := protocolServer.ImportResourceState(ctx, &tfprotov6.ImportResourceStateRequest{TypeName: typeName, ID: promptImportID("imported", "production")})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(imported.Diagnostics) || len(imported.ImportedResources) != 1 {
+		t.Fatalf("import: err=%v diagnostics=%v", err, imported.Diagnostics)
+	}
+	read, err := protocolServer.ReadResource(ctx, &tfprotov6.ReadResourceRequest{TypeName: typeName, CurrentState: imported.ImportedResources[0].State, Private: imported.ImportedResources[0].Private})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(read.Diagnostics) {
+		t.Fatalf("read: err=%v diagnostics=%v", err, read.Diagnostics)
+	}
+	configValues := map[string]interface{}{
+		"prompt_id": "imported", "environment": "production", "prompt_integration": "dotprompt",
+		"dotprompt_content": "content", "prompt_type": "db",
+		"ignore_prompt_manager_model": false, "ignore_prompt_manager_optional_params": false,
+	}
+	config := accessGroupProtocolDynamicValue(t, schema, organizationProjectProtocolValue(t, schema, configValues))
+	planned, err := protocolServer.PlanResourceChange(ctx, &tfprotov6.PlanResourceChangeRequest{TypeName: typeName, Config: config, PriorState: read.NewState, ProposedNewState: read.NewState, PriorPrivate: read.Private})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(planned.Diagnostics) || len(planned.RequiresReplace) != 0 || organizationProjectProtocolPlannedAction(t, schema, read.NewState, planned) != organizationProjectProtocolActionNoOp {
+		t.Fatalf("import plan: err=%v diagnostics=%v replace=%v action=%s", err, planned.Diagnostics, planned.RequiresReplace, organizationProjectProtocolPlannedAction(t, schema, read.NewState, planned))
+	}
+}
+
+func TestPromptCompositeAndLegacyImportProtocol(t *testing.T) {
+	ctx := context.Background()
+	protocolServer, schemas := configuredImportProtocolServer(t, ctx, "http://127.0.0.1:1")
+	const typeName = "litellm_prompt"
+	schema := schemas.ResourceSchemas[typeName]
+	for _, test := range []struct {
+		name, importID, promptID, environment string
+	}{
+		{"composite", promptImportID("prompt:one", "production/east"), "prompt:one", "production/east"},
+		{"legacy", "legacy-prompt", "legacy-prompt", defaultPromptEnvironment},
+		{"escaped legacy", legacyPromptImportID("v1.YQ.Yg"), "v1.YQ.Yg", defaultPromptEnvironment},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			imported, err := protocolServer.ImportResourceState(ctx, &tfprotov6.ImportResourceStateRequest{TypeName: typeName, ID: test.importID})
+			if err != nil || accessGroupProtocolDiagnosticsHaveError(imported.Diagnostics) || len(imported.ImportedResources) != 1 {
+				t.Fatalf("import: err=%v diagnostics=%v", err, imported.Diagnostics)
+			}
+			attributes := protocolAttributeMap(t, schema, imported.ImportedResources[0].State)
+			var promptID, environment, id string
+			if err := attributes["prompt_id"].As(&promptID); err != nil {
+				t.Fatal(err)
+			}
+			if err := attributes["environment"].As(&environment); err != nil {
+				t.Fatal(err)
+			}
+			if err := attributes["id"].As(&id); err != nil {
+				t.Fatal(err)
+			}
+			if promptID != test.promptID || id != test.promptID || environment != test.environment {
+				t.Fatalf("state prompt=%q id=%q environment=%q", promptID, id, environment)
+			}
+		})
+	}
+}

--- a/internal/provider/read_test.go
+++ b/internal/provider/read_test.go
@@ -690,16 +690,20 @@ func TestReadPromptWithRetrySucceedsFirstTry(t *testing.T) {
 	t.Parallel()
 
 	server, client := jsonServer(t, map[string]interface{}{
-		"prompt_id": "prompt-1",
-		"litellm_params": map[string]interface{}{
-			"prompt_integration": "langfuse",
+		"prompt_spec": map[string]interface{}{
+			"prompt_id":   "prompt-1",
+			"environment": "development",
+			"version":     1,
+			"litellm_params": map[string]interface{}{
+				"prompt_integration": "langfuse",
+			},
 		},
 	})
 	defer server.Close()
 
 	r := &PromptResource{client: client}
 	data := &PromptResourceModel{PromptID: types.StringValue("prompt-1")}
-	if err := r.readPromptWithRetry(context.Background(), data, 3); err != nil {
+	if err := r.readPromptWithRetry(context.Background(), data, 3, false); err != nil {
 		t.Fatalf("readPromptWithRetry: %v", err)
 	}
 }

--- a/internal/provider/resource_prompt.go
+++ b/internal/provider/resource_prompt.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -11,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -18,6 +20,8 @@ import (
 
 var _ resource.Resource = &PromptResource{}
 var _ resource.ResourceWithImportState = &PromptResource{}
+
+const promptImportedPrivateKey = "prompt_imported_v1"
 
 func NewPromptResource() resource.Resource {
 	return &PromptResource{}
@@ -38,6 +42,10 @@ type PromptResourceModel struct {
 	IgnorePromptManagerOptionalParams types.Bool   `tfsdk:"ignore_prompt_manager_optional_params"`
 	DotpromptContent                  types.String `tfsdk:"dotprompt_content"`
 	PromptType                        types.String `tfsdk:"prompt_type"`
+	Environment                       types.String `tfsdk:"environment"`
+	Version                           types.Int64  `tfsdk:"version"`
+	CreatedAt                         types.String `tfsdk:"created_at"`
+	UpdatedAt                         types.String `tfsdk:"updated_at"`
 }
 
 func (r *PromptResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -58,6 +66,18 @@ func (r *PromptResource) Schema(ctx context.Context, req resource.SchemaRequest,
 			"prompt_id": schema.StringAttribute{
 				Description: "The unique prompt ID.",
 				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"environment": schema.StringAttribute{
+				Description: "Environment-scoped prompt identity. Defaults to development; changing it creates a separately owned logical prompt.",
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString(defaultPromptEnvironment),
+				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(1),
+				},
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
@@ -99,6 +119,18 @@ func (r *PromptResource) Schema(ctx context.Context, req resource.SchemaRequest,
 					stringvalidator.OneOf("config", "db"),
 				},
 			},
+			"version": schema.Int64Attribute{
+				Description: "Latest version currently owned in this environment. Updates append a new version.",
+				Computed:    true,
+			},
+			"created_at": schema.StringAttribute{
+				Description: "Creation timestamp of the selected latest version.",
+				Computed:    true,
+			},
+			"updated_at": schema.StringAttribute{
+				Description: "Last-update timestamp of the selected latest version.",
+				Computed:    true,
+			},
 		},
 	}
 }
@@ -128,6 +160,19 @@ func (r *PromptResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
+	if !data.PromptType.IsNull() && !data.PromptType.IsUnknown() && data.PromptType.ValueString() == "config" {
+		resp.Diagnostics.AddError("Config Prompt Is Read-Only", "LiteLLM v1.98 cannot update or delete config prompts. Import them for read-only visibility, or use prompt_type = \"db\" for managed resources.")
+		return
+	}
+	exists, existenceErr := promptScopedExists(ctx, r.client, data.PromptID.ValueString(), data.Environment.ValueString())
+	if existenceErr != nil {
+		resp.Diagnostics.AddError("Prompt Existence Not Confirmed", fmt.Sprintf("Unable to verify that the scoped prompt identity is available: %s", existenceErr))
+		return
+	}
+	if exists {
+		resp.Diagnostics.AddError("Prompt Already Exists", fmt.Sprintf("A prompt with this ID and environment already exists. Import it with %q instead of creating a second owner.", promptImportID(data.PromptID.ValueString(), promptEnvironment(data.Environment.ValueString()))))
+		return
+	}
 	promptReq, err := r.buildPromptRequest(ctx, &data)
 	if err != nil {
 		resp.Diagnostics.AddError("Invalid Prompt JSON", err.Error())
@@ -142,9 +187,13 @@ func (r *PromptResource) Create(ctx context.Context, req resource.CreateRequest,
 
 	data.ID = data.PromptID
 
-	// Read back for full state
-	if err := r.readPromptWithRetry(ctx, &data, 8); err != nil {
-		resp.Diagnostics.AddWarning("Read Error", fmt.Sprintf("Prompt created but failed to read back: %s", err))
+	if err := r.readPromptWithRetry(ctx, &data, 8, false); err != nil {
+		data.Version = types.Int64Null()
+		data.CreatedAt = types.StringNull()
+		data.UpdatedAt = types.StringNull()
+		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		resp.Diagnostics.AddError("Prompt Create Not Confirmed", fmt.Sprintf("LiteLLM accepted the prompt create, but scoped read-back failed: %s", err))
+		return
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -158,8 +207,14 @@ func (r *PromptResource) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
-	if err := r.readPromptWithRetry(ctx, &data, 8); err != nil {
-		if IsNotFoundError(err) {
+	importedMarker, privateDiags := req.Private.GetKey(ctx, promptImportedPrivateKey)
+	resp.Diagnostics.Append(privateDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	imported := string(importedMarker) == "true"
+	if err := r.readPromptWithRetry(ctx, &data, 8, imported); err != nil {
+		if isPromptAbsentError(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
@@ -168,6 +223,9 @@ func (r *PromptResource) Read(ctx context.Context, req resource.ReadRequest, res
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	if imported && !resp.Diagnostics.HasError() && resp.Private != nil {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, promptImportedPrivateKey, nil)...)
+	}
 }
 
 func (r *PromptResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
@@ -187,22 +245,49 @@ func (r *PromptResource) Update(ctx context.Context, req resource.UpdateRequest,
 	// Preserve IDs
 	data.ID = state.ID
 	data.PromptID = state.PromptID
+	if (!state.PromptType.IsNull() && !state.PromptType.IsUnknown() && state.PromptType.ValueString() == "config") ||
+		(!data.PromptType.IsNull() && !data.PromptType.IsUnknown() && data.PromptType.ValueString() == "config") {
+		resp.Diagnostics.AddError("Config Prompt Is Read-Only", "LiteLLM v1.98 cannot update config prompts. Keep imported config prompts unchanged, or manage a database prompt instead.")
+		return
+	}
 
 	promptReq, err := r.buildPromptRequest(ctx, &data)
 	if err != nil {
 		resp.Diagnostics.AddError("Invalid Prompt JSON", err.Error())
 		return
 	}
+	var currentRaw map[string]interface{}
+	if err := r.client.DoRequestWithResponse(ctx, "GET", promptEndpoint(data.PromptID.ValueString(), data.Environment.ValueString(), nil), nil, &currentRaw); err != nil {
+		resp.Diagnostics.AddError("Prompt Update Not Safe", fmt.Sprintf("Unable to verify the complete current prompt before versioning: %s", err))
+		return
+	}
+	current, err := promptObject(currentRaw, true, data.PromptID.ValueString(), data.Environment.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Prompt Update Not Safe", err.Error())
+		return
+	}
+	if !state.Version.IsNull() && !state.Version.IsUnknown() && (!current.HasVersion || current.Version != state.Version.ValueInt64()) {
+		resp.Diagnostics.AddError("Prompt Update Not Safe", "The latest scoped prompt version changed after planning; refresh and retry.")
+		return
+	}
+	if err := validateMutablePromptInfo(current.Info); err != nil {
+		resp.Diagnostics.AddError("Config Prompt Is Read-Only", err.Error())
+		return
+	}
+	if err := validatePromptUpdateCoverage(current.Params, &data, &state); err != nil {
+		resp.Diagnostics.AddError("Prompt Update Not Safe", err.Error())
+		return
+	}
 
-	endpoint := fmt.Sprintf("/prompts/%s", data.PromptID.ValueString())
+	endpoint := promptPath(data.PromptID.ValueString(), nil)
 	if err := r.client.DoRequestWithResponse(ctx, "PUT", endpoint, promptReq, nil); err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update prompt: %s", err))
 		return
 	}
 
-	// Read back for full state
-	if err := r.readPromptWithRetry(ctx, &data, 8); err != nil {
-		resp.Diagnostics.AddWarning("Read Error", fmt.Sprintf("Prompt updated but failed to read back: %s", err))
+	if err := r.readPromptWithRetry(ctx, &data, 8, false); err != nil {
+		resp.Diagnostics.AddError("Prompt Update Not Confirmed", fmt.Sprintf("LiteLLM accepted the prompt update, but scoped read-back failed: %s", err))
+		return
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -216,18 +301,102 @@ func (r *PromptResource) Delete(ctx context.Context, req resource.DeleteRequest,
 		return
 	}
 
-	endpoint := fmt.Sprintf("/prompts/%s", data.PromptID.ValueString())
-	if err := r.client.DoRequestWithResponse(ctx, "DELETE", endpoint, nil, nil); err != nil {
-		if !IsNotFoundError(err) {
-			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete prompt: %s", err))
-			return
+	endpoint := promptEndpoint(data.PromptID.ValueString(), data.Environment.ValueString(), nil)
+	deleteErr := r.client.DoRequestWithResponse(ctx, "DELETE", endpoint, nil, nil)
+	// DELETE can return 400 for undeletable config prompts and 404 from a stale
+	// process-local registry even while scoped DB rows still exist. Never remove
+	// state based on the DELETE status alone; the explicit-environment info read
+	// is the authoritative absence check.
+	var probe map[string]interface{}
+	probeErr := r.client.DoRequestWithResponse(ctx, "GET", endpoint, nil, &probe)
+	if deleteErr != nil && IsAPIErrorStatus(deleteErr, http.StatusNotFound) && probeErr == nil {
+		// A v1.98 worker can lose its process-local registry key while the scoped
+		// DB history still exists. Reinitialize that exact latest DB version with
+		// a no-content-change PATCH, retry DELETE once, then prove absence again.
+		observed, decodeErr := promptObject(probe, true, data.PromptID.ValueString(), data.Environment.ValueString())
+		if decodeErr == nil && validateMutablePromptInfo(observed.Info) == nil {
+			patch := map[string]interface{}{"prompt_info": observed.Info}
+			if patchErr := r.client.DoRequestWithResponse(ctx, "PATCH", endpoint, patch, nil); patchErr == nil {
+				deleteErr = r.client.DoRequestWithResponse(ctx, "DELETE", endpoint, nil, nil)
+				probe = nil
+				probeErr = r.client.DoRequestWithResponse(ctx, "GET", endpoint, nil, &probe)
+			}
 		}
 	}
+	if isPromptAbsentError(probeErr) {
+		if deleteErr != nil {
+			resp.Diagnostics.AddWarning("Prompt Delete Recovered", "LiteLLM returned an error after deletion, but a scoped read confirmed this prompt environment is absent.")
+		}
+		return
+	}
+	if deleteErr != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete prompt: %s", deleteErr))
+		return
+	}
+	if probeErr != nil {
+		resp.Diagnostics.AddError("Prompt Delete Not Confirmed", fmt.Sprintf("LiteLLM accepted the scoped delete, but absence could not be confirmed: %s", probeErr))
+		return
+	}
+	resp.Diagnostics.AddError("Prompt Delete Not Confirmed", "LiteLLM accepted the scoped delete, but the prompt environment still exists.")
 }
 
 func (r *PromptResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("prompt_id"), req.ID)...)
+	promptID, environment, err := parsePromptImportID(req.ID)
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid Prompt Import ID", err.Error())
+		return
+	}
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), promptID)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("prompt_id"), promptID)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("environment"), environment)...)
+	if resp.Private != nil {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, promptImportedPrivateKey, []byte("true"))...)
+	}
+}
+
+func validateMutablePromptInfo(info map[string]interface{}) error {
+	value, exists := info["prompt_type"]
+	if !exists || value == nil {
+		return fmt.Errorf("prompt response omitted required prompt_info.prompt_type")
+	}
+	promptType, ok := value.(string)
+	if !ok {
+		return fmt.Errorf("prompt response field %q must be a string", "prompt_info.prompt_type")
+	}
+	switch promptType {
+	case "db":
+		return nil
+	case "config":
+		return fmt.Errorf("LiteLLM reports this as a config prompt, which v1.98 cannot update or delete through the management API")
+	default:
+		return fmt.Errorf("prompt response field %q returned unsupported value %q", "prompt_info.prompt_type", promptType)
+	}
+}
+
+func validatePromptUpdateCoverage(remote map[string]interface{}, plan, prior *PromptResourceModel) error {
+	modeled := map[string]struct{}{
+		"prompt_integration":                    {},
+		"api_base":                              {},
+		"api_key":                               {},
+		"provider_specific_query_params":        {},
+		"ignore_prompt_manager_model":           {},
+		"ignore_prompt_manager_optional_params": {},
+		"dotprompt_content":                     {},
+	}
+	for key, value := range remote {
+		if value == nil {
+			continue
+		}
+		if _, supported := modeled[key]; !supported {
+			return fmt.Errorf("the current prompt contains unmodeled litellm_params field %q; refusing a full-version update that could discard it", key)
+		}
+	}
+	if value, exists := remote["api_key"]; exists && value != nil &&
+		(plan.APIKey.IsNull() || plan.APIKey.IsUnknown() || plan.APIKey.ValueString() == "") &&
+		(prior.APIKey.IsNull() || prior.APIKey.IsUnknown() || prior.APIKey.ValueString() == "") {
+		return fmt.Errorf("the current prompt contains an API credential not owned by Terraform; configure api_key before updating")
+	}
+	return nil
 }
 
 func (r *PromptResource) buildPromptRequest(ctx context.Context, data *PromptResourceModel) (map[string]interface{}, error) {
@@ -266,27 +435,30 @@ func (r *PromptResource) buildPromptRequest(ctx context.Context, data *PromptRes
 		"litellm_params": litellmParams,
 	}
 
-	if !data.PromptType.IsNull() && !data.PromptType.IsUnknown() && data.PromptType.ValueString() != "" {
-		promptReq["prompt_info"] = map[string]interface{}{
-			"prompt_type": data.PromptType.ValueString(),
-		}
+	promptInfo := map[string]interface{}{
+		"environment": promptEnvironment(data.Environment.ValueString()),
+		"prompt_type": "db",
 	}
+	if !data.PromptType.IsNull() && !data.PromptType.IsUnknown() && data.PromptType.ValueString() != "" {
+		promptInfo["prompt_type"] = data.PromptType.ValueString()
+	}
+	promptReq["prompt_info"] = promptInfo
 
 	return promptReq, nil
 }
 
-func (r *PromptResource) readPromptWithRetry(ctx context.Context, data *PromptResourceModel, maxRetries int) error {
+func (r *PromptResource) readPromptWithRetry(ctx context.Context, data *PromptResourceModel, maxRetries int, adoptImportedDefaults bool) error {
 	var err error
 	delay := 1 * time.Second
 	maxDelay := 10 * time.Second
 
 	for i := 0; i < maxRetries; i++ {
-		err = r.readPrompt(ctx, data)
+		err = r.readPrompt(ctx, data, adoptImportedDefaults)
 		if err == nil {
 			return nil
 		}
 
-		if !IsNotFoundError(err) {
+		if !isPromptAbsentError(err) {
 			return err
 		}
 
@@ -302,57 +474,117 @@ func (r *PromptResource) readPromptWithRetry(ctx context.Context, data *PromptRe
 	return err
 }
 
-func (r *PromptResource) readPrompt(ctx context.Context, data *PromptResourceModel) error {
+func promptStringFromAPI(params map[string]interface{}, field string) (types.String, error) {
+	value, exists := params[field]
+	if !exists || value == nil {
+		return types.StringNull(), nil
+	}
+	text, ok := value.(string)
+	if !ok {
+		return types.StringNull(), fmt.Errorf("prompt response field %q must be a string or null", "litellm_params."+field)
+	}
+	return types.StringValue(text), nil
+}
+
+func promptBoolFromAPI(params map[string]interface{}, field string) (types.Bool, error) {
+	value, exists := params[field]
+	if !exists || value == nil {
+		return types.BoolNull(), nil
+	}
+	boolean, ok := value.(bool)
+	if !ok {
+		return types.BoolNull(), fmt.Errorf("prompt response field %q must be a boolean or null", "litellm_params."+field)
+	}
+	return types.BoolValue(boolean), nil
+}
+
+func (r *PromptResource) readPrompt(ctx context.Context, data *PromptResourceModel, adoptImportedDefaults bool) error {
 	promptID := data.PromptID.ValueString()
 	if promptID == "" {
 		promptID = data.ID.ValueString()
 	}
-
-	endpoint := fmt.Sprintf("/prompts/%s", promptID)
+	if promptID == "" {
+		return fmt.Errorf("prompt state omitted its identity")
+	}
+	environment := promptEnvironment(data.Environment.ValueString())
+	endpoint := promptEndpoint(promptID, environment, nil)
 
 	var rawResult map[string]interface{}
 	if err := r.client.DoRequestWithResponse(ctx, "GET", endpoint, nil, &rawResult); err != nil {
 		return err
 	}
-	result := parsePromptResult(rawResult)
-
-	// Update fields from response
-	if id, ok := result["prompt_id"].(string); ok {
-		data.PromptID = types.StringValue(id)
-		data.ID = types.StringValue(id)
+	observed, err := promptObject(rawResult, true, promptID, environment)
+	if err != nil {
+		return err
+	}
+	if !observed.HasVersion {
+		return fmt.Errorf("prompt response omitted required version")
+	}
+	integration, ok := observed.Params["prompt_integration"].(string)
+	if !ok || integration == "" {
+		return fmt.Errorf("prompt response omitted required litellm_params.prompt_integration")
 	}
 
-	// Handle litellm_params
-	if litellmParams, ok := result["litellm_params"].(map[string]interface{}); ok {
-		if integration, ok := litellmParams["prompt_integration"].(string); ok {
-			data.PromptIntegration = types.StringValue(integration)
+	data.ID = types.StringValue(observed.PromptID)
+	data.PromptID = types.StringValue(observed.PromptID)
+	data.Environment = types.StringValue(observed.Environment)
+	data.Version = types.Int64Value(observed.Version)
+	data.PromptIntegration = types.StringValue(integration)
+	data.CreatedAt = types.StringNull()
+	data.UpdatedAt = types.StringNull()
+	if observed.CreatedAt != nil {
+		data.CreatedAt = types.StringValue(*observed.CreatedAt)
+	}
+	if observed.UpdatedAt != nil {
+		data.UpdatedAt = types.StringValue(*observed.UpdatedAt)
+	}
+
+	data.APIBase, err = promptStringFromAPI(observed.Params, "api_base")
+	if err != nil {
+		return err
+	}
+	data.DotpromptContent, err = promptStringFromAPI(observed.Params, "dotprompt_content")
+	if err != nil {
+		return err
+	}
+	if adoptImportedDefaults || !data.IgnorePromptManagerModel.IsNull() || data.IgnorePromptManagerModel.IsUnknown() {
+		data.IgnorePromptManagerModel, err = promptBoolFromAPI(observed.Params, "ignore_prompt_manager_model")
+		if err != nil {
+			return err
 		}
-		if apiBase, ok := litellmParams["api_base"].(string); ok {
-			data.APIBase = types.StringValue(apiBase)
+	}
+	if adoptImportedDefaults || !data.IgnorePromptManagerOptionalParams.IsNull() || data.IgnorePromptManagerOptionalParams.IsUnknown() {
+		data.IgnorePromptManagerOptionalParams, err = promptBoolFromAPI(observed.Params, "ignore_prompt_manager_optional_params")
+		if err != nil {
+			return err
 		}
-		if ignoreModel, ok := litellmParams["ignore_prompt_manager_model"].(bool); ok && !data.IgnorePromptManagerModel.IsNull() {
-			data.IgnorePromptManagerModel = types.BoolValue(ignoreModel)
+	}
+	value, exists := observed.Params["provider_specific_query_params"]
+	if !exists || value == nil {
+		data.ProviderSpecificQueryParams = types.StringNull()
+	} else {
+		object, valid := value.(map[string]interface{})
+		if !valid {
+			return fmt.Errorf("prompt response field %q must be an object or null", "litellm_params.provider_specific_query_params")
 		}
-		if ignoreParams, ok := litellmParams["ignore_prompt_manager_optional_params"].(bool); ok && !data.IgnorePromptManagerOptionalParams.IsNull() {
-			data.IgnorePromptManagerOptionalParams = types.BoolValue(ignoreParams)
+		encoded, marshalErr := json.Marshal(object)
+		if marshalErr != nil {
+			return fmt.Errorf("prompt response field %q could not be encoded", "litellm_params.provider_specific_query_params")
 		}
-		if dotprompt, ok := litellmParams["dotprompt_content"].(string); ok {
-			data.DotpromptContent = types.StringValue(dotprompt)
+		if data.ProviderSpecificQueryParams.IsNull() || data.ProviderSpecificQueryParams.IsUnknown() || !jsonSemanticallyEqual(data.ProviderSpecificQueryParams.ValueString(), string(encoded)) {
+			data.ProviderSpecificQueryParams = types.StringValue(string(encoded))
 		}
-		if providerParams, ok := litellmParams["provider_specific_query_params"].(map[string]interface{}); ok {
-			if jsonBytes, err := json.Marshal(providerParams); err == nil {
-				data.ProviderSpecificQueryParams = types.StringValue(string(jsonBytes))
+	}
+	if adoptImportedDefaults || !data.PromptType.IsNull() || data.PromptType.IsUnknown() {
+		data.PromptType = types.StringNull()
+		if value, exists := observed.Info["prompt_type"]; exists && value != nil {
+			promptType, valid := value.(string)
+			if !valid {
+				return fmt.Errorf("prompt response field %q must be a string or null", "prompt_info.prompt_type")
 			}
-		}
-	}
-
-	// Handle prompt_info
-	if promptInfo, ok := result["prompt_info"].(map[string]interface{}); ok {
-		if promptType, ok := promptInfo["prompt_type"].(string); ok && !data.PromptType.IsNull() {
 			data.PromptType = types.StringValue(promptType)
 		}
 	}
-
 	return nil
 }
 

--- a/internal_testing/datasources/prompt.tf
+++ b/internal_testing/datasources/prompt.tf
@@ -2,7 +2,8 @@
 # Note: prompt_id must reference an existing prompt
 
 data "litellm_prompt" "lookup" {
-  prompt_id = litellm_prompt.minimal.prompt_id
+  prompt_id   = litellm_prompt.minimal.prompt_id
+  environment = litellm_prompt.minimal.environment
 }
 
 output "ds_prompt_integration" {
@@ -15,4 +16,12 @@ output "ds_prompt_type" {
 
 output "ds_prompt_dotprompt_content" {
   value = data.litellm_prompt.lookup.dotprompt_content
+}
+
+output "ds_prompt_version" {
+  value = data.litellm_prompt.lookup.version
+}
+
+output "ds_prompt_created_at" {
+  value = data.litellm_prompt.lookup.created_at
 }

--- a/internal_testing/datasources/prompts_list.tf
+++ b/internal_testing/datasources/prompts_list.tf
@@ -1,6 +1,7 @@
 # data.litellm_prompts - Lists all prompts
 
 data "litellm_prompts" "all" {
+  environment = "development"
 }
 
 output "ds_prompts_list" {

--- a/internal_testing/resources/prompt_full.tf
+++ b/internal_testing/resources/prompt_full.tf
@@ -3,6 +3,7 @@
 
 resource "litellm_prompt" "full" {
   prompt_id          = "test-prompt-full"
+  environment        = "staging"
   prompt_integration = "dotprompt"
   prompt_type        = "db"
 
@@ -20,4 +21,8 @@ resource "litellm_prompt" "full" {
 
 output "prompt_full_id" {
   value = litellm_prompt.full.id
+}
+
+output "prompt_full_version" {
+  value = litellm_prompt.full.version
 }

--- a/internal_testing/resources/prompt_minimal.tf
+++ b/internal_testing/resources/prompt_minimal.tf
@@ -1,11 +1,32 @@
 # litellm_prompt - Minimal
-# Only required attributes
+# Only required attributes; omitted environment preserves the legacy development default.
 
 resource "litellm_prompt" "minimal" {
   prompt_id          = "test-prompt-minimal"
   prompt_integration = "dotprompt"
 }
 
+data "litellm_prompt" "minimal" {
+  prompt_id   = litellm_prompt.minimal.prompt_id
+  environment = litellm_prompt.minimal.environment
+}
+
+data "litellm_prompts" "development" {
+  environment = "development"
+  depends_on  = [litellm_prompt.minimal]
+
+  lifecycle {
+    postcondition {
+      condition     = contains([for prompt in self.prompts : prompt.prompt_id], litellm_prompt.minimal.prompt_id)
+      error_message = "The environment-scoped prompt inventory omitted the managed prompt."
+    }
+  }
+}
+
 output "prompt_minimal_id" {
   value = litellm_prompt.minimal.id
+}
+
+output "prompt_minimal_version" {
+  value = litellm_prompt.minimal.version
 }


### PR DESCRIPTION
### Summary

Closes #194. Prompt ownership is now deterministic across LiteLLM v1.98 environments and versions.

`litellm_prompt` represents the mutable latest logical prompt for one `(prompt_id, environment)` pair. Omitted environment remains `development`; updates append a version through PUT; refresh selects the latest scoped version; destroy always sends the environment and proves scoped absence. The backward-compatible `id` output remains the base `prompt_id`.

The single data source supports environment plus optional explicit-version selection and exports version/timestamps. The list data source exposes environment/version/timestamps and accepts an optional environment filter. Because v1.98's process-local registry collapses equal IDs/versions across environments, filtered inventory discovers visible IDs then resolves each with one bounded authoritative scoped-info request.

### Safety behavior

- Create proves scoped absence through info plus the environment-scoped versions route. Existing identities require import; ambiguous 400/403/transport/malformed responses fail closed.
- Update verifies the latest version has not changed after planning and refuses to drop unowned API keys or non-null unmodeled integration fields during full-version PUT.
- API-managed `prompt_type = "config"` creates/updates are rejected because v1.98 cannot update or delete config prompts; existing/imported config prompts remain read-only.
- Delete never trusts DELETE status alone. It confirms absence through scoped GET. When v1.98 returns 404 from a missing process-local registry key while the DB history survives, the provider performs one scoped no-content-change PATCH, retries DELETE once, and still requires absence confirmation.
- Scoped response decoding requires exact prompt/environment/version identity and rejects conflicting or malformed envelopes.

### Identity and imports

Canonical import grammar:

```text
v1.<base64url(prompt_id)>.<base64url(environment)>
```

Historical bare IDs remain accepted as `development`. Canonical-looking historical IDs can use `legacy.<base64url(prompt_id)>`. Existing schema-v0 state with no environment migrates to development through ordinary refresh with no replacement or HCL rewrite.

### Compatibility

Schema version 0, resource/data-source names, all prior attributes and types, base `id`, and bare imports are preserved. New environment/version/timestamp fields are additive. Existing HCL defaults to development. Optional-only boolean/type fields retain removal semantics; private import provenance adopts their API values only during import.

One intentional safety restriction prevents **new** `prompt_type = "config"` resources because LiteLLM accepts the write but makes the result undeletable. Existing/imported config state remains readable and is never silently discarded.

### Validation

Focused/protocol coverage includes:

- canonical, escaped-legacy, and bare import IDs;
- schema-v0 development migration with no replacement;
- exact endpoint path/query scoping;
- info 400 + versions 404 authoritative create absence;
- ambiguous 400 and existing-version create refusal with zero POSTs;
- version update ownership and concurrent-version preflight;
- explicit version data-source lookup and identity mismatch rejection;
- same-ID cross-environment collision recovery;
- 200-candidate enrichment bound;
- config-prompt read-only enforcement;
- unowned credential/unmodeled-field update refusal;
- DELETE 400/404 state retention;
- stale-registry PATCH/delete recovery;
- malformed/missing/conflicting environment and version responses.

Live LiteLLM v1.98 validation covered same-ID development/production resources, independent v1→v2 update, filtered list recovery, explicit v1 read, canonical and bare import with no drift, optional-field clear, production-only target destroy, development survival, stale-registry delete recovery, and cleanup.

Full Go, repeated focused, race, vet, Terraform formatting, and diff checks passed. Final live provider matrix: **PASS 23 / DRIFT 0 / FAIL 0**. Independent review findings were resolved through three re-review rounds; final verdict: **SHIP**.

### Review focus

Please focus on scoped-create absence proof, legacy state/import migration, update coverage refusal, stale-registry delete recovery, and filtered list collision enrichment.

### Checklist

- [x] Schema-v0 base IDs and legacy imports preserved
- [x] Every prompt operation is environment-scoped through request body or query
- [x] Mutable-latest version ownership documented and tested
- [x] Cross-environment deletion isolation validated live
- [x] Single/list environment, version, and timestamp parity added
- [x] Previous-state/import/no-drift protocol coverage added
- [x] Full 23-resource live matrix passed
- [x] Independent review: SHIP

### Diff size

**Docs and complete example** — 4 files · `+69 / -12`

Documents environment/version ownership, imports, scoped deletion, registry collisions, update safety, config-prompt limitations, and updates invalid complete examples.

**Implementation** — 4 files · `+794 / -128`

Adds identity/endpoint/response helpers and rewrites resource/single/list lifecycle handling around exact v1.98 semantics.

**Tests and acceptance fixtures** — 8 files · `+650 / -7`

Adds focused/protocol compatibility, collision, import, version, failure, clear, and deletion-isolation coverage plus environment-aware acceptance fixtures.
