### PR TITLE
feat(mcp): manage toolsets and assignments with Terraform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`litellm_mcp_toolset` and assignments**: Manage LiteLLM v1.98 MCP toolset definitions with stable ID import, unordered server/tool membership, empty toolsets, and create, read, update, and delete lifecycle support. Keys and teams manage unordered toolset assignments with explicit clear, omission-based ownership release, and import behavior; assignment mutations are transactional and retain prior state until an authoritative readback confirms them. Toolset creates distinguish rejected, accepted-unconfirmed, and dispatched-uncertain outcomes, recover accepted creates only through exact-name evidence with direct-ID and definition confirmation, fail closed on unknown values and terminal recovery answers, and use context-aware bounded backoff. `litellm_key` state upgrades to schema v3 and `litellm_team` to v2 with direct upgraders from every prior version. User assignments are out of scope for this change. ([#207](https://github.com/ncecere/terraform-provider-litellm/issues/207))
+
 ## [2.1.0] - 2026-08-29
 
 ### Upgrade Notes

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ For full details on the <code>litellm_key</code> resource, see the [key resource
 - <code>litellm_agent</code>: Manage LiteLLM Agents (A2A). [Documentation](docs/resources/agent.md)
 - <code>litellm_search_tool</code>: Manage web-search tool configurations. [Documentation](docs/resources/search_tool.md)
 - <code>litellm_mcp_server</code>: Manage MCP (Model Context Protocol) servers. [Documentation](docs/resources/mcp_server.md)
+- <code>litellm_mcp_toolset</code>: Manage MCP toolset definitions. [Documentation](docs/resources/mcp_toolset.md)
 - <code>litellm_credential</code>: Manage credentials for secure authentication. [Documentation](docs/resources/credential.md)
 - <code>litellm_vector_store</code>: Manage vector stores for embeddings and RAG. [Documentation](docs/resources/vector_store.md)
 - <code>litellm_jwt_key_mapping</code>: Manage JWT string claim-to-existing-virtual-key mappings. [Documentation](docs/resources/jwt_key_mapping.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -142,6 +142,7 @@ The LiteLLM provider supports the following resources:
 ### Integrations
 
 * [`litellm_mcp_server`](./resources/mcp_server.md) - Manage MCP (Model Context Protocol) servers
+* [`litellm_mcp_toolset`](./resources/mcp_toolset.md) - Manage MCP toolset definitions
 * [`litellm_search_tool`](./resources/search_tool.md) - Manage search tool configurations
 * [`litellm_vector_store`](./resources/vector_store.md) - Manage vector stores
 

--- a/docs/resources/key.md
+++ b/docs/resources/key.md
@@ -186,6 +186,17 @@ resource "litellm_key" "routed" {
 
 Removing the entire block sends an explicit empty object to clear the key-level override and restores team/global inheritance. Setting `fallbacks = jsonencode([])` retains a non-empty key-level settings document and intentionally suppresses inherited fallbacks.
 
+### Key with MCP Toolsets
+
+```hcl
+resource "litellm_key" "incident_response" {
+  key_alias       = "incident-response"
+  mcp_toolset_ids = [litellm_mcp_toolset.incident_response.toolset_id]
+}
+```
+
+The key assignment is the effective LiteLLM toolset grant. If the key belongs to a team whose `mcp_toolset_ids` is nonempty, the key's set must be a subset of the team's set.
+
 ### Service Account Key
 
 ```hcl
@@ -242,6 +253,8 @@ The following arguments are supported:
 * `key_alias` - (Optional) Human-readable alias for this key.
 
 * `models` - (Optional) List of models that can be used with this key.
+
+* `mcp_toolset_ids` - (Optional) Unordered set of MCP toolset IDs granted directly to the key. Omit it to leave remote assignments unmanaged. Set it to `[]` to clear toolset assignments without changing sibling object permissions.
 
 * `max_budget` - (Optional) Maximum budget for this key.
 

--- a/docs/resources/mcp_toolset.md
+++ b/docs/resources/mcp_toolset.md
@@ -1,0 +1,95 @@
+# litellm_mcp_toolset (Resource)
+
+Manages an MCP toolset definition in LiteLLM. A toolset is an unordered set of MCP server and tool pairs.
+
+The toolset resource manages only the definition. Assign its `toolset_id` through `mcp_toolset_ids` on a key or team resource.
+
+## Example usage
+
+```hcl
+resource "litellm_mcp_toolset" "incident_response" {
+  toolset_name = "incident-response"
+  description  = "Read-only incident response tools"
+
+  tools = [
+    {
+      server_id = "pagerduty-server-id"
+      tool_name = "list_incidents"
+    },
+    {
+      server_id = "datadog-server-id"
+      tool_name = "search_datadog_logs"
+    }
+  ]
+}
+```
+
+An empty toolset is valid:
+
+```hcl
+resource "litellm_mcp_toolset" "empty" {
+  toolset_name = "empty"
+}
+```
+
+## Assign toolsets
+
+Assign a toolset directly to a key:
+
+```hcl
+resource "litellm_key" "incident_response" {
+  key_alias       = "incident-response"
+  mcp_toolset_ids = [litellm_mcp_toolset.incident_response.toolset_id]
+}
+```
+
+LiteLLM treats a nonempty team assignment as a ceiling for keys in that team. The team assignment does not grant the toolset to its keys automatically, and a null or empty team assignment imposes no ceiling, so clearing the team set to `[]` removes the ceiling rather than denying all toolsets. Configure the toolset on both resources:
+
+```hcl
+resource "litellm_team" "responders" {
+  team_alias       = "Responders"
+  mcp_toolset_ids  = [litellm_mcp_toolset.incident_response.toolset_id]
+}
+
+resource "litellm_key" "responder" {
+  key_alias       = "responder"
+  team_id         = litellm_team.responders.id
+  mcp_toolset_ids = [litellm_mcp_toolset.incident_response.toolset_id]
+}
+```
+
+User toolset assignments are out of scope for this resource. LiteLLM v1.98 stores them and returns them from `/v2/user/info`, but the provider does not manage user assignments; managing them is a separate resource-scope decision.
+
+For each target resource, omit `mcp_toolset_ids` to leave remote assignments unmanaged. Set it to `[]` to clear the complete toolset assignment while preserving other object permissions. Assignment order is not significant.
+
+Importing a key or team reads its current assignments into the initial state. If the post-import configuration omits `mcp_toolset_ids`, the next apply removes only the imported Terraform value and leaves the LiteLLM assignments unchanged.
+
+LiteLLM v1.98 does not support toolset assignments on legacy or unified access groups.
+
+Assignment updates are transactional. If LiteLLM accepts an update but the authoritative readback fails or does not match the plan, Terraform keeps the prior state and reports an error. Run `terraform apply` again after the API is reachable; the next refresh reconciles the assignments.
+
+## Create recovery
+
+`toolset_name` is unique in LiteLLM. When LiteLLM accepts a create but the response is unusable, Terraform keeps a name-bound partial state and recovers the identity on the next refresh through exact-name evidence and a direct-ID read that must match the requested definition. When the create request is dispatched but no response status arrives, the toolset may or may not exist: Terraform keeps the name-bound state to block a duplicate create and asks you to confirm the toolset in LiteLLM, then import it by ID or remove the resource from state.
+
+## Argument reference
+
+- `toolset_name` - (Required) The unique toolset name.
+- `description` - (Optional) A description of the toolset.
+- `tools` - (Optional) An unordered set of MCP tools. The default is an empty set. Each entry requires these attributes:
+  - `server_id` - The MCP server identifier.
+  - `tool_name` - The tool name exposed by the MCP server.
+
+The provider does not query the live MCP catalog to validate `server_id` or `tool_name`.
+
+## Attribute reference
+
+- `toolset_id` - The identifier assigned by LiteLLM.
+
+## Import
+
+Import a toolset with its LiteLLM toolset ID:
+
+```shell
+terraform import litellm_mcp_toolset.example <toolset-id>
+```

--- a/docs/resources/team.md
+++ b/docs/resources/team.md
@@ -48,6 +48,17 @@ resource "litellm_team" "engineering" {
 
 `access_group_ids` is unordered. Set it to `[]` to detach all access groups; omitting it allows the provider to read the current API associations.
 
+### With MCP Toolsets
+
+```hcl
+resource "litellm_team" "responders" {
+  team_alias      = "Responders"
+  mcp_toolset_ids = [litellm_mcp_toolset.incident_response.toolset_id]
+}
+```
+
+LiteLLM treats the team's toolset IDs as the ceiling for toolsets assigned to its keys. The team assignment does not grant the toolsets to those keys automatically.
+
 ### Full
 
 ```hcl
@@ -163,6 +174,7 @@ The following arguments are supported:
 * `team_id` - (Optional, Computed, Forces replacement) Stable LiteLLM team identifier. Supply a predetermined value for external identity or JWT group mapping, or omit it to let the provider generate a UUID.
 * `organization_id` - (Optional) The ID of the organization this team belongs to.
 * `access_group_ids` - (Optional, Computed) Unordered set of access group IDs associated with the team. Use `[]` to detach all groups.
+* `mcp_toolset_ids` - (Optional) Unordered set of MCP toolset IDs that keys in this team may request. A nonempty set constrains key grants to that ceiling. LiteLLM treats a null and an empty team assignment the same way: no ceiling. Setting `[]` therefore removes the ceiling rather than denying all toolsets, and it does not change sibling object permissions. Omit the attribute to leave the remote value unmanaged.
 * `max_budget` - (Optional) Maximum budget allocated to the team.
 * `budget_duration` - (Optional) Recurring team budget reset interval. Use a positive integer followed by `s`, `m`, `h`, `d`, or `w` (for example, `30d`, `24h`, or `1w`); one of the exact aliases `hourly`, `daily`, `weekly`, or `monthly`; or exactly `1mo`. Zero values, other month counts such as `2mo` or `12mo`, case variants, and malformed aliases or units are rejected.
 * `tpm_limit` - (Optional) Tokens per minute limit for the team.

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,6 +11,7 @@ This directory contains example configurations for the LiteLLM Terraform provide
 | [multi-provider](./multi-provider/) | Configuring multiple LLM providers (OpenAI, Anthropic, Azure, Bedrock) |
 | [data-sources](./data-sources/) | Using data sources to reference existing resources |
 | [mcp-servers](./mcp-servers/) | MCP server configurations (HTTP, SSE, OAuth, stdio) |
+| [mcp-toolsets](./mcp-toolsets/) | MCP toolset definitions |
 | [search-tools](./search-tools/) | Search tool configurations (Tavily, Serper, Bing, Google) |
 
 ## Prerequisites and Compatibility
@@ -108,6 +109,10 @@ Complete examples of MCP server configurations:
 - **SSE transport**: Zapier automation
 - **OAuth**: Enterprise API with OAuth2
 - **Stdio**: Local development tools
+
+### MCP Toolsets (`mcp-toolsets/`)
+
+Shows populated and empty MCP toolset definitions and assignments to keys and teams.
 
 ### Search Tools (`search-tools/`)
 

--- a/examples/mcp-toolsets/main.tf
+++ b/examples/mcp-toolsets/main.tf
@@ -1,0 +1,43 @@
+terraform {
+  required_version = ">= 1.1.0"
+
+  required_providers {
+    litellm = {
+      source  = "registry.terraform.io/ncecere/litellm"
+      version = ">= 2.0.1, < 3.0.0"
+    }
+  }
+}
+
+provider "litellm" {}
+
+resource "litellm_mcp_toolset" "incident_response" {
+  toolset_name = "incident-response"
+  description  = "Read-only incident response tools"
+
+  tools = [
+    {
+      server_id = "pagerduty-server-id"
+      tool_name = "list_incidents"
+    },
+    {
+      server_id = "datadog-server-id"
+      tool_name = "search_datadog_logs"
+    }
+  ]
+}
+
+resource "litellm_mcp_toolset" "empty" {
+  toolset_name = "empty"
+}
+
+resource "litellm_team" "responders" {
+  team_alias      = "Responders"
+  mcp_toolset_ids = [litellm_mcp_toolset.incident_response.toolset_id]
+}
+
+resource "litellm_key" "responder" {
+  key_alias       = "incident-response"
+  team_id         = litellm_team.responders.id
+  mcp_toolset_ids = [litellm_mcp_toolset.incident_response.toolset_id]
+}

--- a/internal/contract/manifest.json
+++ b/internal/contract/manifest.json
@@ -1,10 +1,10 @@
 {
   "classification": {
     "excluded_non_durable": 504,
-    "operation_count": 693,
+    "operation_count": 688,
     "path": "internal/contract/reviewed-operation-classification.json",
-    "sha256": "c1fa3c7f88f6d738cc30dfc94c402f0eddce0a5663f45890692714cadef3c393",
-    "unsupported_durable": 189
+    "sha256": "7812184edd3beb358e0f7e6e054507197ff30f9d5a5da325f970499ff3e7b053",
+    "unsupported_durable": 184
   },
   "generation_command": "make contract-update LITELLM_SOURCE=../litellm",
   "openapi": {
@@ -14,9 +14,9 @@
     "sha256": "ab876dc970a8cc835e30cbdf65ece45a7bfd90bad0c7585bd4557d27c4a7615a"
   },
   "provider_golden": {
-    "operation_count": 108,
+    "operation_count": 113,
     "path": "internal/contractapi/testdata/provider-operations.golden.json",
-    "sha256": "a1a5114f93cc432a97f4da76def86ce238d712fba471dbb2d703768e7cecfe51"
+    "sha256": "3a4296f6974e11d5611978fd1e171b99993f350c129c0e3b2c2ac790f57e2e95"
   },
   "provider_operations": [
     {
@@ -476,7 +476,7 @@
       "evidence": [
         {
           "file": "internal/provider/resource_key.go",
-          "line": 1049
+          "line": 1076
         }
       ],
       "method": "POST",
@@ -488,11 +488,11 @@
       "evidence": [
         {
           "file": "internal/provider/resource_key.go",
-          "line": 633
+          "line": 643
         },
         {
           "file": "internal/provider/resource_key.go",
-          "line": 635
+          "line": 645
         }
       ],
       "method": "POST",
@@ -508,15 +508,15 @@
         },
         {
           "file": "internal/provider/resource_key.go",
-          "line": 1416
+          "line": 1476
         },
         {
           "file": "internal/provider/resource_key.go",
-          "line": 1433
+          "line": 1493
         },
         {
           "file": "internal/provider/resource_key.go",
-          "line": 1478
+          "line": 1538
         },
         {
           "file": "internal/provider/resource_key_block.go",
@@ -567,11 +567,11 @@
       "evidence": [
         {
           "file": "internal/provider/resource_key.go",
-          "line": 633
+          "line": 643
         },
         {
           "file": "internal/provider/resource_key.go",
-          "line": 635
+          "line": 645
         }
       ],
       "method": "POST",
@@ -595,7 +595,7 @@
       "evidence": [
         {
           "file": "internal/provider/resource_key.go",
-          "line": 979
+          "line": 995
         },
         {
           "file": "internal/provider/resource_unified_access_group.go",
@@ -1172,7 +1172,7 @@
       "evidence": [
         {
           "file": "internal/provider/resource_team.go",
-          "line": 926
+          "line": 949
         }
       ],
       "method": "POST",
@@ -1188,11 +1188,11 @@
         },
         {
           "file": "internal/provider/resource_team.go",
-          "line": 1268
+          "line": 1300
         },
         {
           "file": "internal/provider/resource_team.go",
-          "line": 1281
+          "line": 1313
         },
         {
           "file": "internal/provider/resource_team_block.go",
@@ -1296,7 +1296,7 @@
       "evidence": [
         {
           "file": "internal/provider/resource_team.go",
-          "line": 580
+          "line": 591
         }
       ],
       "method": "POST",
@@ -1312,7 +1312,7 @@
         },
         {
           "file": "internal/provider/resource_team.go",
-          "line": 1395
+          "line": 1427
         }
       ],
       "method": "GET",
@@ -1326,7 +1326,7 @@
       "evidence": [
         {
           "file": "internal/provider/resource_team.go",
-          "line": 872
+          "line": 887
         }
       ],
       "method": "POST",
@@ -1350,11 +1350,11 @@
       "evidence": [
         {
           "file": "internal/provider/resource_team.go",
-          "line": 847
+          "line": 862
         },
         {
           "file": "internal/provider/resource_team.go",
-          "line": 856
+          "line": 871
         }
       ],
       "method": "POST",
@@ -1704,6 +1704,78 @@
       "path": "/v1/mcp/server/{server_id}",
       "path_parameters": [
         "server_id"
+      ],
+      "query_parameters": []
+    },
+    {
+      "evidence": [
+        {
+          "file": "internal/provider/resource_mcp_toolset.go",
+          "line": 477
+        }
+      ],
+      "method": "GET",
+      "path": "/v1/mcp/toolset",
+      "path_parameters": [],
+      "query_parameters": []
+    },
+    {
+      "evidence": [
+        {
+          "file": "internal/provider/resource_mcp_toolset.go",
+          "line": 404
+        }
+      ],
+      "method": "POST",
+      "path": "/v1/mcp/toolset",
+      "path_parameters": [],
+      "query_parameters": []
+    },
+    {
+      "evidence": [
+        {
+          "file": "internal/provider/resource_mcp_toolset.go",
+          "line": 551
+        }
+      ],
+      "method": "PUT",
+      "path": "/v1/mcp/toolset",
+      "path_parameters": [],
+      "query_parameters": []
+    },
+    {
+      "evidence": [
+        {
+          "file": "internal/provider/resource_mcp_toolset.go",
+          "line": 569
+        }
+      ],
+      "method": "DELETE",
+      "path": "/v1/mcp/toolset/{toolset_id}",
+      "path_parameters": [
+        "toolset_id"
+      ],
+      "query_parameters": []
+    },
+    {
+      "evidence": [
+        {
+          "file": "internal/provider/resource_mcp_toolset.go",
+          "line": 505
+        },
+        {
+          "file": "internal/provider/resource_mcp_toolset.go",
+          "line": 532
+        },
+        {
+          "file": "internal/provider/resource_mcp_toolset.go",
+          "line": 559
+        }
+      ],
+      "method": "GET",
+      "path": "/v1/mcp/toolset/{toolset_id}",
+      "path_parameters": [
+        "toolset_id"
       ],
       "query_parameters": []
     },

--- a/internal/contract/metadata_hcl_test.go
+++ b/internal/contract/metadata_hcl_test.go
@@ -27,6 +27,7 @@ var (
 		"examples/complete/main.tf",
 		"examples/data-sources/main.tf",
 		"examples/mcp-servers/main.tf",
+		"examples/mcp-toolsets/main.tf",
 		"examples/minimal/main.tf",
 		"examples/multi-provider/main.tf",
 		"examples/search-tools/main.tf",

--- a/internal/contract/reviewed-operation-classification.json
+++ b/internal/contract/reviewed-operation-classification.json
@@ -2606,31 +2606,6 @@
       "path": "/v1/mcp/tools"
     },
     {
-      "category": "mcp_toolset_management",
-      "method": "GET",
-      "path": "/v1/mcp/toolset"
-    },
-    {
-      "category": "mcp_toolset_management",
-      "method": "POST",
-      "path": "/v1/mcp/toolset"
-    },
-    {
-      "category": "mcp_toolset_management",
-      "method": "PUT",
-      "path": "/v1/mcp/toolset"
-    },
-    {
-      "category": "mcp_toolset_management",
-      "method": "DELETE",
-      "path": "/v1/mcp/toolset/{toolset_id}"
-    },
-    {
-      "category": "mcp_toolset_management",
-      "method": "GET",
-      "path": "/v1/mcp/toolset/{toolset_id}"
-    },
-    {
       "category": "mcp_credential_configuration",
       "method": "GET",
       "path": "/v1/mcp/user-credentials"

--- a/internal/contract/reviewed-pins.json
+++ b/internal/contract/reviewed-pins.json
@@ -2,14 +2,14 @@
   "artifacts": {
     "classification": {
       "excluded_non_durable_count": 504,
-      "operation_count": 693,
+      "operation_count": 688,
       "path": "internal/contract/reviewed-operation-classification.json",
-      "sha256": "c1fa3c7f88f6d738cc30dfc94c402f0eddce0a5663f45890692714cadef3c393",
-      "unsupported_durable_count": 189
+      "sha256": "7812184edd3beb358e0f7e6e054507197ff30f9d5a5da325f970499ff3e7b053",
+      "unsupported_durable_count": 184
     },
     "manifest": {
       "path": "internal/contract/manifest.json",
-      "sha256": "7738abd950f1ebb6b5be1ebadb626a9370e8ec7fd0adda3719239f97f16cb1c1"
+      "sha256": "441bba08bbb588b1047dfbf4e9a1b236bb6a9a4d212a667cd219ee7227e15e3a"
     },
     "openapi": {
       "operation_count": 800,
@@ -18,9 +18,9 @@
       "sha256": "ab876dc970a8cc835e30cbdf65ece45a7bfd90bad0c7585bd4557d27c4a7615a"
     },
     "provider_golden": {
-      "operation_count": 108,
+      "operation_count": 113,
       "path": "internal/contractapi/testdata/provider-operations.golden.json",
-      "sha256": "a1a5114f93cc432a97f4da76def86ce238d712fba471dbb2d703768e7cecfe51"
+      "sha256": "3a4296f6974e11d5611978fd1e171b99993f350c129c0e3b2c2ac790f57e2e95"
     },
     "supplemental": {
       "operation_count": 1,

--- a/internal/contractapi/contract.go
+++ b/internal/contractapi/contract.go
@@ -1261,11 +1261,12 @@ var reviewedPaginationFunctions = map[string]bool{
 // raw-identity helpers and promptEnvironment. Any implementation or dependency
 // change must be independently reviewed before its new proof is admitted here.
 var reviewedRawIdentityProofs = map[string]string{
-	"keyDataSourceLookup":          "f08481c1c2e15199e9c41d00951db05a4c7a4f9b2c47808b8cc856064292f54c",
-	"keyLookupIdentifier":          "f49ebea85202b2949fdd44b9aab7cc8c417a72d3d187733f2796194962471652",
-	"keyBlockStateIdentity":        "565265e0425d3c4820d1bd198c0fed6f1b641e4dc4790752c269de3bd49eb08f",
-	"batchTeamID":                  "c568cb284d64ec148f22093cc28d161db0f7f00d88a7728f53b44d9d12fd3c04",
-	"teamMemberConfiguredIdentity": "f7f74ec5327d73d2f6a935213553eaab298068b93fe1b081734d619a51adfc3d",
+	"keyDataSourceLookup":           "f08481c1c2e15199e9c41d00951db05a4c7a4f9b2c47808b8cc856064292f54c",
+	"mcpToolsetRecoveredIdentifier": "d033f5fb1197863e7de681d0665ec565ad9f43147b2b1defccafdc4d5083be40",
+	"keyLookupIdentifier":           "f638e6ceae941566d90284c9ca00290bd11a785e58b168c06f21c7d6e6a5b55d",
+	"keyBlockStateIdentity":         "565265e0425d3c4820d1bd198c0fed6f1b641e4dc4790752c269de3bd49eb08f",
+	"batchTeamID":                   "c568cb284d64ec148f22093cc28d161db0f7f00d88a7728f53b44d9d12fd3c04",
+	"teamMemberConfiguredIdentity":  "f7f74ec5327d73d2f6a935213553eaab298068b93fe1b081734d619a51adfc3d",
 }
 
 var reviewedPromptEnvironmentProof = "9796a2c10e9c247caa736ddc593d0fff808ff9b1f846541349008174604f2920"

--- a/internal/contractapi/contract_test.go
+++ b/internal/contractapi/contract_test.go
@@ -138,8 +138,8 @@ func TestResolvedOperationTableHasReviewedPathModes(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(operations) != 108 {
-		t.Fatalf("operation count = %d, want 108", len(operations))
+	if len(operations) != 113 {
+		t.Fatalf("operation count = %d, want 113", len(operations))
 	}
 	captures := map[string]bool{
 		"GET /credentials/by_name/{credential_name}": true,
@@ -710,8 +710,8 @@ func TestProductionRawIdentityFlowsKeepLexicalIdentity(t *testing.T) {
 		t.Fatal(err)
 	}
 	operations, err := ResolveOperations(extracted, contracts)
-	if err != nil || len(operations) != 108 {
-		t.Fatalf("shadowed production operation inventory = %d, want 108: %v", len(operations), err)
+	if err != nil || len(operations) != 113 {
+		t.Fatalf("shadowed production operation inventory = %d, want 113: %v", len(operations), err)
 	}
 
 	for _, pattern := range patterns {
@@ -3188,8 +3188,44 @@ func TestManifestPinnedMetadataCountsAndReviewInventory(t *testing.T) {
 	if err != nil || json.Unmarshal(pinsData, &pins) != nil {
 		t.Fatalf("load reviewed pins: %v", err)
 	}
-	if pins.Upstream.UV != "0.12.6" || pins.Artifacts.ProviderGolden.OperationCount != 108 || pins.Artifacts.Classification.OperationCount != 693 || len(pins.LazyFeatures) != 33 {
+	if pins.Upstream.UV != "0.12.6" || pins.Artifacts.ProviderGolden.OperationCount != 113 || pins.Artifacts.Classification.OperationCount != 688 || len(pins.LazyFeatures) != 33 {
 		t.Fatalf("reviewed pins changed unexpectedly: artifacts=%+v lazy=%d", pins.Artifacts, len(pins.LazyFeatures))
+	}
+}
+
+func TestMCPToolsetOperationsAreExactSupportedInventory(t *testing.T) {
+	root := repositoryRoot(t)
+	var golden []Operation
+	if err := readJSONFile(filepath.Join(root, "internal", "contractapi", "testdata", "provider-operations.golden.json"), &golden); err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]string{
+		"GET /v1/mcp/toolset":                 "",
+		"POST /v1/mcp/toolset":                "",
+		"PUT /v1/mcp/toolset":                 "",
+		"DELETE /v1/mcp/toolset/{toolset_id}": "",
+		"GET /v1/mcp/toolset/{toolset_id}":    "",
+	}
+	seen := map[string]string{}
+	for _, operation := range golden {
+		key := operation.Method + " " + operation.Path
+		if _, reviewed := want[key]; reviewed {
+			seen[key] = strings.Join(operation.QueryParameters, ",")
+		}
+	}
+	if !reflect.DeepEqual(seen, want) {
+		t.Fatalf("MCP toolset provider inventory = %#v, want %#v", seen, want)
+	}
+
+	var classification ReviewedClassification
+	if err := readJSONFile(filepath.Join(root, "internal", "contract", "reviewed-operation-classification.json"), &classification); err != nil {
+		t.Fatal(err)
+	}
+	for _, operation := range classification.Operations {
+		key := operation.Method + " " + operation.Path
+		if _, supported := want[key]; supported {
+			t.Fatalf("supported MCP toolset operation remains classified as unsupported: %s", key)
+		}
 	}
 }
 
@@ -3381,7 +3417,6 @@ func TestLazyExpansionHasExactReviewedClassification(t *testing.T) {
 		t.Fatalf("lazy expansion counts changed: %v", counts)
 	}
 	for key, category := range map[string]string{
-		"GET /v1/mcp/toolset":                             "mcp_toolset_management",
 		"POST /v1/mcp/server/{server_id}/user-credential": "mcp_credential_configuration",
 		"GET /prompts/{prompt_id}/info":                   "agent_prompt_tool_management",
 		"POST /prompts/test":                              "testing_validation",

--- a/internal/contractapi/testdata/provider-operations.golden.json
+++ b/internal/contractapi/testdata/provider-operations.golden.json
@@ -460,7 +460,7 @@
     "evidence": [
       {
         "file": "internal/provider/resource_key.go",
-        "line": 1049
+        "line": 1076
       }
     ]
   },
@@ -472,11 +472,11 @@
     "evidence": [
       {
         "file": "internal/provider/resource_key.go",
-        "line": 633
+        "line": 643
       },
       {
         "file": "internal/provider/resource_key.go",
-        "line": 635
+        "line": 645
       }
     ]
   },
@@ -494,15 +494,15 @@
       },
       {
         "file": "internal/provider/resource_key.go",
-        "line": 1416
+        "line": 1476
       },
       {
         "file": "internal/provider/resource_key.go",
-        "line": 1433
+        "line": 1493
       },
       {
         "file": "internal/provider/resource_key.go",
-        "line": 1478
+        "line": 1538
       },
       {
         "file": "internal/provider/resource_key_block.go",
@@ -551,11 +551,11 @@
     "evidence": [
       {
         "file": "internal/provider/resource_key.go",
-        "line": 633
+        "line": 643
       },
       {
         "file": "internal/provider/resource_key.go",
-        "line": 635
+        "line": 645
       }
     ]
   },
@@ -579,7 +579,7 @@
     "evidence": [
       {
         "file": "internal/provider/resource_key.go",
-        "line": 979
+        "line": 995
       },
       {
         "file": "internal/provider/resource_unified_access_group.go",
@@ -1156,7 +1156,7 @@
     "evidence": [
       {
         "file": "internal/provider/resource_team.go",
-        "line": 926
+        "line": 949
       }
     ]
   },
@@ -1174,11 +1174,11 @@
       },
       {
         "file": "internal/provider/resource_team.go",
-        "line": 1268
+        "line": 1300
       },
       {
         "file": "internal/provider/resource_team.go",
-        "line": 1281
+        "line": 1313
       },
       {
         "file": "internal/provider/resource_team_block.go",
@@ -1280,7 +1280,7 @@
     "evidence": [
       {
         "file": "internal/provider/resource_team.go",
-        "line": 580
+        "line": 591
       }
     ]
   },
@@ -1298,7 +1298,7 @@
       },
       {
         "file": "internal/provider/resource_team.go",
-        "line": 1395
+        "line": 1427
       }
     ]
   },
@@ -1310,7 +1310,7 @@
     "evidence": [
       {
         "file": "internal/provider/resource_team.go",
-        "line": 872
+        "line": 887
       }
     ]
   },
@@ -1334,11 +1334,11 @@
     "evidence": [
       {
         "file": "internal/provider/resource_team.go",
-        "line": 847
+        "line": 862
       },
       {
         "file": "internal/provider/resource_team.go",
-        "line": 856
+        "line": 871
       }
     ]
   },
@@ -1684,6 +1684,78 @@
       {
         "file": "internal/provider/resource_mcp_server.go",
         "line": 2322
+      }
+    ]
+  },
+  {
+    "method": "GET",
+    "path": "/v1/mcp/toolset",
+    "path_parameters": [],
+    "query_parameters": [],
+    "evidence": [
+      {
+        "file": "internal/provider/resource_mcp_toolset.go",
+        "line": 477
+      }
+    ]
+  },
+  {
+    "method": "POST",
+    "path": "/v1/mcp/toolset",
+    "path_parameters": [],
+    "query_parameters": [],
+    "evidence": [
+      {
+        "file": "internal/provider/resource_mcp_toolset.go",
+        "line": 404
+      }
+    ]
+  },
+  {
+    "method": "PUT",
+    "path": "/v1/mcp/toolset",
+    "path_parameters": [],
+    "query_parameters": [],
+    "evidence": [
+      {
+        "file": "internal/provider/resource_mcp_toolset.go",
+        "line": 551
+      }
+    ]
+  },
+  {
+    "method": "DELETE",
+    "path": "/v1/mcp/toolset/{toolset_id}",
+    "path_parameters": [
+      "toolset_id"
+    ],
+    "query_parameters": [],
+    "evidence": [
+      {
+        "file": "internal/provider/resource_mcp_toolset.go",
+        "line": 569
+      }
+    ]
+  },
+  {
+    "method": "GET",
+    "path": "/v1/mcp/toolset/{toolset_id}",
+    "path_parameters": [
+      "toolset_id"
+    ],
+    "query_parameters": [],
+    "evidence": [
+      {
+        "file": "internal/provider/resource_mcp_toolset.go",
+        "line": 505
+      },
+      {
+        "file": "internal/provider/resource_mcp_toolset.go",
+        "line": 532
+      },
+      {
+        "file": "internal/provider/resource_mcp_toolset.go",
+        "line": 559
       }
     ]
   },

--- a/internal/provider/mcp_toolset_assignment_protocol_test.go
+++ b/internal/provider/mcp_toolset_assignment_protocol_test.go
@@ -1,0 +1,683 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"sort"
+	"sync"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// mcpToolsetAssignmentProtocolServer simulates the LiteLLM team surface with
+// an API-side object_permission that always carries an unmanaged mcp_servers
+// sibling, so every step proves the provider neither clobbers nor adopts it.
+type mcpToolsetAssignmentProtocolServer struct {
+	mu             sync.Mutex
+	remoteToolsets []interface{}
+	remoteAlias    string
+	mutations      []map[string]interface{}
+	malformedInfo  bool
+	divergentInfo  []interface{}
+}
+
+func (s *mcpToolsetAssignmentProtocolServer) handler(t *testing.T) http.HandlerFunc {
+	return func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		switch request.URL.Path {
+		case "/team/new", "/team/update":
+			var body map[string]interface{}
+			if err := json.NewDecoder(request.Body).Decode(&body); err != nil {
+				http.Error(writer, "bad request", http.StatusBadRequest)
+				return
+			}
+			s.mu.Lock()
+			permission, present := body["object_permission"].(map[string]interface{})
+			if present {
+				if _, fabricated := permission["mcp_servers"]; fabricated {
+					t.Errorf("mutation fabricated the unmanaged mcp_servers sibling: %#v", permission)
+				}
+				if toolsets, ok := permission["mcp_toolsets"].([]interface{}); ok {
+					s.remoteToolsets = toolsets
+				}
+			}
+			if alias, ok := body["team_alias"].(string); ok && alias != "" {
+				s.remoteAlias = alias
+			}
+			if _, tracked := body["object_permission"]; tracked {
+				s.mutations = append(s.mutations, permission)
+			} else {
+				s.mutations = append(s.mutations, nil)
+			}
+			s.mu.Unlock()
+			_ = json.NewEncoder(writer).Encode(map[string]interface{}{"team_id": "team-toolsets"})
+		case "/team/info":
+			s.mu.Lock()
+			toolsets := make([]interface{}, len(s.remoteToolsets))
+			copy(toolsets, s.remoteToolsets)
+			if s.divergentInfo != nil {
+				toolsets = append([]interface{}{}, s.divergentInfo...)
+			}
+			alias := s.remoteAlias
+			if alias == "" {
+				alias = "toolsets"
+			}
+			malformed := s.malformedInfo
+			s.mu.Unlock()
+			if malformed {
+				_, _ = writer.Write([]byte(`not json`))
+				return
+			}
+			_ = json.NewEncoder(writer).Encode(map[string]interface{}{
+				"team_id":          "team-toolsets",
+				"keys":             []interface{}{},
+				"team_memberships": []interface{}{},
+				"team_info": map[string]interface{}{
+					"team_id": "team-toolsets", "team_alias": alias,
+					"models": []interface{}{}, "access_group_ids": []interface{}{}, "blocked": false,
+					"metadata":                 map[string]interface{}{},
+					"litellm_model_table":      map[string]interface{}{"model_aliases": map[string]interface{}{}},
+					"team_member_budget_table": nil,
+					"object_permission": map[string]interface{}{
+						"object_permission_id": "permission-id",
+						"mcp_servers":          []interface{}{"external-server"},
+						"mcp_toolsets":         toolsets,
+					},
+				},
+			})
+		case "/team/permissions_list":
+			_ = json.NewEncoder(writer).Encode(map[string]interface{}{"team_id": request.URL.Query().Get("team_id"), "team_member_permissions": []interface{}{}})
+		default:
+			http.NotFound(writer, request)
+		}
+	}
+}
+
+func (s *mcpToolsetAssignmentProtocolServer) lastMutationToolsets(t *testing.T) (interface{}, bool) {
+	t.Helper()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.mutations) == 0 {
+		t.Fatal("no mutations recorded")
+	}
+	permission := s.mutations[len(s.mutations)-1]
+	if permission == nil {
+		return nil, false
+	}
+	return permission["mcp_toolsets"], true
+}
+
+func mcpToolsetAssignmentSetValue(elements ...string) []tftypes.Value {
+	values := make([]tftypes.Value, 0, len(elements))
+	for _, element := range elements {
+		values = append(values, tftypes.NewValue(tftypes.String, element))
+	}
+	return values
+}
+
+func mcpToolsetAssignmentStateSet(t *testing.T, value tftypes.Value) []string {
+	t.Helper()
+	if value.IsNull() {
+		return nil
+	}
+	var elements []tftypes.Value
+	if err := value.As(&elements); err != nil {
+		t.Fatal(err)
+	}
+	out := make([]string, 0, len(elements))
+	for _, element := range elements {
+		var text string
+		if err := element.As(&text); err != nil {
+			t.Fatal(err)
+		}
+		out = append(out, text)
+	}
+	return out
+}
+
+func TestTeamProtocolMCPToolsetAssignmentLifecycle(t *testing.T) {
+	ctx := context.Background()
+	backend := &mcpToolsetAssignmentProtocolServer{remoteToolsets: []interface{}{}}
+	server := httptest.NewServer(backend.handler(t))
+	defer server.Close()
+
+	protocolServer, schemas := configuredImportProtocolServer(t, ctx, server.URL)
+	const typeName = "litellm_team"
+	schema := schemas.ResourceSchemas[typeName]
+	computed := map[string]interface{}{
+		"id": tftypes.UnknownValue, "access_group_ids": tftypes.UnknownValue, "metadata": tftypes.UnknownValue,
+		"models": tftypes.UnknownValue, "model_aliases": tftypes.UnknownValue, "model_rpm_limit": tftypes.UnknownValue,
+		"model_tpm_limit": tftypes.UnknownValue, "tags": tftypes.UnknownValue, "guardrails": tftypes.UnknownValue,
+		"prompts": tftypes.UnknownValue, "blocked": tftypes.UnknownValue,
+	}
+	baseConfig := func(toolsets interface{}) map[string]interface{} {
+		values := map[string]interface{}{"team_id": "team-toolsets", "team_alias": "toolsets"}
+		if toolsets != nil {
+			values["mcp_toolset_ids"] = toolsets
+		}
+		return values
+	}
+	apply := func(configValues map[string]interface{}, prior *tfprotov6.DynamicValue, priorPrivate []byte, proposed *tfprotov6.DynamicValue) *tfprotov6.ApplyResourceChangeResponse {
+		t.Helper()
+		config := accessGroupProtocolDynamicValue(t, schema, organizationProjectProtocolValue(t, schema, configValues))
+		planned, err := protocolServer.PlanResourceChange(ctx, &tfprotov6.PlanResourceChangeRequest{TypeName: typeName, Config: config, PriorState: prior, ProposedNewState: proposed, PriorPrivate: priorPrivate})
+		if err != nil || accessGroupProtocolDiagnosticsHaveError(planned.Diagnostics) {
+			t.Fatalf("plan err=%v diagnostics=%s", err, agentProtocolDiagnosticsText(planned.Diagnostics))
+		}
+		applied, err := protocolServer.ApplyResourceChange(ctx, &tfprotov6.ApplyResourceChangeRequest{TypeName: typeName, Config: config, PriorState: prior, PlannedState: planned.PlannedState, PlannedPrivate: planned.PlannedPrivate})
+		if err != nil || accessGroupProtocolDiagnosticsHaveError(applied.Diagnostics) {
+			t.Fatalf("apply err=%v diagnostics=%s", err, agentProtocolDiagnosticsText(applied.Diagnostics))
+		}
+		return applied
+	}
+
+	// Create with a nonempty assignment: the request carries the sorted
+	// complete membership, LiteLLM's nonempty team list is the key ceiling.
+	createValues := baseConfig(mcpToolsetAssignmentSetValue("toolset-b", "toolset-a"))
+	proposedValues := map[string]interface{}{}
+	for key, value := range createValues {
+		proposedValues[key] = value
+	}
+	for key, value := range computed {
+		proposedValues[key] = value
+	}
+	nullState := accessGroupProtocolDynamicValue(t, schema, tftypes.NewValue(schema.ValueType(), nil))
+	created := apply(createValues, nullState, nil, accessGroupProtocolDynamicValue(t, schema, organizationProjectProtocolValue(t, schema, proposedValues)))
+	if sent, present := backend.lastMutationToolsets(t); !present || !reflect.DeepEqual(sent, []interface{}{"toolset-a", "toolset-b"}) {
+		t.Fatalf("create mutation toolsets = %#v present=%v, want sorted complete membership", sent, present)
+	}
+	if got := mcpToolsetAssignmentStateSet(t, protocolAttributeMap(t, schema, created.NewState)["mcp_toolset_ids"]); !reflect.DeepEqual(got, []string{"toolset-a", "toolset-b"}) {
+		t.Fatalf("created assignment state = %#v", got)
+	}
+
+	// Configured -> empty: the request pins an explicit empty list, which
+	// removes the team ceiling in LiteLLM rather than denying all toolsets.
+	emptied := apply(baseConfig(mcpToolsetAssignmentSetValue()), created.NewState, created.Private,
+		organizationProjectProtocolReplace(t, schema, created.NewState, map[string]interface{}{"mcp_toolset_ids": []tftypes.Value{}}))
+	if sent, present := backend.lastMutationToolsets(t); !present || !reflect.DeepEqual(sent, []interface{}{}) {
+		t.Fatalf("clear mutation toolsets = %#v present=%v, want explicit empty list", sent, present)
+	}
+	if got := mcpToolsetAssignmentStateSet(t, protocolAttributeMap(t, schema, emptied.NewState)["mcp_toolset_ids"]); !reflect.DeepEqual(got, []string{}) {
+		t.Fatalf("cleared assignment state = %#v", got)
+	}
+
+	// Omission releases ownership: the mutation carries no object_permission
+	// and the state returns to null without adopting the remote value.
+	released := apply(baseConfig(nil), emptied.NewState, emptied.Private,
+		organizationProjectProtocolReplace(t, schema, emptied.NewState, map[string]interface{}{"mcp_toolset_ids": nil}))
+	if _, present := backend.lastMutationToolsets(t); present {
+		t.Fatal("ownership release still sent object_permission")
+	}
+	if got := protocolAttributeMap(t, schema, released.NewState)["mcp_toolset_ids"]; !got.IsNull() {
+		t.Fatalf("released assignment state = %s, want null", got)
+	}
+
+	// Re-manage one toolset, then simulate LiteLLM dropping the assignment
+	// after the toolset row was deleted externally: the managed read adopts
+	// the remote membership so the next plan repairs the drift.
+	managed := apply(baseConfig(mcpToolsetAssignmentSetValue("toolset-a")), released.NewState, released.Private,
+		organizationProjectProtocolReplace(t, schema, released.NewState, map[string]interface{}{"mcp_toolset_ids": mcpToolsetAssignmentSetValue("toolset-a")}))
+	backend.mu.Lock()
+	backend.remoteToolsets = []interface{}{}
+	backend.mu.Unlock()
+	refreshed, err := protocolServer.ReadResource(ctx, &tfprotov6.ReadResourceRequest{TypeName: typeName, CurrentState: managed.NewState, Private: managed.Private})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(refreshed.Diagnostics) {
+		t.Fatalf("read err=%v diagnostics=%s", err, agentProtocolDiagnosticsText(refreshed.Diagnostics))
+	}
+	if got := mcpToolsetAssignmentStateSet(t, protocolAttributeMap(t, schema, refreshed.NewState)["mcp_toolset_ids"]); !reflect.DeepEqual(got, []string{}) {
+		t.Fatalf("stale assignment read = %#v, want emptied remote membership", got)
+	}
+	repairConfig := accessGroupProtocolDynamicValue(t, schema, organizationProjectProtocolValue(t, schema, baseConfig(mcpToolsetAssignmentSetValue("toolset-a"))))
+	repairPlan, err := protocolServer.PlanResourceChange(ctx, &tfprotov6.PlanResourceChangeRequest{TypeName: typeName, Config: repairConfig, PriorState: refreshed.NewState, ProposedNewState: organizationProjectProtocolReplace(t, schema, refreshed.NewState, map[string]interface{}{"mcp_toolset_ids": mcpToolsetAssignmentSetValue("toolset-a")}), PriorPrivate: refreshed.Private})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(repairPlan.Diagnostics) {
+		t.Fatalf("repair plan err=%v diagnostics=%s", err, agentProtocolDiagnosticsText(repairPlan.Diagnostics))
+	}
+	if action := organizationProjectProtocolPlannedAction(t, schema, refreshed.NewState, repairPlan); action != organizationProjectProtocolActionUpdate {
+		t.Fatalf("repair plan action = %s, want Update", action)
+	}
+}
+
+func TestTeamProtocolMCPToolsetAssignmentMalformedReadRetainsPriorState(t *testing.T) {
+	ctx := context.Background()
+	backend := &mcpToolsetAssignmentProtocolServer{remoteToolsets: []interface{}{"toolset-a"}}
+	server := httptest.NewServer(backend.handler(t))
+	defer server.Close()
+
+	protocolServer, schemas := configuredImportProtocolServer(t, ctx, server.URL)
+	const typeName = "litellm_team"
+	schema := schemas.ResourceSchemas[typeName]
+
+	imported, err := protocolServer.ImportResourceState(ctx, &tfprotov6.ImportResourceStateRequest{TypeName: typeName, ID: "team-toolsets"})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(imported.Diagnostics) || len(imported.ImportedResources) != 1 {
+		t.Fatalf("import err=%v diagnostics=%s", err, agentProtocolDiagnosticsText(imported.Diagnostics))
+	}
+	importRead, err := protocolServer.ReadResource(ctx, &tfprotov6.ReadResourceRequest{TypeName: typeName, CurrentState: imported.ImportedResources[0].State, Private: imported.ImportedResources[0].Private})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(importRead.Diagnostics) {
+		t.Fatalf("import read err=%v diagnostics=%s", err, agentProtocolDiagnosticsText(importRead.Diagnostics))
+	}
+	if got := mcpToolsetAssignmentStateSet(t, protocolAttributeMap(t, schema, importRead.NewState)["mcp_toolset_ids"]); !reflect.DeepEqual(got, []string{"toolset-a"}) {
+		t.Fatalf("imported assignment = %#v, want adopted remote membership", got)
+	}
+
+	// A malformed transactional read after an accepted mutation must retain
+	// the prior public state instead of publishing the requested values.
+	backend.mu.Lock()
+	backend.malformedInfo = true
+	backend.mu.Unlock()
+	config := accessGroupProtocolDynamicValue(t, schema, organizationProjectProtocolValue(t, schema, map[string]interface{}{"team_id": "team-toolsets", "team_alias": "toolsets", "mcp_toolset_ids": mcpToolsetAssignmentSetValue("toolset-b")}))
+	proposed := organizationProjectProtocolReplace(t, schema, importRead.NewState, map[string]interface{}{"mcp_toolset_ids": mcpToolsetAssignmentSetValue("toolset-b")})
+	planned, err := protocolServer.PlanResourceChange(ctx, &tfprotov6.PlanResourceChangeRequest{TypeName: typeName, Config: config, PriorState: importRead.NewState, ProposedNewState: proposed, PriorPrivate: importRead.Private})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(planned.Diagnostics) {
+		t.Fatalf("plan err=%v diagnostics=%s", err, agentProtocolDiagnosticsText(planned.Diagnostics))
+	}
+	failed, err := protocolServer.ApplyResourceChange(ctx, &tfprotov6.ApplyResourceChangeRequest{TypeName: typeName, Config: config, PriorState: importRead.NewState, PlannedState: planned.PlannedState, PlannedPrivate: planned.PlannedPrivate})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !accessGroupProtocolDiagnosticsHaveError(failed.Diagnostics) {
+		t.Fatal("malformed transactional read did not error")
+	}
+	priorValue, _ := importRead.NewState.Unmarshal(schema.ValueType())
+	failedValue, _ := failed.NewState.Unmarshal(schema.ValueType())
+	if !priorValue.Equal(failedValue) {
+		t.Fatalf("malformed read published requested state\nprior: %s\n  got: %s", priorValue, failedValue)
+	}
+}
+
+// mcpToolsetKeyAssignmentProtocolServer simulates the LiteLLM key surface with
+// an API-side object_permission that always carries an unmanaged mcp_servers
+// sibling, so every step proves the provider neither clobbers nor adopts it.
+type mcpToolsetKeyAssignmentProtocolServer struct {
+	mu             sync.Mutex
+	remoteToolsets []interface{}
+	mutations      []map[string]interface{}
+	malformedInfo  bool
+	divergentInfo  []interface{}
+}
+
+func (s *mcpToolsetKeyAssignmentProtocolServer) handler(t *testing.T) http.HandlerFunc {
+	return func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		switch request.URL.Path {
+		case "/key/generate", "/key/update":
+			var body map[string]interface{}
+			if err := json.NewDecoder(request.Body).Decode(&body); err != nil {
+				http.Error(writer, "bad request", http.StatusBadRequest)
+				return
+			}
+			s.mu.Lock()
+			permission, present := body["object_permission"].(map[string]interface{})
+			if present {
+				if _, fabricated := permission["mcp_servers"]; fabricated {
+					t.Errorf("mutation fabricated the unmanaged mcp_servers sibling: %#v", permission)
+				}
+				if toolsets, ok := permission["mcp_toolsets"].([]interface{}); ok {
+					s.remoteToolsets = toolsets
+				}
+			}
+			if _, tracked := body["object_permission"]; tracked {
+				s.mutations = append(s.mutations, permission)
+			} else {
+				s.mutations = append(s.mutations, nil)
+			}
+			s.mu.Unlock()
+			_ = json.NewEncoder(writer).Encode(map[string]interface{}{"key": "sk-key-toolsets"})
+		case "/key/info":
+			s.mu.Lock()
+			toolsets := make([]interface{}, len(s.remoteToolsets))
+			copy(toolsets, s.remoteToolsets)
+			if s.divergentInfo != nil {
+				toolsets = append([]interface{}{}, s.divergentInfo...)
+			}
+			malformed := s.malformedInfo
+			s.mu.Unlock()
+			if malformed {
+				_, _ = writer.Write([]byte(`not json`))
+				return
+			}
+			_ = json.NewEncoder(writer).Encode(map[string]interface{}{
+				"key": "sk-key-toolsets",
+				"info": map[string]interface{}{
+					"metadata": map[string]interface{}{}, "config": map[string]interface{}{}, "permissions": map[string]interface{}{},
+					"object_permission": map[string]interface{}{
+						"object_permission_id": "permission-id",
+						"mcp_servers":          []interface{}{"external-server"},
+						"mcp_toolsets":         toolsets,
+					},
+				},
+			})
+		default:
+			http.NotFound(writer, request)
+		}
+	}
+}
+
+func (s *mcpToolsetKeyAssignmentProtocolServer) lastMutationToolsets(t *testing.T) (interface{}, bool) {
+	t.Helper()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.mutations) == 0 {
+		t.Fatal("no mutations recorded")
+	}
+	permission := s.mutations[len(s.mutations)-1]
+	if permission == nil {
+		return nil, false
+	}
+	return permission["mcp_toolsets"], true
+}
+
+// mcpToolsetKeyAssignmentCreate applies a healthy create carrying the given
+// assignment and returns the applied response for follow-up steps.
+func mcpToolsetKeyAssignmentCreate(t *testing.T, ctx context.Context, protocolServer tfprotov6.ProviderServer, schema *tfprotov6.Schema, toolsets []tftypes.Value) *tfprotov6.ApplyResourceChangeResponse {
+	t.Helper()
+	const typeName = "litellm_key"
+	values := map[string]interface{}{"key": "sk-key-toolsets", "mcp_toolset_ids": toolsets}
+	config := accessGroupProtocolDynamicValue(t, schema, organizationProjectProtocolValue(t, schema, values))
+	nullState := accessGroupProtocolDynamicValue(t, schema, tftypes.NewValue(schema.ValueType(), nil))
+	planned, err := protocolServer.PlanResourceChange(ctx, &tfprotov6.PlanResourceChangeRequest{
+		TypeName: typeName, Config: config, PriorState: nullState, ProposedNewState: keySemanticCreateProposed(t, schema, values),
+	})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(planned.Diagnostics) {
+		t.Fatalf("create plan err=%v diagnostics=%s", err, agentProtocolDiagnosticsText(planned.Diagnostics))
+	}
+	applied, err := protocolServer.ApplyResourceChange(ctx, &tfprotov6.ApplyResourceChangeRequest{
+		TypeName: typeName, Config: config, PriorState: nullState, PlannedState: planned.PlannedState, PlannedPrivate: planned.PlannedPrivate,
+	})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(applied.Diagnostics) {
+		t.Fatalf("create apply err=%v diagnostics=%s", err, agentProtocolDiagnosticsText(applied.Diagnostics))
+	}
+	return applied
+}
+
+// Assignment-only key plans must survive ModifyPlan: an update, an explicit
+// [] clear, and an omission-based ownership release each produce a plan that
+// differs from prior state instead of being replaced by it.
+func TestKeyProtocolMCPToolsetAssignmentPlansAreNotSuppressed(t *testing.T) {
+	ctx := context.Background()
+	backend := &mcpToolsetKeyAssignmentProtocolServer{remoteToolsets: []interface{}{}}
+	server := httptest.NewServer(backend.handler(t))
+	defer server.Close()
+
+	protocolServer, schemas := configuredImportProtocolServer(t, ctx, server.URL)
+	const typeName = "litellm_key"
+	schema := schemas.ResourceSchemas[typeName]
+	created := mcpToolsetKeyAssignmentCreate(t, ctx, protocolServer, schema, mcpToolsetAssignmentSetValue("toolset-a", "toolset-b"))
+
+	plan := func(configValues map[string]interface{}, replacement map[string]interface{}) *tfprotov6.PlanResourceChangeResponse {
+		t.Helper()
+		config := accessGroupProtocolDynamicValue(t, schema, organizationProjectProtocolValue(t, schema, configValues))
+		planned, err := protocolServer.PlanResourceChange(ctx, &tfprotov6.PlanResourceChangeRequest{
+			TypeName: typeName, Config: config, PriorState: created.NewState,
+			ProposedNewState: organizationProjectProtocolReplace(t, schema, created.NewState, replacement),
+			PriorPrivate:     created.Private,
+		})
+		if err != nil || accessGroupProtocolDiagnosticsHaveError(planned.Diagnostics) {
+			t.Fatalf("plan err=%v diagnostics=%s", err, agentProtocolDiagnosticsText(planned.Diagnostics))
+		}
+		return planned
+	}
+
+	updated := plan(map[string]interface{}{"key": "sk-key-toolsets", "mcp_toolset_ids": mcpToolsetAssignmentSetValue("toolset-b")},
+		map[string]interface{}{"mcp_toolset_ids": mcpToolsetAssignmentSetValue("toolset-b")})
+	if got := mcpToolsetAssignmentStateSet(t, protocolAttributeMap(t, schema, updated.PlannedState)["mcp_toolset_ids"]); !reflect.DeepEqual(got, []string{"toolset-b"}) {
+		t.Fatalf("assignment-only update plan = %#v, want [toolset-b]", got)
+	}
+
+	cleared := plan(map[string]interface{}{"key": "sk-key-toolsets", "mcp_toolset_ids": mcpToolsetAssignmentSetValue()},
+		map[string]interface{}{"mcp_toolset_ids": []tftypes.Value{}})
+	if got := mcpToolsetAssignmentStateSet(t, protocolAttributeMap(t, schema, cleared.PlannedState)["mcp_toolset_ids"]); got == nil || len(got) != 0 {
+		t.Fatalf("assignment clear plan = %#v, want []", got)
+	}
+
+	released := plan(map[string]interface{}{"key": "sk-key-toolsets"},
+		map[string]interface{}{"mcp_toolset_ids": nil})
+	if got := protocolAttributeMap(t, schema, released.PlannedState)["mcp_toolset_ids"]; !got.IsNull() {
+		t.Fatalf("omission release plan = %s, want null", got)
+	}
+
+	// Composition: an assignment change planned together with a semantic
+	// dictionary change keeps both surfaces in the planned state.
+	composed := plan(map[string]interface{}{"key": "sk-key-toolsets", "metadata_json": `{"tier":"gold"}`, "mcp_toolset_ids": mcpToolsetAssignmentSetValue("toolset-b")},
+		map[string]interface{}{"metadata_json": "{\"tier\":\"gold\"}", "mcp_toolset_ids": mcpToolsetAssignmentSetValue("toolset-b")})
+	attributes := protocolAttributeMap(t, schema, composed.PlannedState)
+	if got := mcpToolsetAssignmentStateSet(t, attributes["mcp_toolset_ids"]); !reflect.DeepEqual(got, []string{"toolset-b"}) {
+		t.Fatalf("composed plan assignment = %#v, want [toolset-b]", got)
+	}
+	var metadataJSON string
+	if err := attributes["metadata_json"].As(&metadataJSON); err != nil || metadataJSON != `{"tier":"gold"}` {
+		t.Fatalf("composed plan metadata_json = %q err=%v", metadataJSON, err)
+	}
+}
+
+// Importing a key adopts the remote assignment membership exactly.
+func TestKeyProtocolMCPToolsetAssignmentImportAdoptsRemoteMembership(t *testing.T) {
+	ctx := context.Background()
+	backend := &mcpToolsetKeyAssignmentProtocolServer{remoteToolsets: []interface{}{"toolset-b", "toolset-a"}}
+	server := httptest.NewServer(backend.handler(t))
+	defer server.Close()
+
+	protocolServer, schemas := configuredImportProtocolServer(t, ctx, server.URL)
+	const typeName = "litellm_key"
+	schema := schemas.ResourceSchemas[typeName]
+	imported, err := protocolServer.ImportResourceState(ctx, &tfprotov6.ImportResourceStateRequest{TypeName: typeName, ID: "sk-key-toolsets"})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(imported.Diagnostics) || len(imported.ImportedResources) != 1 {
+		t.Fatalf("import err=%v diagnostics=%s", err, agentProtocolDiagnosticsText(imported.Diagnostics))
+	}
+	importRead, err := protocolServer.ReadResource(ctx, &tfprotov6.ReadResourceRequest{TypeName: typeName, CurrentState: imported.ImportedResources[0].State, Private: imported.ImportedResources[0].Private})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(importRead.Diagnostics) {
+		t.Fatalf("import read err=%v diagnostics=%s", err, agentProtocolDiagnosticsText(importRead.Diagnostics))
+	}
+	got := mcpToolsetAssignmentStateSet(t, protocolAttributeMap(t, schema, importRead.NewState)["mcp_toolset_ids"])
+	sort.Strings(got)
+	if !reflect.DeepEqual(got, []string{"toolset-a", "toolset-b"}) {
+		t.Fatalf("imported assignment = %#v, want adopted remote membership", got)
+	}
+}
+
+// A key assignment mutation is transactional: an accepted update whose
+// authoritative readback fails or diverges retains prior state and errors
+// instead of publishing unconfirmed assignments.
+func TestKeyProtocolMCPToolsetAssignmentUnconfirmedUpdateRetainsPriorState(t *testing.T) {
+	ctx := context.Background()
+	backend := &mcpToolsetKeyAssignmentProtocolServer{remoteToolsets: []interface{}{}}
+	server := httptest.NewServer(backend.handler(t))
+	defer server.Close()
+
+	protocolServer, schemas := configuredImportProtocolServer(t, ctx, server.URL)
+	const typeName = "litellm_key"
+	schema := schemas.ResourceSchemas[typeName]
+	created := mcpToolsetKeyAssignmentCreate(t, ctx, protocolServer, schema, mcpToolsetAssignmentSetValue("toolset-a"))
+
+	applyUpdate := func() *tfprotov6.ApplyResourceChangeResponse {
+		t.Helper()
+		config := accessGroupProtocolDynamicValue(t, schema, organizationProjectProtocolValue(t, schema, map[string]interface{}{"key": "sk-key-toolsets", "mcp_toolset_ids": mcpToolsetAssignmentSetValue("toolset-b")}))
+		proposed := organizationProjectProtocolReplace(t, schema, created.NewState, map[string]interface{}{"mcp_toolset_ids": mcpToolsetAssignmentSetValue("toolset-b")})
+		planned, err := protocolServer.PlanResourceChange(ctx, &tfprotov6.PlanResourceChangeRequest{TypeName: typeName, Config: config, PriorState: created.NewState, ProposedNewState: proposed, PriorPrivate: created.Private})
+		if err != nil || accessGroupProtocolDiagnosticsHaveError(planned.Diagnostics) {
+			t.Fatalf("plan err=%v diagnostics=%s", err, agentProtocolDiagnosticsText(planned.Diagnostics))
+		}
+		applied, err := protocolServer.ApplyResourceChange(ctx, &tfprotov6.ApplyResourceChangeRequest{TypeName: typeName, Config: config, PriorState: created.NewState, PlannedState: planned.PlannedState, PlannedPrivate: planned.PlannedPrivate})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return applied
+	}
+	assertRetained := func(step string, applied *tfprotov6.ApplyResourceChangeResponse) {
+		t.Helper()
+		if !accessGroupProtocolDiagnosticsHaveError(applied.Diagnostics) {
+			t.Fatalf("%s: unconfirmed assignment mutation did not error", step)
+		}
+		priorValue, _ := created.NewState.Unmarshal(schema.ValueType())
+		failedValue, _ := applied.NewState.Unmarshal(schema.ValueType())
+		if !priorValue.Equal(failedValue) {
+			t.Fatalf("%s published unconfirmed state\nprior: %s\n  got: %s", step, priorValue, failedValue)
+		}
+	}
+
+	backend.mu.Lock()
+	backend.malformedInfo = true
+	backend.mu.Unlock()
+	assertRetained("malformed readback", applyUpdate())
+
+	backend.mu.Lock()
+	backend.malformedInfo = false
+	backend.divergentInfo = []interface{}{"toolset-x"}
+	backend.mu.Unlock()
+	assertRetained("divergent readback", applyUpdate())
+}
+
+// A team assignment mutation whose accepted readback reports a different
+// membership must retain prior state instead of publishing either value.
+func TestTeamProtocolMCPToolsetAssignmentDivergentReadbackRetainsPriorState(t *testing.T) {
+	ctx := context.Background()
+	backend := &mcpToolsetAssignmentProtocolServer{remoteToolsets: []interface{}{"toolset-a"}}
+	server := httptest.NewServer(backend.handler(t))
+	defer server.Close()
+
+	protocolServer, schemas := configuredImportProtocolServer(t, ctx, server.URL)
+	const typeName = "litellm_team"
+	schema := schemas.ResourceSchemas[typeName]
+
+	imported, err := protocolServer.ImportResourceState(ctx, &tfprotov6.ImportResourceStateRequest{TypeName: typeName, ID: "team-toolsets"})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(imported.Diagnostics) || len(imported.ImportedResources) != 1 {
+		t.Fatalf("import err=%v diagnostics=%s", err, agentProtocolDiagnosticsText(imported.Diagnostics))
+	}
+	importRead, err := protocolServer.ReadResource(ctx, &tfprotov6.ReadResourceRequest{TypeName: typeName, CurrentState: imported.ImportedResources[0].State, Private: imported.ImportedResources[0].Private})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(importRead.Diagnostics) {
+		t.Fatalf("import read err=%v diagnostics=%s", err, agentProtocolDiagnosticsText(importRead.Diagnostics))
+	}
+
+	backend.mu.Lock()
+	backend.divergentInfo = []interface{}{"toolset-x"}
+	backend.mu.Unlock()
+	config := accessGroupProtocolDynamicValue(t, schema, organizationProjectProtocolValue(t, schema, map[string]interface{}{"team_id": "team-toolsets", "team_alias": "toolsets", "mcp_toolset_ids": mcpToolsetAssignmentSetValue("toolset-b")}))
+	proposed := organizationProjectProtocolReplace(t, schema, importRead.NewState, map[string]interface{}{"mcp_toolset_ids": mcpToolsetAssignmentSetValue("toolset-b")})
+	planned, err := protocolServer.PlanResourceChange(ctx, &tfprotov6.PlanResourceChangeRequest{TypeName: typeName, Config: config, PriorState: importRead.NewState, ProposedNewState: proposed, PriorPrivate: importRead.Private})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(planned.Diagnostics) {
+		t.Fatalf("plan err=%v diagnostics=%s", err, agentProtocolDiagnosticsText(planned.Diagnostics))
+	}
+	failed, err := protocolServer.ApplyResourceChange(ctx, &tfprotov6.ApplyResourceChangeRequest{TypeName: typeName, Config: config, PriorState: importRead.NewState, PlannedState: planned.PlannedState, PlannedPrivate: planned.PlannedPrivate})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !accessGroupProtocolDiagnosticsHaveError(failed.Diagnostics) {
+		t.Fatal("divergent readback did not error")
+	}
+	priorValue, _ := importRead.NewState.Unmarshal(schema.ValueType())
+	failedValue, _ := failed.NewState.Unmarshal(schema.ValueType())
+	if !priorValue.Equal(failedValue) {
+		t.Fatalf("divergent readback published state\nprior: %s\n  got: %s", priorValue, failedValue)
+	}
+}
+
+// Adding mcp_toolset_ids to the key and team schemas requires a version bump
+// and direct upgraders from every historical version: upgraded states carry a
+// null (unmanaged) assignment and preserve the other attributes exactly.
+func TestMCPToolsetAssignmentSchemaUpgrades(t *testing.T) {
+	ctx := context.Background()
+	server := httptest.NewServer(http.NotFoundHandler())
+	defer server.Close()
+	protocolServer, schemas := configuredImportProtocolServer(t, ctx, server.URL)
+
+	keySchema := schemas.ResourceSchemas["litellm_key"]
+	if keySchema.Version != 3 {
+		t.Fatalf("litellm_key schema version = %d, want 3 after adding mcp_toolset_ids", keySchema.Version)
+	}
+	teamSchema := schemas.ResourceSchemas["litellm_team"]
+	if teamSchema.Version != 2 {
+		t.Fatalf("litellm_team schema version = %d, want 2 after adding mcp_toolset_ids", teamSchema.Version)
+	}
+
+	for _, test := range []struct {
+		typeName string
+		version  int64
+		raw      map[string]interface{}
+		wantJSON map[string]string
+	}{
+		{"litellm_key", 0, map[string]interface{}{"id": "sk-upgrade-v0", "key": "sk-preserved"}, map[string]string{"metadata_json": ""}},
+		{"litellm_key", 1, map[string]interface{}{"id": hashKeyForID("sk-upgrade-v1"), "key": "sk-preserved"}, map[string]string{"metadata_json": ""}},
+		{"litellm_key", 2, map[string]interface{}{"id": hashKeyForID("sk-upgrade-v2"), "key": "sk-preserved", "metadata_json": `{"tier":"gold"}`}, map[string]string{"metadata_json": `{"tier":"gold"}`}},
+		{"litellm_team", 0, map[string]interface{}{"id": "team-upgrade", "team_id": "team-upgrade", "team_alias": "upgrade", "metadata_json": `{"tier":"gold"}`}, map[string]string{"metadata_json": ""}},
+		{"litellm_team", 1, map[string]interface{}{"id": "team-upgrade", "team_id": "team-upgrade", "team_alias": "upgrade", "metadata_json": `{"tier":"gold"}`}, map[string]string{"metadata_json": `{"tier":"gold"}`}},
+	} {
+		raw, err := json.Marshal(test.raw)
+		if err != nil {
+			t.Fatal(err)
+		}
+		upgraded, err := protocolServer.UpgradeResourceState(ctx, &tfprotov6.UpgradeResourceStateRequest{
+			TypeName: test.typeName, Version: test.version, RawState: &tfprotov6.RawState{JSON: raw},
+		})
+		if err != nil || accessGroupProtocolDiagnosticsHaveError(upgraded.Diagnostics) || upgraded.UpgradedState == nil {
+			t.Fatalf("%s v%d upgrade: err=%v diagnostics=%s", test.typeName, test.version, err, agentProtocolDiagnosticsText(upgraded.Diagnostics))
+		}
+		schema := schemas.ResourceSchemas[test.typeName]
+		attributes := protocolAttributeMap(t, schema, upgraded.UpgradedState)
+		if !attributes["mcp_toolset_ids"].IsNull() {
+			t.Fatalf("%s v%d upgraded mcp_toolset_ids = %s, want null (unmanaged)", test.typeName, test.version, attributes["mcp_toolset_ids"])
+		}
+		for name, want := range test.wantJSON {
+			if want == "" {
+				if !attributes[name].IsNull() {
+					t.Fatalf("%s v%d %s was adopted: %s", test.typeName, test.version, name, attributes[name])
+				}
+				continue
+			}
+			var got string
+			if err := attributes[name].As(&got); err != nil || got != want {
+				t.Fatalf("%s v%d %s = %q err=%v, want preserved %q", test.typeName, test.version, name, got, err, want)
+			}
+		}
+	}
+}
+
+// An update that changes another team field while the managed assignment is
+// unchanged still dispatched object_permission, so a divergent readback must
+// retain prior state instead of publishing the divergent access control.
+func TestTeamProtocolMCPToolsetAssignmentUnchangedDivergentReadbackRetainsPriorState(t *testing.T) {
+	ctx := context.Background()
+	backend := &mcpToolsetAssignmentProtocolServer{remoteToolsets: []interface{}{"toolset-a"}}
+	server := httptest.NewServer(backend.handler(t))
+	defer server.Close()
+
+	protocolServer, schemas := configuredImportProtocolServer(t, ctx, server.URL)
+	const typeName = "litellm_team"
+	schema := schemas.ResourceSchemas[typeName]
+
+	imported, err := protocolServer.ImportResourceState(ctx, &tfprotov6.ImportResourceStateRequest{TypeName: typeName, ID: "team-toolsets"})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(imported.Diagnostics) || len(imported.ImportedResources) != 1 {
+		t.Fatalf("import err=%v diagnostics=%s", err, agentProtocolDiagnosticsText(imported.Diagnostics))
+	}
+	importRead, err := protocolServer.ReadResource(ctx, &tfprotov6.ReadResourceRequest{TypeName: typeName, CurrentState: imported.ImportedResources[0].State, Private: imported.ImportedResources[0].Private})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(importRead.Diagnostics) {
+		t.Fatalf("import read err=%v diagnostics=%s", err, agentProtocolDiagnosticsText(importRead.Diagnostics))
+	}
+
+	// The alias changes; the managed assignment stays ["toolset-a"], but the
+	// readback reports an emptied membership.
+	backend.mu.Lock()
+	backend.divergentInfo = []interface{}{}
+	backend.mu.Unlock()
+	config := accessGroupProtocolDynamicValue(t, schema, organizationProjectProtocolValue(t, schema, map[string]interface{}{"team_id": "team-toolsets", "team_alias": "renamed", "mcp_toolset_ids": mcpToolsetAssignmentSetValue("toolset-a")}))
+	proposed := organizationProjectProtocolReplace(t, schema, importRead.NewState, map[string]interface{}{"team_alias": "renamed"})
+	planned, err := protocolServer.PlanResourceChange(ctx, &tfprotov6.PlanResourceChangeRequest{TypeName: typeName, Config: config, PriorState: importRead.NewState, ProposedNewState: proposed, PriorPrivate: importRead.Private})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(planned.Diagnostics) {
+		t.Fatalf("plan err=%v diagnostics=%s", err, agentProtocolDiagnosticsText(planned.Diagnostics))
+	}
+	failed, err := protocolServer.ApplyResourceChange(ctx, &tfprotov6.ApplyResourceChangeRequest{TypeName: typeName, Config: config, PriorState: importRead.NewState, PlannedState: planned.PlannedState, PlannedPrivate: planned.PlannedPrivate})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !accessGroupProtocolDiagnosticsHaveError(failed.Diagnostics) {
+		t.Fatal("unchanged-assignment divergent readback did not error")
+	}
+	priorValue, _ := importRead.NewState.Unmarshal(schema.ValueType())
+	failedValue, _ := failed.NewState.Unmarshal(schema.ValueType())
+	if !priorValue.Equal(failedValue) {
+		t.Fatalf("divergent readback published state\nprior: %s\n  got: %s", priorValue, failedValue)
+	}
+}

--- a/internal/provider/mcp_toolset_assignments.go
+++ b/internal/provider/mcp_toolset_assignments.go
@@ -1,0 +1,69 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// addMCPToolsetIDsToRequest merges configured MCP toolset IDs into the
+// request's object_permission map. A null set leaves the remote value
+// unmanaged; an empty set clears it explicitly.
+func addMCPToolsetIDsToRequest(ctx context.Context, request map[string]interface{}, toolsetIDs types.Set) diag.Diagnostics {
+	var diagnostics diag.Diagnostics
+	if toolsetIDs.IsNull() {
+		return diagnostics
+	}
+	if toolsetIDs.IsUnknown() {
+		diagnostics.AddAttributeError(path.Root("mcp_toolset_ids"), "Invalid MCP Toolset Assignment", "The mcp_toolset_ids value must be known before it can be sent to LiteLLM. No request was sent.")
+		return diagnostics
+	}
+
+	ids, _, conversionDiagnostics := strictTerraformStringSet(ctx, toolsetIDs, path.Root("mcp_toolset_ids"))
+	diagnostics.Append(conversionDiagnostics...)
+	if diagnostics.HasError() {
+		return diagnostics
+	}
+	sort.Strings(ids)
+
+	permission, present := request["object_permission"].(map[string]interface{})
+	if !present {
+		permission = map[string]interface{}{}
+		request["object_permission"] = permission
+	}
+	permission["mcp_toolsets"] = ids
+	return diagnostics
+}
+
+// readMCPToolsetIDs projects object_permission.mcp_toolsets from an API
+// container. When the attribute is unmanaged (null state) and the resource was
+// not imported, the prior value is retained so unconfigured remote toolsets do
+// not create drift.
+func readMCPToolsetIDs(ctx context.Context, container map[string]interface{}, current types.Set, imported bool) (types.Set, error) {
+	if !imported && current.IsNull() {
+		return current, nil
+	}
+
+	rawPermission, present := container["object_permission"]
+	if !present || rawPermission == nil {
+		return stringSetFromAPI(ctx, nil)
+	}
+	permission, ok := rawPermission.(map[string]interface{})
+	if !ok {
+		return types.SetNull(types.StringType), fmt.Errorf("object_permission must be an object, got %T", rawPermission)
+	}
+
+	rawIDs, present := permission["mcp_toolsets"]
+	if !present || rawIDs == nil {
+		return stringSetFromAPI(ctx, nil)
+	}
+	ids, err := stringSetFromAPI(ctx, rawIDs)
+	if err != nil {
+		return types.SetNull(types.StringType), fmt.Errorf("invalid object_permission.mcp_toolsets: %w", err)
+	}
+	return ids, nil
+}

--- a/internal/provider/mcp_toolset_assignments_test.go
+++ b/internal/provider/mcp_toolset_assignments_test.go
@@ -1,0 +1,281 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	resourceschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// validateSetAttribute runs every declared set validator against value and
+// returns the combined diagnostics.
+func validateSetAttribute(attribute resourceschema.SetAttribute, value types.Set) diag.Diagnostics {
+	var diagnostics diag.Diagnostics
+	request := validator.SetRequest{
+		Path:        path.Root("mcp_toolset_ids"),
+		ConfigValue: value,
+	}
+	for _, candidate := range attribute.SetValidators() {
+		var response validator.SetResponse
+		candidate.ValidateSet(context.Background(), request, &response)
+		diagnostics.Append(response.Diagnostics...)
+	}
+	return diagnostics
+}
+
+func TestMCPToolsetAssignmentSchemasAreOptionalSets(t *testing.T) {
+	t.Parallel()
+
+	resources := map[string]resource.Resource{
+		"key":  &KeyResource{},
+		"team": &TeamResource{},
+	}
+	for name, candidate := range resources {
+		name, candidate := name, candidate
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			var response resource.SchemaResponse
+			candidate.Schema(context.Background(), resource.SchemaRequest{}, &response)
+			attribute, ok := response.Schema.Attributes["mcp_toolset_ids"].(resourceschema.SetAttribute)
+			if !ok {
+				t.Fatalf("mcp_toolset_ids schema = %T, want schema.SetAttribute", response.Schema.Attributes["mcp_toolset_ids"])
+			}
+			if !attribute.Optional || attribute.Computed || attribute.ElementType != types.StringType {
+				t.Fatalf("mcp_toolset_ids schema = %#v, want optional-only set(string)", attribute)
+			}
+			if got := validateSetAttribute(attribute, types.SetValueMust(types.StringType, []attr.Value{types.StringValue("")})); !got.HasError() {
+				t.Fatalf("empty-string toolset ID passed validation, want rejection")
+			}
+			if got := validateSetAttribute(attribute, types.SetValueMust(types.StringType, []attr.Value{types.StringValue("toolset-a")})); got.HasError() {
+				t.Fatalf("valid toolset ID failed validation: %v", got.Errors())
+			}
+		})
+	}
+}
+
+func TestMCPToolsetAssignmentsUseObjectPermissionField(t *testing.T) {
+	t.Parallel()
+
+	configured := types.SetValueMust(types.StringType, []attr.Value{
+		types.StringValue("toolset-b"),
+		types.StringValue("toolset-a"),
+	})
+	empty := types.SetValueMust(types.StringType, []attr.Value{})
+	null := types.SetNull(types.StringType)
+
+	tests := map[string]struct {
+		build func(types.Set) (map[string]interface{}, error)
+	}{
+		"key": {
+			build: func(value types.Set) (map[string]interface{}, error) {
+				request, diagnostics := (&KeyResource{}).buildKeyRequest(context.Background(), &KeyResourceModel{MCPToolsetIDs: value})
+				if diagnostics.HasError() {
+					return nil, fmt.Errorf("build key request: %v", diagnostics.Errors())
+				}
+				return request, nil
+			},
+		},
+		"team": {
+			build: func(value types.Set) (map[string]interface{}, error) {
+				return (&TeamResource{}).buildTeamRequest(context.Background(), &TeamResourceModel{
+					TeamAlias: types.StringValue("team"), MCPToolsetIDs: value,
+				}, "team-id")
+			},
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			request, err := test.build(null)
+			if err != nil {
+				t.Fatalf("build null request: %v", err)
+			}
+			if _, present := request["object_permission"]; present {
+				t.Fatalf("unmanaged request contains object_permission: %#v", request)
+			}
+
+			request, err = test.build(configured)
+			if err != nil {
+				t.Fatalf("build configured request: %v", err)
+			}
+			permission, ok := request["object_permission"].(map[string]interface{})
+			if !ok {
+				t.Fatalf("object_permission = %T, want map", request["object_permission"])
+			}
+			if got := permission["mcp_toolsets"]; !reflect.DeepEqual(got, []string{"toolset-a", "toolset-b"}) {
+				t.Fatalf("mcp_toolsets = %#v, want sorted complete set", got)
+			}
+
+			request, err = test.build(empty)
+			if err != nil {
+				t.Fatalf("build empty request: %v", err)
+			}
+			permission = request["object_permission"].(map[string]interface{})
+			if got := permission["mcp_toolsets"]; !reflect.DeepEqual(got, []string{}) {
+				t.Fatalf("cleared mcp_toolsets = %#v, want explicit empty list", got)
+			}
+		})
+	}
+}
+
+func TestMCPToolsetAssignmentsReadOnlyWhenManagedOrImported(t *testing.T) {
+	t.Parallel()
+
+	remote := map[string]interface{}{
+		"object_permission_id": "permission-id",
+		"mcp_servers":          []interface{}{"server-that-must-not-be-adopted"},
+		"mcp_toolsets":         []interface{}{"toolset-b", "toolset-a"},
+	}
+
+	tests := map[string]struct {
+		read func(*httptest.Server, types.Set, bool) (types.Set, error)
+	}{
+		"key": {
+			read: func(server *httptest.Server, value types.Set, imported bool) (types.Set, error) {
+				data := KeyResourceModel{Key: types.StringValue("sk-test"), MCPToolsetIDs: value}
+				r := &KeyResource{client: &Client{APIBase: server.URL, APIKey: "admin", HTTPClient: server.Client()}}
+				err := r.readKeyWithNumericOwnership(context.Background(), &data, imported)
+				return data.MCPToolsetIDs, err
+			},
+		},
+		"team": {
+			read: func(server *httptest.Server, value types.Set, imported bool) (types.Set, error) {
+				data := TeamResourceModel{ID: types.StringValue("team-id"), MCPToolsetIDs: value}
+				r := &TeamResource{client: &Client{APIBase: server.URL, APIKey: "admin", HTTPClient: server.Client()}}
+				err := r.readTeamWithNumericOwnership(context.Background(), &data, imported)
+				return data.MCPToolsetIDs, err
+			},
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				writer.Header().Set("Content-Type", "application/json")
+				if request.URL.Path == "/team/permissions_list" {
+					_ = json.NewEncoder(writer).Encode(map[string]interface{}{
+						"team_id":                 request.URL.Query().Get("team_id"),
+						"team_member_permissions": []interface{}{},
+					})
+					return
+				}
+				switch name {
+				case "key":
+					_ = json.NewEncoder(writer).Encode(map[string]interface{}{"key": "sk-test", "info": map[string]interface{}{"token": "sk-test", "object_permission": remote}})
+				case "team":
+					_ = json.NewEncoder(writer).Encode(map[string]interface{}{
+						"team_id":          "team-id",
+						"keys":             []interface{}{},
+						"team_memberships": []interface{}{},
+						"team_info":        map[string]interface{}{"team_id": "team-id", "team_alias": "team", "access_group_ids": []interface{}{}, "object_permission": remote},
+					})
+				}
+			}))
+			defer server.Close()
+
+			unmanaged, err := test.read(server, types.SetNull(types.StringType), false)
+			if err != nil {
+				t.Fatalf("read unmanaged assignment: %v", err)
+			}
+			if !unmanaged.IsNull() {
+				t.Fatalf("unmanaged assignment was adopted: %#v", unmanaged)
+			}
+
+			managed, err := test.read(server, types.SetValueMust(types.StringType, []attr.Value{types.StringValue("old")}), false)
+			if err != nil {
+				t.Fatalf("read managed assignment: %v", err)
+			}
+			if !managed.Equal(types.SetValueMust(types.StringType, []attr.Value{types.StringValue("toolset-a"), types.StringValue("toolset-b")})) {
+				t.Fatalf("managed assignment = %#v, want remote membership", managed)
+			}
+
+			imported, err := test.read(server, types.SetNull(types.StringType), true)
+			if err != nil {
+				t.Fatalf("read imported assignment: %v", err)
+			}
+			if !imported.Equal(managed) {
+				t.Fatalf("imported assignment = %#v, want %#v", imported, managed)
+			}
+		})
+	}
+}
+
+// The key planner must treat assignment-only differences as real configuration
+// changes so ModifyPlan does not replace an assignment update, clear, or
+// omission-based ownership release with prior state.
+func TestKeyPlannerTreatsMCPToolsetIDsAsConfigurationChange(t *testing.T) {
+	t.Parallel()
+
+	assigned := types.SetValueMust(types.StringType, []attr.Value{types.StringValue("toolset-a")})
+	empty := types.SetValueMust(types.StringType, []attr.Value{})
+
+	var config, state KeyResourceModel
+	config.MCPToolsetIDs = types.SetNull(types.StringType)
+	state.MCPToolsetIDs = types.SetNull(types.StringType)
+	if keyHasNonSemanticConfigurationChange(config, state) {
+		t.Fatal("identical unmanaged models must not force a plan")
+	}
+
+	config.MCPToolsetIDs = assigned
+	if !keyHasNonSemanticConfigurationChange(config, state) {
+		t.Fatal("new assignment must produce a plan")
+	}
+
+	state.MCPToolsetIDs = assigned
+	if keyHasNonSemanticConfigurationChange(config, state) {
+		t.Fatal("equal assignment must not force a plan")
+	}
+
+	config.MCPToolsetIDs = empty
+	if !keyHasNonSemanticConfigurationChange(config, state) {
+		t.Fatal("explicit [] clear must produce a plan")
+	}
+
+	config.MCPToolsetIDs = types.SetNull(types.StringType)
+	if !keyHasNonSemanticConfigurationChange(config, state) {
+		t.Fatal("omission-based ownership release must produce a plan")
+	}
+
+	config.MCPToolsetIDs = types.SetUnknown(types.StringType)
+	if !keyHasNonSemanticConfigurationChange(config, state) {
+		t.Fatal("unknown assignment must produce a plan")
+	}
+}
+
+// Team update convergence must compare mcp_toolset_ids so an accepted update
+// whose readback does not reflect the planned assignments is not published.
+func TestTeamChangedFieldMismatchComparesMCPToolsetIDs(t *testing.T) {
+	t.Parallel()
+
+	assigned := types.SetValueMust(types.StringType, []attr.Value{types.StringValue("toolset-a")})
+	desired := partialTeamState("team-id")
+	prior := partialTeamState("team-id")
+	actual := partialTeamState("team-id")
+	desired.MCPToolsetIDs = assigned
+
+	field, mismatch := teamChangedFieldMismatch(desired, prior, actual)
+	if !mismatch || field != "mcp_toolset_ids" {
+		t.Fatalf("mismatch = (%q, %t), want (\"mcp_toolset_ids\", true)", field, mismatch)
+	}
+
+	actual.MCPToolsetIDs = assigned
+	if field, mismatch := teamChangedFieldMismatch(desired, prior, actual); mismatch {
+		t.Fatalf("converged assignments reported mismatch on %q", field)
+	}
+}

--- a/internal/provider/mcp_toolset_lifecycle_protocol_test.go
+++ b/internal/provider/mcp_toolset_lifecycle_protocol_test.go
@@ -1,0 +1,402 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func mcpToolsetProtocolToolType() tftypes.Type {
+	return tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		"server_id": tftypes.String,
+		"tool_name": tftypes.String,
+	}}
+}
+
+func mcpToolsetProtocolValue(t *testing.T, schema *tfprotov6.Schema, toolsetID interface{}, name, description interface{}, tools []tftypes.Value) tftypes.Value {
+	t.Helper()
+	if tools == nil {
+		tools = []tftypes.Value{}
+	}
+	return tftypes.NewValue(schema.ValueType(), map[string]tftypes.Value{
+		"toolset_id":   tftypes.NewValue(tftypes.String, toolsetID),
+		"toolset_name": tftypes.NewValue(tftypes.String, name),
+		"description":  tftypes.NewValue(tftypes.String, description),
+		"tools":        tftypes.NewValue(tftypes.Set{ElementType: mcpToolsetProtocolToolType()}, tools),
+	})
+}
+
+// shortenMCPToolsetRecoveryDelay must only be called from tests that do not
+// run in parallel: provider-constructed resources copy the base delay at
+// construction time inside the calling test.
+func shortenMCPToolsetRecoveryDelay(t *testing.T) {
+	t.Helper()
+	prior := mcpToolsetRecoveryBaseDelay
+	mcpToolsetRecoveryBaseDelay = time.Millisecond
+	t.Cleanup(func() { mcpToolsetRecoveryBaseDelay = prior })
+}
+
+func mcpToolsetProtocolCreate(t *testing.T, ctx context.Context, apiBase string) (*tfprotov6.ApplyResourceChangeResponse, *tfprotov6.Schema) {
+	t.Helper()
+	applied, schema, _ := mcpToolsetProtocolCreateWithServer(t, ctx, apiBase)
+	return applied, schema
+}
+
+func mcpToolsetProtocolCreateWithServer(t *testing.T, ctx context.Context, apiBase string) (*tfprotov6.ApplyResourceChangeResponse, *tfprotov6.Schema, tfprotov6.ProviderServer) {
+	t.Helper()
+	protocolServer, schemas := configuredImportProtocolServer(t, ctx, apiBase)
+	schema := schemas.ResourceSchemas["litellm_mcp_toolset"]
+	config := accessGroupProtocolDynamicValue(t, schema, mcpToolsetProtocolValue(t, schema, nil, "incident-response", nil, nil))
+	proposed := accessGroupProtocolDynamicValue(t, schema, mcpToolsetProtocolValue(t, schema, tftypes.UnknownValue, "incident-response", nil, nil))
+	nullState := accessGroupProtocolDynamicValue(t, schema, tftypes.NewValue(schema.ValueType(), nil))
+	planned, err := protocolServer.PlanResourceChange(ctx, &tfprotov6.PlanResourceChangeRequest{TypeName: "litellm_mcp_toolset", Config: config, PriorState: nullState, ProposedNewState: proposed})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(planned.Diagnostics) {
+		t.Fatalf("plan err=%v diagnostics=%s", err, agentProtocolDiagnosticsText(planned.Diagnostics))
+	}
+	applied, err := protocolServer.ApplyResourceChange(ctx, &tfprotov6.ApplyResourceChangeRequest{TypeName: "litellm_mcp_toolset", Config: config, PriorState: nullState, PlannedState: planned.PlannedState, PlannedPrivate: planned.PlannedPrivate})
+	if err != nil {
+		t.Fatalf("apply err=%v", err)
+	}
+	return applied, schema, protocolServer
+}
+
+func TestMCPToolsetProtocolAcceptedMalformedCreateRetainsNameBoundPartialState(t *testing.T) {
+	shortenMCPToolsetRecoveryDelay(t)
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/mcp/toolset":
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`not json`))
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/mcp/toolset":
+			// Pinned list_mcp_toolsets converts database failures to an empty
+			// list, so the provider must never treat this as absence.
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	applied, schema := mcpToolsetProtocolCreate(t, ctx, server.URL)
+	if !accessGroupProtocolDiagnosticsHaveError(applied.Diagnostics) {
+		t.Fatal("unconfirmed accepted create did not error")
+	}
+	if text := agentProtocolDiagnosticsText(applied.Diagnostics); !strings.Contains(text, "name-bound partial state was retained") {
+		t.Fatalf("diagnostic does not describe partial-state retention: %s", text)
+	}
+	attributes := protocolAttributeMap(t, schema, applied.NewState)
+	if !attributes["toolset_id"].IsNull() {
+		t.Fatalf("unconfirmed toolset_id persisted: %s", attributes["toolset_id"])
+	}
+	var name string
+	if err := attributes["toolset_name"].As(&name); err != nil || name != "incident-response" {
+		t.Fatalf("name-bound state lost the toolset name: %q err=%v", name, err)
+	}
+}
+
+func TestMCPToolsetProtocolAcceptedInterruptedCreateRecoversByNameWithDirectConfirmation(t *testing.T) {
+	shortenMCPToolsetRecoveryDelay(t)
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/mcp/toolset":
+			// Advertise more body than is sent so the accepted response dies
+			// mid-read, the canceled/interrupted transactional shape.
+			w.Header().Set("Content-Length", "512")
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"toolset_id":"toolset-`))
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/mcp/toolset":
+			_, _ = w.Write([]byte(`[{"toolset_name":"other","toolset_id":"toolset-other"},{"toolset_name":"incident-response","toolset_id":"toolset-recovered"}]`))
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/mcp/toolset/toolset-recovered":
+			_ = json.NewEncoder(w).Encode(mcpToolsetResponse{ToolsetID: "toolset-recovered", ToolsetName: "incident-response"})
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	applied, schema := mcpToolsetProtocolCreate(t, ctx, server.URL)
+	if accessGroupProtocolDiagnosticsHaveError(applied.Diagnostics) {
+		t.Fatalf("recovered create errored: %s", agentProtocolDiagnosticsText(applied.Diagnostics))
+	}
+	attributes := protocolAttributeMap(t, schema, applied.NewState)
+	var toolsetID string
+	if err := attributes["toolset_id"].As(&toolsetID); err != nil || toolsetID != "toolset-recovered" {
+		t.Fatalf("toolset_id=%q err=%v, want recovered identity", toolsetID, err)
+	}
+}
+
+func TestMCPToolsetProtocolRejectedCreateLeavesNoState(t *testing.T) {
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"detail":{"error":"A toolset named 'incident-response' already exists."}}`, http.StatusConflict)
+	}))
+	defer server.Close()
+
+	applied, schema := mcpToolsetProtocolCreate(t, ctx, server.URL)
+	if !accessGroupProtocolDiagnosticsHaveError(applied.Diagnostics) {
+		t.Fatal("rejected create did not error")
+	}
+	state, err := applied.NewState.Unmarshal(schema.ValueType())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !state.IsNull() {
+		t.Fatalf("rejected create persisted state: %s", state)
+	}
+}
+
+func TestMCPToolsetProtocolReadRepairsAcceptedNameBoundPartialState(t *testing.T) {
+	shortenMCPToolsetRecoveryDelay(t)
+	ctx := context.Background()
+	var healthy atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/mcp/toolset":
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`not json`))
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/mcp/toolset":
+			if !healthy.Load() {
+				http.Error(w, `{"error":"transient"}`, http.StatusBadGateway)
+				return
+			}
+			_, _ = w.Write([]byte(`[{"toolset_name":"incident-response","toolset_id":"toolset-repaired"}]`))
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/mcp/toolset/toolset-repaired":
+			_ = json.NewEncoder(w).Encode(mcpToolsetResponse{ToolsetID: "toolset-repaired", ToolsetName: "incident-response"})
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	applied, schema, protocolServer := mcpToolsetProtocolCreateWithServer(t, ctx, server.URL)
+	if !accessGroupProtocolDiagnosticsHaveError(applied.Diagnostics) {
+		t.Fatal("unconfirmed accepted create did not error")
+	}
+	if !protocolPrivateHasKey(t, applied.Private, mcpToolsetAcceptedCreatePrivateKey) {
+		t.Fatalf("accepted-create marker missing from private state: %s", applied.Private)
+	}
+
+	healthy.Store(true)
+	read, err := protocolServer.ReadResource(ctx, &tfprotov6.ReadResourceRequest{TypeName: "litellm_mcp_toolset", CurrentState: applied.NewState, Private: applied.Private})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(read.Diagnostics) {
+		t.Fatalf("read err=%v diagnostics=%s", err, agentProtocolDiagnosticsText(read.Diagnostics))
+	}
+	attributes := protocolAttributeMap(t, schema, read.NewState)
+	var toolsetID string
+	if err := attributes["toolset_id"].As(&toolsetID); err != nil || toolsetID != "toolset-repaired" {
+		t.Fatalf("toolset_id=%q err=%v, want repaired identity", toolsetID, err)
+	}
+	if protocolPrivateHasKey(t, read.Private, mcpToolsetAcceptedCreatePrivateKey) {
+		t.Fatalf("recovered read retained the accepted-create marker: %s", read.Private)
+	}
+}
+
+func TestMCPToolsetProtocolDispatchedCreateWithoutStatusRequiresReconciliation(t *testing.T) {
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/v1/mcp/toolset" {
+			// Drop the connection before any status line: the mutation was
+			// dispatched but its outcome was never proven.
+			hijacker, ok := w.(http.Hijacker)
+			if !ok {
+				t.Fatal("test server does not support hijacking")
+			}
+			connection, _, err := hijacker.Hijack()
+			if err != nil {
+				t.Fatalf("hijack: %v", err)
+			}
+			_ = connection.Close()
+			return
+		}
+		t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+	}))
+	defer server.Close()
+
+	applied, schema, protocolServer := mcpToolsetProtocolCreateWithServer(t, ctx, server.URL)
+	if !accessGroupProtocolDiagnosticsHaveError(applied.Diagnostics) {
+		t.Fatal("uncertain dispatched create did not error")
+	}
+	if text := agentProtocolDiagnosticsText(applied.Diagnostics); !strings.Contains(text, "may or may not exist") {
+		t.Fatalf("diagnostic does not describe the uncertain outcome: %s", text)
+	}
+	attributes := protocolAttributeMap(t, schema, applied.NewState)
+	if !attributes["toolset_id"].IsNull() {
+		t.Fatalf("uncertain create persisted an identity: %s", attributes["toolset_id"])
+	}
+	var name string
+	if err := attributes["toolset_name"].As(&name); err != nil || name != "incident-response" {
+		t.Fatalf("uncertain create lost the blocking name-bound state: %q err=%v", name, err)
+	}
+	if protocolPrivateHasKey(t, applied.Private, mcpToolsetAcceptedCreatePrivateKey) {
+		t.Fatalf("uncertain create wrote the accepted-create marker: %s", applied.Private)
+	}
+
+	// Refresh must not adopt by name: an exact-name match could be a
+	// pre-existing toolset the interrupted create was rejected against.
+	read, err := protocolServer.ReadResource(ctx, &tfprotov6.ReadResourceRequest{TypeName: "litellm_mcp_toolset", CurrentState: applied.NewState, Private: applied.Private})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !accessGroupProtocolDiagnosticsHaveError(read.Diagnostics) {
+		t.Fatal("uncertain identity read did not instruct reconciliation")
+	}
+	if text := agentProtocolDiagnosticsText(read.Diagnostics); !strings.Contains(text, "import it by ID") {
+		t.Fatalf("read diagnostic does not instruct reconciliation: %s", text)
+	}
+}
+
+func TestMCPToolsetProtocolUnrepairablePartialStateFailsWithoutRemoval(t *testing.T) {
+	shortenMCPToolsetRecoveryDelay(t)
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer server.Close()
+
+	protocolServer, schemas := configuredImportProtocolServer(t, ctx, server.URL)
+	schema := schemas.ResourceSchemas["litellm_mcp_toolset"]
+	prior := accessGroupProtocolDynamicValue(t, schema, mcpToolsetProtocolValue(t, schema, nil, "incident-response", nil, nil))
+	read, err := protocolServer.ReadResource(ctx, &tfprotov6.ReadResourceRequest{TypeName: "litellm_mcp_toolset", CurrentState: prior})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !accessGroupProtocolDiagnosticsHaveError(read.Diagnostics) {
+		t.Fatal("unrepairable partial state did not error")
+	}
+	state, err := read.NewState.Unmarshal(schema.ValueType())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.IsNull() {
+		t.Fatal("empty collection was treated as absence authority and removed the partial state")
+	}
+}
+
+func TestMCPToolsetProtocolAcceptedMalformedUpdateConfirmsThroughDirectReadback(t *testing.T) {
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPut && r.URL.Path == "/v1/mcp/toolset":
+			_, _ = w.Write([]byte(`not json`))
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/mcp/toolset/toolset-stable":
+			_ = json.NewEncoder(w).Encode(mcpToolsetResponse{ToolsetID: "toolset-stable", ToolsetName: "after"})
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	protocolServer, schemas := configuredImportProtocolServer(t, ctx, server.URL)
+	schema := schemas.ResourceSchemas["litellm_mcp_toolset"]
+	prior := accessGroupProtocolDynamicValue(t, schema, mcpToolsetProtocolValue(t, schema, "toolset-stable", "before", nil, nil))
+	config := accessGroupProtocolDynamicValue(t, schema, mcpToolsetProtocolValue(t, schema, nil, "after", nil, nil))
+	proposed := accessGroupProtocolDynamicValue(t, schema, mcpToolsetProtocolValue(t, schema, "toolset-stable", "after", nil, nil))
+	planned, err := protocolServer.PlanResourceChange(ctx, &tfprotov6.PlanResourceChangeRequest{TypeName: "litellm_mcp_toolset", Config: config, PriorState: prior, ProposedNewState: proposed})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(planned.Diagnostics) {
+		t.Fatalf("plan err=%v diagnostics=%s", err, agentProtocolDiagnosticsText(planned.Diagnostics))
+	}
+	applied, err := protocolServer.ApplyResourceChange(ctx, &tfprotov6.ApplyResourceChangeRequest{TypeName: "litellm_mcp_toolset", Config: config, PriorState: prior, PlannedState: planned.PlannedState, PlannedPrivate: planned.PlannedPrivate})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(applied.Diagnostics) {
+		t.Fatalf("apply err=%v diagnostics=%s", err, agentProtocolDiagnosticsText(applied.Diagnostics))
+	}
+	attributes := protocolAttributeMap(t, schema, applied.NewState)
+	var name string
+	if err := attributes["toolset_name"].As(&name); err != nil || name != "after" {
+		t.Fatalf("toolset_name=%q err=%v, want direct-readback value", name, err)
+	}
+}
+
+// A decodable accepted create response that does not match the requested
+// definition must not enter state; the provider recovers through exact-name
+// evidence plus direct confirmation of the requested definition.
+func TestMCPToolsetProtocolMismatchedCreateResponseRecoversRequestedRow(t *testing.T) {
+	shortenMCPToolsetRecoveryDelay(t)
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/mcp/toolset":
+			// Decodable body describing a different row.
+			_ = json.NewEncoder(w).Encode(mcpToolsetResponse{ToolsetID: "toolset-other", ToolsetName: "other-name"})
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/mcp/toolset":
+			_ = json.NewEncoder(w).Encode([]mcpToolsetResponse{
+				{ToolsetID: "toolset-other", ToolsetName: "other-name"},
+				{ToolsetID: "toolset-real", ToolsetName: "incident-response"},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/mcp/toolset/toolset-real":
+			_ = json.NewEncoder(w).Encode(mcpToolsetResponse{ToolsetID: "toolset-real", ToolsetName: "incident-response"})
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	applied, schema := mcpToolsetProtocolCreate(t, ctx, server.URL)
+	if accessGroupProtocolDiagnosticsHaveError(applied.Diagnostics) {
+		t.Fatalf("apply diagnostics=%s", agentProtocolDiagnosticsText(applied.Diagnostics))
+	}
+	attributes := protocolAttributeMap(t, schema, applied.NewState)
+	var toolsetID, name string
+	if err := attributes["toolset_id"].As(&toolsetID); err != nil || toolsetID != "toolset-real" {
+		t.Fatalf("toolset_id=%q err=%v, want the recovered requested row", toolsetID, err)
+	}
+	if err := attributes["toolset_name"].As(&name); err != nil || name != "incident-response" {
+		t.Fatalf("toolset_name=%q err=%v, want the requested name", name, err)
+	}
+}
+
+// An accepted update whose direct readback describes a different definition
+// must error and retain prior state instead of publishing either value.
+func TestMCPToolsetProtocolUpdateReadbackDefinitionMismatchRetainsPriorState(t *testing.T) {
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPut && r.URL.Path == "/v1/mcp/toolset":
+			_ = json.NewEncoder(w).Encode(mcpToolsetResponse{ToolsetID: "toolset-stable", ToolsetName: "after"})
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/mcp/toolset/toolset-stable":
+			// Authoritative readback does not reflect the planned definition.
+			_ = json.NewEncoder(w).Encode(mcpToolsetResponse{ToolsetID: "toolset-stable", ToolsetName: "someone-else"})
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	protocolServer, schemas := configuredImportProtocolServer(t, ctx, server.URL)
+	schema := schemas.ResourceSchemas["litellm_mcp_toolset"]
+	prior := accessGroupProtocolDynamicValue(t, schema, mcpToolsetProtocolValue(t, schema, "toolset-stable", "before", nil, nil))
+	config := accessGroupProtocolDynamicValue(t, schema, mcpToolsetProtocolValue(t, schema, nil, "after", nil, nil))
+	proposed := accessGroupProtocolDynamicValue(t, schema, mcpToolsetProtocolValue(t, schema, "toolset-stable", "after", nil, nil))
+	planned, err := protocolServer.PlanResourceChange(ctx, &tfprotov6.PlanResourceChangeRequest{TypeName: "litellm_mcp_toolset", Config: config, PriorState: prior, ProposedNewState: proposed})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(planned.Diagnostics) {
+		t.Fatalf("plan err=%v diagnostics=%s", err, agentProtocolDiagnosticsText(planned.Diagnostics))
+	}
+	applied, err := protocolServer.ApplyResourceChange(ctx, &tfprotov6.ApplyResourceChangeRequest{TypeName: "litellm_mcp_toolset", Config: config, PriorState: prior, PlannedState: planned.PlannedState, PlannedPrivate: planned.PlannedPrivate})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !accessGroupProtocolDiagnosticsHaveError(applied.Diagnostics) {
+		t.Fatal("mismatched readback did not error")
+	}
+	priorValue, _ := prior.Unmarshal(schema.ValueType())
+	failedValue, _ := applied.NewState.Unmarshal(schema.ValueType())
+	if !priorValue.Equal(failedValue) {
+		t.Fatalf("mismatched readback published state\nprior: %s\n  got: %s", priorValue, failedValue)
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -150,6 +150,7 @@ func (p *LiteLLMProvider) Resources(ctx context.Context) []func() resource.Resou
 		NewTeamMemberResource,
 		NewTeamMemberAddResource,
 		NewMCPServerResource,
+		NewMCPToolsetResource,
 		NewCredentialResource,
 		NewVectorStoreResource,
 		NewOrganizationResource,

--- a/internal/provider/provider_smoke_test.go
+++ b/internal/provider/provider_smoke_test.go
@@ -32,6 +32,7 @@ var expectedResourceTypeNames = []string{
 	"litellm_team_member",
 	"litellm_team_member_add",
 	"litellm_mcp_server",
+	"litellm_mcp_toolset",
 	"litellm_credential",
 	"litellm_vector_store",
 	"litellm_organization",
@@ -413,13 +414,17 @@ func TestResourcesImportState(t *testing.T) {
 			continue
 		}
 
+		identityPath := path.Root("id")
+		if metaResp.TypeName == "litellm_mcp_toolset" {
+			identityPath = path.Root("toolset_id")
+		}
 		var id string
-		if diags := importResp.State.GetAttribute(context.Background(), path.Root("id"), &id); diags.HasError() {
+		if diags := importResp.State.GetAttribute(context.Background(), identityPath, &id); diags.HasError() {
 			t.Errorf("resource %q: reading imported id: %v", metaResp.TypeName, diags.Errors())
 			continue
 		}
 		if id == "" {
-			t.Errorf("resource %q: ImportState did not populate id", metaResp.TypeName)
+			t.Errorf("resource %q: ImportState did not populate identity", metaResp.TypeName)
 		}
 	}
 }

--- a/internal/provider/resource_key.go
+++ b/internal/provider/resource_key.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -164,6 +165,7 @@ type KeyResourceModel struct {
 	Tags                     types.List    `tfsdk:"tags"`
 	Blocked                  types.Bool    `tfsdk:"blocked"`
 	RouterSettings           types.Object  `tfsdk:"router_settings"`
+	MCPToolsetIDs            types.Set     `tfsdk:"mcp_toolset_ids"`
 }
 
 func (r *KeyResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -173,7 +175,7 @@ func (r *KeyResource) Metadata(ctx context.Context, req resource.MetadataRequest
 func (r *KeyResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Description: "Manages a LiteLLM API key.",
-		Version:     2,
+		Version:     3,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: "Non-sensitive unique identifier for this key (SHA256 hash of the key value).",
@@ -220,6 +222,14 @@ func (r *KeyResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 				Optional:    true,
 				Computed:    true,
 				ElementType: types.StringType,
+			},
+			"mcp_toolset_ids": schema.SetAttribute{
+				Description: "MCP toolset IDs granted directly to this key. Omit this attribute to leave remote toolset grants unmanaged; set it to an empty set to clear them.",
+				Optional:    true,
+				ElementType: types.StringType,
+				Validators: []validator.Set{
+					setvalidator.ValueStringsAre(stringvalidator.LengthAtLeast(1)),
+				},
 			},
 			"allowed_routes": schema.ListAttribute{
 				Description: "List of allowed API routes.",
@@ -970,6 +980,12 @@ func (r *KeyResource) Update(ctx context.Context, req resource.UpdateRequest, re
 	}
 	updateReq["key"] = keyIdentifier
 
+	// LiteLLM persists object_permission before the key row, so a mutation that
+	// carries assignments must not publish planned state until an authoritative
+	// readback confirms both halves committed together.
+	_, assignmentMutation := updateReq["object_permission"]
+	plannedToolsets := data.MCPToolsetIDs
+
 	retainPriorUpdate := func(localCtx context.Context) {
 		if len(pendingTransitionPrivate) != 0 && resp.Private != nil {
 			resp.Diagnostics.Append(resp.Private.SetKey(localCtx, keyPendingUpdatePrivateKey, pendingTransitionPrivate)...)
@@ -992,7 +1008,18 @@ func (r *KeyResource) Update(ctx context.Context, req resource.UpdateRequest, re
 			return
 		}
 	} else if err := r.readKey(ctx, &data); err != nil {
+		if assignmentMutation {
+			retainPriorUpdate(context.WithoutCancel(ctx))
+			resp.Diagnostics.AddError("MCP Toolset Assignment Not Confirmed", "LiteLLM accepted the key update, but an authoritative readback did not confirm the toolset assignments. Terraform retained prior state; refresh reconciles the assignments.")
+			return
+		}
 		resp.Diagnostics.AddWarning("Read Error", keyResourceReadError(err))
+	}
+
+	if assignmentMutation && !resp.Diagnostics.HasError() && !data.MCPToolsetIDs.Equal(plannedToolsets) {
+		retainPriorUpdate(context.WithoutCancel(ctx))
+		resp.Diagnostics.AddError("MCP Toolset Assignment Did Not Converge", "LiteLLM accepted the key update, but authoritative readback did not match the planned toolset assignments. Terraform retained prior state.")
+		return
 	}
 
 	if !data.RouterSettings.IsNull() || !state.RouterSettings.IsNull() {
@@ -1106,9 +1133,10 @@ func (r *KeyResource) ImportState(ctx context.Context, req resource.ImportStateR
 	}
 }
 
-// UpgradeState handles direct migrations to schema v2. Version 0 also hashes
-// the historical raw key ID; both prior versions initialize semantic JSON as
-// unconfigured typed nulls and never adopt remote dictionary data.
+// UpgradeState handles direct migrations to schema v3. Version 0 also hashes
+// the historical raw key ID; versions 0 and 1 initialize semantic JSON as
+// unconfigured typed nulls and never adopt remote dictionary data. Every
+// prior version initializes mcp_toolset_ids as an unmanaged null.
 func (r *KeyResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
 	return map[int64]resource.StateUpgrader{
 		0: {
@@ -1162,6 +1190,9 @@ func (r *KeyResource) UpgradeState(ctx context.Context) map[int64]resource.State
 				priorState["metadata_json"] = json.RawMessage("null")
 				priorState["config_json"] = json.RawMessage("null")
 				priorState["permissions_json"] = json.RawMessage("null")
+				if _, present := priorState["mcp_toolset_ids"]; !present {
+					priorState["mcp_toolset_ids"] = json.RawMessage("null")
+				}
 
 				upgradedJSON, err := json.Marshal(priorState)
 				if err != nil {
@@ -1195,6 +1226,32 @@ func (r *KeyResource) UpgradeState(ctx context.Context) map[int64]resource.State
 				priorState["metadata_json"] = json.RawMessage("null")
 				priorState["config_json"] = json.RawMessage("null")
 				priorState["permissions_json"] = json.RawMessage("null")
+				if _, present := priorState["mcp_toolset_ids"]; !present {
+					priorState["mcp_toolset_ids"] = json.RawMessage("null")
+				}
+				upgraded, err := json.Marshal(priorState)
+				if err != nil {
+					resp.Diagnostics.AddError("Unable to Upgrade State", "Failed to encode upgraded key state.")
+					return
+				}
+				resp.DynamicValue = &tfprotov6.DynamicValue{JSON: upgraded}
+			},
+		},
+		2: {
+			PriorSchema: nil,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				if req.RawState == nil {
+					resp.Diagnostics.AddError("Unable to Upgrade State", "RawState is nil. This is a bug in the provider.")
+					return
+				}
+				var priorState map[string]json.RawMessage
+				if err := json.Unmarshal(req.RawState.JSON, &priorState); err != nil {
+					resp.Diagnostics.AddError("Unable to Upgrade State", "Failed to decode prior key state.")
+					return
+				}
+				if _, present := priorState["mcp_toolset_ids"]; !present {
+					priorState["mcp_toolset_ids"] = json.RawMessage("null")
+				}
 				upgraded, err := json.Marshal(priorState)
 				if err != nil {
 					resp.Diagnostics.AddError("Unable to Upgrade State", "Failed to encode upgraded key state.")
@@ -1365,6 +1422,9 @@ func (r *KeyResource) buildKeyRequest(ctx context.Context, data *KeyResourceMode
 			return nil, diagnostics
 		}
 		keyReq["router_settings"] = routerSettings
+	}
+	if toolsetDiagnostics := addMCPToolsetIDsToRequest(ctx, keyReq, data.MCPToolsetIDs); toolsetDiagnostics.HasError() {
+		return nil, toolsetDiagnostics
 	}
 
 	// Handle service account
@@ -1862,6 +1922,10 @@ func (r *KeyResource) readKeyWithTransport(ctx context.Context, data *KeyResourc
 
 	modelTPMOwned := imported || (!data.ModelTPMLimit.IsNull() && !data.ModelTPMLimit.IsUnknown())
 	if err := updateInt64MapFromAPI(&data.ModelTPMLimit, info, imported, modelTPMOwned, "metadata", "model_tpm_limit"); err != nil {
+		return err
+	}
+	data.MCPToolsetIDs, err = readMCPToolsetIDs(ctx, info, data.MCPToolsetIDs, imported)
+	if err != nil {
 		return err
 	}
 

--- a/internal/provider/resource_key_semantic_dictionary.go
+++ b/internal/provider/resource_key_semantic_dictionary.go
@@ -384,6 +384,11 @@ func keyHasNonSemanticConfigurationChange(config, state KeyResourceModel) bool {
 			return true
 		}
 	}
+	// mcp_toolset_ids is Optional-only: a null configuration releases ownership
+	// rather than retaining state, so null-versus-managed also plans an update.
+	if config.MCPToolsetIDs.IsUnknown() || !config.MCPToolsetIDs.Equal(state.MCPToolsetIDs) {
+		return true
+	}
 	for _, value := range []struct{ config, state types.Float64 }{
 		{config.MaxBudget, state.MaxBudget}, {config.SoftBudget, state.SoftBudget},
 	} {

--- a/internal/provider/resource_key_semantic_dictionary_test.go
+++ b/internal/provider/resource_key_semantic_dictionary_test.go
@@ -14,8 +14,8 @@ func TestKeySemanticDictionarySchemaAndDirectUpgrades(t *testing.T) {
 	ctx := context.Background()
 	var schemaResponse frameworkresource.SchemaResponse
 	(&KeyResource{}).Schema(ctx, frameworkresource.SchemaRequest{}, &schemaResponse)
-	if schemaResponse.Schema.Version != 2 {
-		t.Fatalf("schema version = %d, want 2", schemaResponse.Schema.Version)
+	if schemaResponse.Schema.Version != 3 {
+		t.Fatalf("schema version = %d, want 3", schemaResponse.Schema.Version)
 	}
 	for _, name := range []string{"metadata_json", "config_json", "permissions_json"} {
 		attribute, ok := schemaResponse.Schema.Attributes[name]

--- a/internal/provider/resource_mcp_toolset.go
+++ b/internal/provider/resource_mcp_toolset.go
@@ -1,0 +1,627 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sort"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ resource.Resource = &MCPToolsetResource{}
+var _ resource.ResourceWithImportState = &MCPToolsetResource{}
+
+var mcpToolsetToolAttributeTypes = map[string]attr.Type{
+	"server_id": types.StringType,
+	"tool_name": types.StringType,
+}
+
+// mcpToolsetRecoveryBaseDelay seeds the accepted-mutation recovery backoff.
+// Non-parallel protocol tests shorten it; production uses one second.
+var mcpToolsetRecoveryBaseDelay = time.Second
+
+// mcpToolsetAcceptedCreatePrivateKey marks name-bound partial state whose
+// create was proven accepted by a 2xx, so Read may recover the identity by
+// unique name. Its absence on identity-free state means the create outcome
+// was never proven and only operator reconciliation is safe.
+const mcpToolsetAcceptedCreatePrivateKey = "mcp_toolset_accepted_create"
+
+func NewMCPToolsetResource() resource.Resource {
+	return &MCPToolsetResource{createRecoveryDelay: mcpToolsetRecoveryBaseDelay}
+}
+
+type MCPToolsetResource struct {
+	client *Client
+	// createRecoveryDelay overrides the first accepted-create recovery
+	// backoff step; zero selects the production one-second default.
+	createRecoveryDelay time.Duration
+}
+
+type MCPToolsetToolModel struct {
+	ServerID types.String `tfsdk:"server_id"`
+	ToolName types.String `tfsdk:"tool_name"`
+}
+
+type MCPToolsetResourceModel struct {
+	ToolsetID   types.String `tfsdk:"toolset_id"`
+	ToolsetName types.String `tfsdk:"toolset_name"`
+	Description types.String `tfsdk:"description"`
+	Tools       types.Set    `tfsdk:"tools"`
+}
+
+type mcpToolsetTool struct {
+	ServerID string `json:"server_id"`
+	ToolName string `json:"tool_name"`
+}
+
+type mcpToolsetRequest struct {
+	ToolsetID   string           `json:"toolset_id,omitempty"`
+	ToolsetName string           `json:"toolset_name"`
+	Description *string          `json:"description,omitempty"`
+	Tools       []mcpToolsetTool `json:"tools"`
+}
+
+type mcpToolsetResponse struct {
+	ToolsetID   string           `json:"toolset_id"`
+	ToolsetName string           `json:"toolset_name"`
+	Description *string          `json:"description"`
+	Tools       []mcpToolsetTool `json:"tools"`
+}
+
+func (r *MCPToolsetResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_mcp_toolset"
+}
+
+func (r *MCPToolsetResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	toolType := types.ObjectType{AttrTypes: mcpToolsetToolAttributeTypes}
+	emptyTools, diags := types.SetValue(toolType, nil)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Schema = schema.Schema{
+		Description: "Manages a LiteLLM MCP toolset definition.",
+		Attributes: map[string]schema.Attribute{
+			"toolset_id": schema.StringAttribute{
+				Description: "The unique identifier for the MCP toolset.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"toolset_name": schema.StringAttribute{
+				Description: "The unique name of the MCP toolset.",
+				Required:    true,
+			},
+			"description": schema.StringAttribute{
+				Description: "A description of the MCP toolset.",
+				Optional:    true,
+			},
+			"tools": schema.SetNestedAttribute{
+				Description: "The unordered set of MCP server and tool pairs in the toolset.",
+				Optional:    true,
+				Computed:    true,
+				Default:     setdefault.StaticValue(emptyTools),
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"server_id": schema.StringAttribute{
+							Description: "The MCP server identifier.",
+							Required:    true,
+						},
+						"tool_name": schema.StringAttribute{
+							Description: "The tool name as exposed by the MCP server.",
+							Required:    true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (r *MCPToolsetResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Resource Configure Type", fmt.Sprintf("Expected *Client, got: %T.", req.ProviderData))
+		return
+	}
+
+	r.client = client
+}
+
+func (r *MCPToolsetResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data MCPToolsetResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	outcome, err := r.createMCPToolset(ctx, &data)
+	if err != nil {
+		switch outcome {
+		case mcpToolsetCreateAccepted:
+			// LiteLLM committed the uniquely named row, so retain a
+			// name-bound partial state instead of orphaning it behind
+			// its own name conflict. Refresh recovers the identity.
+			recoveryCtx := context.WithoutCancel(ctx)
+			partial := data
+			partial.ToolsetID = types.StringNull()
+			resp.Diagnostics.Append(resp.State.Set(recoveryCtx, &partial)...)
+			if resp.Private != nil {
+				resp.Diagnostics.Append(resp.Private.SetKey(recoveryCtx, mcpToolsetAcceptedCreatePrivateKey, []byte("true"))...)
+			}
+			resp.Diagnostics.AddError("MCP Toolset Create Not Confirmed", fmt.Sprintf("LiteLLM accepted the create but the toolset identity was not confirmed: %s. The name-bound partial state was retained; refresh converges once the toolset is readable.", err))
+		case mcpToolsetCreateUncertain:
+			// The request was dispatched but no status arrived, so the row
+			// may or may not exist. Retain name-bound state without the
+			// recovery marker: it blocks a blind duplicate create, and
+			// refresh instructs reconciliation instead of adopting by name.
+			recoveryCtx := context.WithoutCancel(ctx)
+			partial := data
+			partial.ToolsetID = types.StringNull()
+			resp.Diagnostics.Append(resp.State.Set(recoveryCtx, &partial)...)
+			resp.Diagnostics.AddError("MCP Toolset Create Uncertain", fmt.Sprintf("The create request was dispatched but LiteLLM returned no response status: %s. The toolset may or may not exist. The name-bound state was retained to block a duplicate create; confirm the toolset in LiteLLM, then import it by ID if it exists or remove this resource from state.", err))
+		default:
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create MCP toolset: %s", err))
+		}
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *MCPToolsetResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data MCPToolsetResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.ToolsetID.IsNull() || data.ToolsetID.ValueString() == "" {
+		marker, markerDiags := req.Private.GetKey(ctx, mcpToolsetAcceptedCreatePrivateKey)
+		resp.Diagnostics.Append(markerDiags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		if string(marker) != "true" {
+			// The interrupted create never proved acceptance, so an
+			// exact-name match could be a pre-existing toolset that must
+			// not be adopted. Only the operator can reconcile this.
+			resp.Diagnostics.AddError("MCP Toolset Identity Uncertain", fmt.Sprintf("An interrupted create never confirmed whether LiteLLM committed toolset %q. Confirm the toolset in LiteLLM, then import it by ID if it exists or remove this resource from state.", data.ToolsetName.ValueString()))
+			return
+		}
+		// Name-bound partial state from an unconfirmed accepted create.
+		// Recovery errors format with %s, never %w, so an embedded 404 can
+		// never masquerade as direct absence proof and remove the state.
+		recovered, err := r.recoverMCPToolsetByName(ctx, data.ToolsetName.ValueString(), nil, &data)
+		if err != nil {
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read MCP toolset: recover the unconfirmed toolset %q by name: %s", data.ToolsetName.ValueString(), err))
+			return
+		}
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, mcpToolsetAcceptedCreatePrivateKey, nil)...)
+		resp.Diagnostics.Append(resp.State.Set(ctx, &recovered)...)
+		return
+	}
+
+	if err := r.readMCPToolset(ctx, &data); err != nil {
+		if IsNotFoundError(err) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read MCP toolset: %s", err))
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *MCPToolsetResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data MCPToolsetResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var state MCPToolsetResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	data.ToolsetID = state.ToolsetID
+
+	if err := r.updateMCPToolset(ctx, &data); err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update MCP toolset: %s", err))
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *MCPToolsetResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data MCPToolsetResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.ToolsetID.IsNull() || data.ToolsetID.ValueString() == "" {
+		resp.Diagnostics.AddError("MCP Toolset Identity Not Confirmed", "The toolset identity was never confirmed after an accepted create. Refresh state to recover the identity, then destroy again.")
+		return
+	}
+
+	if err := r.deleteMCPToolset(ctx, data.ToolsetID.ValueString()); err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete MCP toolset: %s", err))
+	}
+}
+
+func (r *MCPToolsetResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("toolset_id"), req, resp)
+}
+
+func buildMCPToolsetRequest(ctx context.Context, data *MCPToolsetResourceModel, includeID bool) (mcpToolsetRequest, error) {
+	// Unknown values must fail closed before dispatch; serializing them would
+	// silently send empty or omitted wire values that LiteLLM persists.
+	if data.ToolsetName.IsUnknown() {
+		return mcpToolsetRequest{}, fmt.Errorf("toolset_name is unknown")
+	}
+	if data.Description.IsUnknown() {
+		return mcpToolsetRequest{}, fmt.Errorf("description is unknown")
+	}
+	request := mcpToolsetRequest{
+		ToolsetName: data.ToolsetName.ValueString(),
+		Tools:       []mcpToolsetTool{},
+	}
+	if includeID {
+		request.ToolsetID = data.ToolsetID.ValueString()
+		if data.Description.IsNull() {
+			empty := ""
+			request.Description = &empty
+		}
+	}
+	if !data.Description.IsNull() && !data.Description.IsUnknown() {
+		description := data.Description.ValueString()
+		request.Description = &description
+	}
+
+	if !data.Tools.IsNull() {
+		if data.Tools.IsUnknown() {
+			return mcpToolsetRequest{}, fmt.Errorf("tools is unknown")
+		}
+
+		var tools []MCPToolsetToolModel
+		if diags := data.Tools.ElementsAs(ctx, &tools, false); diags.HasError() {
+			return mcpToolsetRequest{}, fmt.Errorf("failed to decode tools: %v", diags.Errors())
+		}
+		seen := make(map[mcpToolsetTool]struct{}, len(tools))
+		for _, tool := range tools {
+			if tool.ServerID.IsUnknown() || tool.ToolName.IsUnknown() {
+				return mcpToolsetRequest{}, fmt.Errorf("tools contains an unknown server_id or tool_name")
+			}
+			apiTool := mcpToolsetTool{
+				ServerID: tool.ServerID.ValueString(),
+				ToolName: tool.ToolName.ValueString(),
+			}
+			if _, exists := seen[apiTool]; exists {
+				continue
+			}
+			seen[apiTool] = struct{}{}
+			request.Tools = append(request.Tools, apiTool)
+		}
+	}
+
+	sort.Slice(request.Tools, func(i, j int) bool {
+		if request.Tools[i].ServerID == request.Tools[j].ServerID {
+			return request.Tools[i].ToolName < request.Tools[j].ToolName
+		}
+		return request.Tools[i].ServerID < request.Tools[j].ServerID
+	})
+	return request, nil
+}
+
+// confirmMCPToolsetDefinition proves a decodable response describes exactly
+// the requested definition. A response with a different name, description, or
+// tool membership is evidence of another row or a partial write and must not
+// enter state as the requested toolset.
+func confirmMCPToolsetDefinition(request mcpToolsetRequest, result mcpToolsetResponse) error {
+	if result.ToolsetName != request.ToolsetName {
+		return fmt.Errorf("LiteLLM returned toolset_name %q for requested name %q", result.ToolsetName, request.ToolsetName)
+	}
+	requestedDescription := ""
+	if request.Description != nil {
+		requestedDescription = *request.Description
+	}
+	returnedDescription := ""
+	if result.Description != nil {
+		returnedDescription = *result.Description
+	}
+	if requestedDescription != returnedDescription {
+		return fmt.Errorf("LiteLLM returned a different description for toolset %q", request.ToolsetName)
+	}
+	returnedTools := make([]mcpToolsetTool, 0, len(result.Tools))
+	seen := make(map[mcpToolsetTool]struct{}, len(result.Tools))
+	for _, tool := range result.Tools {
+		if _, exists := seen[tool]; exists {
+			continue
+		}
+		seen[tool] = struct{}{}
+		returnedTools = append(returnedTools, tool)
+	}
+	sort.Slice(returnedTools, func(i, j int) bool {
+		if returnedTools[i].ServerID == returnedTools[j].ServerID {
+			return returnedTools[i].ToolName < returnedTools[j].ToolName
+		}
+		return returnedTools[i].ServerID < returnedTools[j].ServerID
+	})
+	if len(returnedTools) != len(request.Tools) {
+		return fmt.Errorf("LiteLLM returned %d tools for toolset %q, requested %d", len(returnedTools), request.ToolsetName, len(request.Tools))
+	}
+	for index := range returnedTools {
+		if returnedTools[index] != request.Tools[index] {
+			return fmt.Errorf("LiteLLM returned a different tool membership for toolset %q", request.ToolsetName)
+		}
+	}
+	return nil
+}
+
+// mcpToolsetCreateOutcome records what the create mutation proved. Rejected
+// means LiteLLM answered without committing, accepted means a 2xx proved the
+// uniquely named row exists, and uncertain means the request was dispatched
+// but no response status arrived, so the row may or may not exist.
+type mcpToolsetCreateOutcome int
+
+const (
+	mcpToolsetCreateRejected mcpToolsetCreateOutcome = iota
+	mcpToolsetCreateAccepted
+	mcpToolsetCreateUncertain
+)
+
+// createMCPToolset posts the new toolset and confirms its identity. When the
+// outcome is accepted and err is non-nil, the uniquely named row exists but
+// its identity was not confirmed; when the outcome is uncertain, only
+// name-bound state without automatic recovery is safe, because a dispatched
+// request without a status could equally have hit a pre-existing-name
+// conflict that the provider must never adopt.
+func (r *MCPToolsetResource) createMCPToolset(ctx context.Context, data *MCPToolsetResourceModel) (mcpToolsetCreateOutcome, error) {
+	request, err := buildMCPToolsetRequest(ctx, data, false)
+	if err != nil {
+		return mcpToolsetCreateRejected, err
+	}
+
+	var result mcpToolsetResponse
+	accepted, err := r.client.doRequestWithResponse(ctx, http.MethodPost, "/v1/mcp/toolset", request, &result)
+	if err == nil {
+		err = confirmMCPToolsetDefinition(request, result)
+	}
+	if err == nil {
+		err = applyMCPToolsetResponse(ctx, result, "", data)
+	}
+	if err == nil {
+		return mcpToolsetCreateAccepted, nil
+	}
+	if !accepted {
+		if classification := ClassifyHTTPFailure(err); classification.RequestDispatched && classification.StatusCode == 0 {
+			return mcpToolsetCreateUncertain, err
+		}
+		return mcpToolsetCreateRejected, err
+	}
+	// LiteLLM accepted the create, so the toolset exists even though the
+	// response body was unusable. toolset_name is unique in LiteLLM v1.98, so
+	// recover the stored identity from the collection instead of stranding a
+	// row that blocks every retry with a name conflict.
+	recovered, recoverErr := r.recoverMCPToolsetByName(ctx, request.ToolsetName, &request, data)
+	if recoverErr != nil {
+		return mcpToolsetCreateAccepted, fmt.Errorf("LiteLLM accepted the create but returned an unusable response (%s); recovery by name failed: %s", err, recoverErr)
+	}
+	*data = recovered
+	return mcpToolsetCreateAccepted, nil
+}
+
+// mcpToolsetRecoveryFailureIsTerminal reports whether a recovery probe
+// failure is authoritative and must stop the bounded retry loop: an explicit
+// status-bearing terminal answer (401/403/404), a canceled context, or an
+// expired deadline. Transient transport and contract failures stay
+// inconclusive and retry.
+func mcpToolsetRecoveryFailureIsTerminal(err error) bool {
+	switch ClassifyHTTPFailure(err).Kind {
+	case HTTPFailureTerminalResponse, HTTPFailureCanceled, HTTPFailureDeadline:
+		return true
+	default:
+		return false
+	}
+}
+
+// recoverMCPToolsetByName recovers an accepted mutation whose response body
+// was unusable. It requires positive exact-name evidence from the collection
+// listing, then confirms the row through the direct-ID endpoint before
+// returning it. When definition is non-nil (create recovery), the confirmed
+// row must also match the requested definition exactly; a nil definition
+// (read repair) adopts the remote definition as ordinary drift. An empty
+// collection is never absence authority because LiteLLM's pinned
+// list_mcp_toolsets converts database failures to an empty list, so every
+// inconclusive read retries with context-aware bounded backoff on the
+// fresh-connection probe path.
+func (r *MCPToolsetResource) recoverMCPToolsetByName(ctx context.Context, name string, definition *mcpToolsetRequest, data *MCPToolsetResourceModel) (MCPToolsetResourceModel, error) {
+	delay := r.createRecoveryDelay
+	if delay <= 0 {
+		delay = time.Second
+	}
+	var lastErr error
+	for attempt := 0; attempt < 5; attempt++ {
+		if attempt > 0 {
+			timer := time.NewTimer(delay)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				if lastErr == nil {
+					lastErr = ctx.Err()
+				}
+				return MCPToolsetResourceModel{}, lastErr
+			case <-timer.C:
+			}
+			delay *= 2
+		}
+		var toolsets []mcpToolsetResponse
+		if err := r.client.doFreshRequestWithResponse(ctx, http.MethodGet, "/v1/mcp/toolset", nil, &toolsets); err != nil {
+			if mcpToolsetRecoveryFailureIsTerminal(err) {
+				return MCPToolsetResourceModel{}, err
+			}
+			lastErr = err
+			continue
+		}
+		var match *mcpToolsetResponse
+		ambiguous := false
+		for index := range toolsets {
+			if toolsets[index].ToolsetName != name {
+				continue
+			}
+			if match != nil {
+				ambiguous = true
+				break
+			}
+			match = &toolsets[index]
+		}
+		if ambiguous {
+			return MCPToolsetResourceModel{}, fmt.Errorf("multiple toolsets named %q", name)
+		}
+		if match == nil {
+			lastErr = fmt.Errorf("no positive collection evidence for toolset %q", name)
+			continue
+		}
+		matchID := mcpToolsetRecoveredIdentifier(*match)
+		var confirmed mcpToolsetResponse
+		if err := r.client.doFreshRequestWithResponse(ctx, http.MethodGet, mcpToolsetEndpoint(matchID), nil, &confirmed); err != nil {
+			if mcpToolsetRecoveryFailureIsTerminal(err) {
+				return MCPToolsetResourceModel{}, fmt.Errorf("confirm toolset %q through the direct endpoint: %s", matchID, err)
+			}
+			lastErr = fmt.Errorf("confirm toolset %q through the direct endpoint: %s", matchID, err)
+			continue
+		}
+		if definition != nil {
+			// A confirmed row that does not match the accepted request is
+			// authoritative evidence of a different row; do not adopt it.
+			if err := confirmMCPToolsetDefinition(*definition, confirmed); err != nil {
+				return MCPToolsetResourceModel{}, err
+			}
+		}
+		next := *data
+		if err := applyMCPToolsetResponse(ctx, confirmed, matchID, &next); err != nil {
+			lastErr = err
+			continue
+		}
+		return next, nil
+	}
+	return MCPToolsetResourceModel{}, lastErr
+}
+
+func (r *MCPToolsetResource) readMCPToolset(ctx context.Context, data *MCPToolsetResourceModel) error {
+	toolsetID := data.ToolsetID.ValueString()
+	var result mcpToolsetResponse
+	if err := r.client.DoRequestWithResponse(ctx, http.MethodGet, mcpToolsetEndpoint(toolsetID), nil, &result); err != nil {
+		return err
+	}
+
+	return applyMCPToolsetResponse(ctx, result, toolsetID, data)
+}
+
+func (r *MCPToolsetResource) updateMCPToolset(ctx context.Context, data *MCPToolsetResourceModel) error {
+	toolsetID := data.ToolsetID.ValueString()
+	if data.ToolsetID.IsNull() || toolsetID == "" {
+		return fmt.Errorf("the toolset identity was never confirmed; refresh state to recover it before updating")
+	}
+
+	request, err := buildMCPToolsetRequest(ctx, data, true)
+	if err != nil {
+		return err
+	}
+
+	var result mcpToolsetResponse
+	if accepted, updateErr := r.client.doRequestWithResponse(ctx, http.MethodPut, "/v1/mcp/toolset", request, &result); updateErr != nil && !accepted {
+		return updateErr
+	}
+	// The direct singular endpoint is the mandatory readback authority for an
+	// accepted update; the mutation envelope is used only for acceptance. The
+	// confirmed row must match the planned definition exactly before it is
+	// published as the update result.
+	var confirmed mcpToolsetResponse
+	if err := r.client.doFreshRequestWithResponse(ctx, http.MethodGet, mcpToolsetEndpoint(toolsetID), nil, &confirmed); err != nil {
+		return fmt.Errorf("LiteLLM accepted the update but direct readback failed: %s", err)
+	}
+	if err := confirmMCPToolsetDefinition(request, confirmed); err != nil {
+		return fmt.Errorf("LiteLLM accepted the update but readback did not match the planned definition: %s", err)
+	}
+	return applyMCPToolsetResponse(ctx, confirmed, toolsetID, data)
+}
+
+func (r *MCPToolsetResource) deleteMCPToolset(ctx context.Context, toolsetID string) error {
+	err := r.client.DoRequestWithResponse(ctx, http.MethodDelete, mcpToolsetEndpoint(toolsetID), nil, nil)
+	if IsNotFoundError(err) {
+		return nil
+	}
+	return err
+}
+
+func mcpToolsetEndpoint(toolsetID string) string {
+	return endpointWithPathSegment("/v1/mcp/toolset/", toolsetID, "")
+}
+
+// mcpToolsetRecoveredIdentifier is the reviewed raw-identity boundary for
+// accepted-mutation recovery: the identity of the exact-name collection match
+// that the direct endpoint must confirm before it enters state.
+func mcpToolsetRecoveredIdentifier(match mcpToolsetResponse) string {
+	return match.ToolsetID
+}
+
+func applyMCPToolsetResponse(ctx context.Context, result mcpToolsetResponse, expectedID string, data *MCPToolsetResourceModel) error {
+	if result.ToolsetID == "" {
+		return fmt.Errorf("LiteLLM response omitted toolset_id")
+	}
+	if expectedID != "" && result.ToolsetID != expectedID {
+		return fmt.Errorf("LiteLLM returned toolset_id %q for %q", result.ToolsetID, expectedID)
+	}
+
+	toolValues := make([]attr.Value, 0, len(result.Tools))
+	seen := make(map[mcpToolsetTool]struct{}, len(result.Tools))
+	for _, tool := range result.Tools {
+		if _, exists := seen[tool]; exists {
+			continue
+		}
+		seen[tool] = struct{}{}
+		value, diags := types.ObjectValue(mcpToolsetToolAttributeTypes, map[string]attr.Value{
+			"server_id": types.StringValue(tool.ServerID),
+			"tool_name": types.StringValue(tool.ToolName),
+		})
+		if diags.HasError() {
+			return fmt.Errorf("failed to encode tool %q from server %q: %v", tool.ToolName, tool.ServerID, diags.Errors())
+		}
+		toolValues = append(toolValues, value)
+	}
+	tools, diags := types.SetValue(types.ObjectType{AttrTypes: mcpToolsetToolAttributeTypes}, toolValues)
+	if diags.HasError() {
+		return fmt.Errorf("failed to encode tools: %v", diags.Errors())
+	}
+
+	next := *data
+	next.ToolsetID = types.StringValue(result.ToolsetID)
+	next.ToolsetName = types.StringValue(result.ToolsetName)
+	if result.Description == nil || (*result.Description == "" && data.Description.IsNull()) {
+		next.Description = types.StringNull()
+	} else {
+		next.Description = types.StringValue(*result.Description)
+	}
+	next.Tools = tools
+	*data = next
+	return nil
+}

--- a/internal/provider/resource_mcp_toolset_test.go
+++ b/internal/provider/resource_mcp_toolset_test.go
@@ -1,0 +1,921 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestMCPToolsetResourceSchema(t *testing.T) {
+	t.Parallel()
+
+	underTest := &MCPToolsetResource{}
+	var resp resource.SchemaResponse
+	underTest.Schema(context.Background(), resource.SchemaRequest{}, &resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("schema returned diagnostics: %v", resp.Diagnostics.Errors())
+	}
+	if diags := resp.Schema.ValidateImplementation(context.Background()); diags.HasError() {
+		t.Fatalf("schema implementation validation failed: %v", diags.Errors())
+	}
+
+	toolsetName, ok := resp.Schema.Attributes["toolset_name"].(schema.StringAttribute)
+	if !ok || !toolsetName.Required {
+		t.Fatalf("toolset_name must be a required string attribute, got %#v", resp.Schema.Attributes["toolset_name"])
+	}
+
+	description, ok := resp.Schema.Attributes["description"].(schema.StringAttribute)
+	if !ok || !description.Optional {
+		t.Fatalf("description must be an optional string attribute, got %#v", resp.Schema.Attributes["description"])
+	}
+
+	toolsetID, ok := resp.Schema.Attributes["toolset_id"].(schema.StringAttribute)
+	if !ok || !toolsetID.Computed {
+		t.Fatalf("toolset_id must be a computed string attribute, got %#v", resp.Schema.Attributes["toolset_id"])
+	}
+
+	tools, ok := resp.Schema.Attributes["tools"].(schema.SetNestedAttribute)
+	if !ok {
+		t.Fatalf("tools must be a nested set attribute, got %T", resp.Schema.Attributes["tools"])
+	}
+	if !tools.Optional || tools.Default == nil {
+		t.Fatalf("tools must be optional with an empty-set default, got %#v", tools)
+	}
+
+	for _, name := range []string{"server_id", "tool_name"} {
+		attribute, ok := tools.NestedObject.Attributes[name].(schema.StringAttribute)
+		if !ok || !attribute.Required {
+			t.Fatalf("tools.%s must be a required string attribute, got %#v", name, tools.NestedObject.Attributes[name])
+		}
+		if len(attribute.Validators) != 0 {
+			t.Fatalf("tools.%s must not perform live catalog validation", name)
+		}
+	}
+}
+
+func TestProviderRegistersMCPToolsetResource(t *testing.T) {
+	t.Parallel()
+
+	provider := &LiteLLMProvider{}
+	for _, factory := range provider.Resources(context.Background()) {
+		var resp resource.MetadataResponse
+		factory().Metadata(context.Background(), resource.MetadataRequest{ProviderTypeName: "litellm"}, &resp)
+		if resp.TypeName == "litellm_mcp_toolset" {
+			return
+		}
+	}
+
+	t.Fatal("provider did not register litellm_mcp_toolset")
+}
+
+func TestBuildMCPToolsetRequestTreatsToolsAsAnUnorderedSet(t *testing.T) {
+	t.Parallel()
+
+	tools := types.SetValueMust(
+		types.ObjectType{AttrTypes: mcpToolsetToolAttributeTypes},
+		[]attr.Value{
+			mcpToolsetToolValue("server-b", "deploy"),
+			mcpToolsetToolValue("server-a", "search"),
+			mcpToolsetToolValue("server-a", "search"),
+		},
+	)
+	data := MCPToolsetResourceModel{
+		ToolsetID:   types.StringValue("toolset-1"),
+		ToolsetName: types.StringValue("sre-readonly"),
+		Description: types.StringValue("Read-only SRE tools"),
+		Tools:       tools,
+	}
+
+	request, err := buildMCPToolsetRequest(context.Background(), &data, true)
+	if err != nil {
+		t.Fatalf("buildMCPToolsetRequest returned error: %v", err)
+	}
+
+	want := mcpToolsetRequest{
+		ToolsetID:   "toolset-1",
+		ToolsetName: "sre-readonly",
+		Description: mcpToolsetStringPointer("Read-only SRE tools"),
+		Tools: []mcpToolsetTool{
+			{ServerID: "server-a", ToolName: "search"},
+			{ServerID: "server-b", ToolName: "deploy"},
+		},
+	}
+	if !reflect.DeepEqual(request, want) {
+		t.Fatalf("unexpected request\nwant: %#v\n got: %#v", want, request)
+	}
+}
+
+func TestBuildMCPToolsetRequestDefaultsToolsToEmpty(t *testing.T) {
+	t.Parallel()
+
+	data := MCPToolsetResourceModel{
+		ToolsetName: types.StringValue("empty"),
+		Description: types.StringNull(),
+		Tools:       types.SetNull(types.ObjectType{AttrTypes: mcpToolsetToolAttributeTypes}),
+	}
+
+	request, err := buildMCPToolsetRequest(context.Background(), &data, false)
+	if err != nil {
+		t.Fatalf("buildMCPToolsetRequest returned error: %v", err)
+	}
+	if request.Tools == nil || len(request.Tools) != 0 {
+		t.Fatalf("tools must be a non-nil empty list, got %#v", request.Tools)
+	}
+	if request.Description != nil {
+		t.Fatalf("create request must omit an unconfigured description, got %#v", request.Description)
+	}
+}
+
+func TestCreateMCPToolsetStoresReturnedState(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/mcp/toolset" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		var request mcpToolsetRequest
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if request.ToolsetID != "" || request.ToolsetName != "incident-response" || len(request.Tools) != 1 {
+			t.Fatalf("unexpected create payload: %#v", request)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(mcpToolsetResponse{
+			ToolsetID:   "toolset-created",
+			ToolsetName: "incident-response",
+			Description: mcpToolsetStringPointer("Incident response reads"),
+			Tools:       []mcpToolsetTool{{ServerID: "pagerduty", ToolName: "list_incidents"}},
+		})
+	}))
+	defer server.Close()
+
+	resource := testMCPToolsetResource(server)
+	data := MCPToolsetResourceModel{
+		ToolsetID:   types.StringUnknown(),
+		ToolsetName: types.StringValue("incident-response"),
+		Description: types.StringValue("Incident response reads"),
+		Tools:       mcpToolsetToolsValue(mcpToolsetTool{"pagerduty", "list_incidents"}),
+	}
+
+	if _, err := resource.createMCPToolset(context.Background(), &data); err != nil {
+		t.Fatalf("createMCPToolset returned error: %v", err)
+	}
+	if got := data.ToolsetID.ValueString(); got != "toolset-created" {
+		t.Fatalf("expected returned toolset ID, got %q", got)
+	}
+}
+
+func TestCreateMCPToolsetRejectsDuplicateNameWithoutPartialState(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"detail":{"error":"already exists"}}`, http.StatusConflict)
+	}))
+	defer server.Close()
+
+	resource := testMCPToolsetResource(server)
+	data := MCPToolsetResourceModel{
+		ToolsetID:   types.StringUnknown(),
+		ToolsetName: types.StringValue("duplicate"),
+		Description: types.StringNull(),
+		Tools:       mcpToolsetToolsValue(),
+	}
+
+	outcome, err := resource.createMCPToolset(context.Background(), &data)
+	if err == nil {
+		t.Fatal("expected create conflict error")
+	}
+	if outcome != mcpToolsetCreateRejected {
+		t.Fatalf("conflict create outcome = %v, want rejected", outcome)
+	}
+	if !data.ToolsetID.IsUnknown() {
+		t.Fatalf("failed create changed toolset_id to %#v", data.ToolsetID)
+	}
+}
+
+func TestCreateMCPToolsetRecoversAcceptedCreateWithUnusableResponse(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/mcp/toolset":
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"toolset_name":"incident-response"}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/mcp/toolset":
+			_ = json.NewEncoder(w).Encode([]mcpToolsetResponse{
+				{ToolsetID: "toolset-other", ToolsetName: "other"},
+				{ToolsetID: "toolset-recovered", ToolsetName: "incident-response"},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/mcp/toolset/toolset-recovered":
+			_ = json.NewEncoder(w).Encode(mcpToolsetResponse{
+				ToolsetID:   "toolset-recovered",
+				ToolsetName: "incident-response",
+				Description: mcpToolsetStringPointer("Incident response reads"),
+				Tools:       []mcpToolsetTool{{ServerID: "pagerduty", ToolName: "list_incidents"}},
+			})
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	resource := testMCPToolsetResource(server)
+	data := MCPToolsetResourceModel{
+		ToolsetID:   types.StringUnknown(),
+		ToolsetName: types.StringValue("incident-response"),
+		Description: types.StringValue("Incident response reads"),
+		Tools:       mcpToolsetToolsValue(mcpToolsetTool{"pagerduty", "list_incidents"}),
+	}
+
+	if _, err := resource.createMCPToolset(context.Background(), &data); err != nil {
+		t.Fatalf("createMCPToolset returned error: %v", err)
+	}
+	if got := data.ToolsetID.ValueString(); got != "toolset-recovered" {
+		t.Fatalf("expected recovered toolset ID, got %q", got)
+	}
+}
+
+func TestCreateMCPToolsetRecoveryRetriesTransientListFailures(t *testing.T) {
+	t.Parallel()
+
+	var listCalls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/mcp/toolset":
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`not json`))
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/mcp/toolset":
+			switch atomic.AddInt32(&listCalls, 1) {
+			case 1:
+				http.Error(w, `{"error":"transient"}`, http.StatusBadGateway)
+			case 2:
+				_, _ = w.Write([]byte(`[]`))
+			default:
+				_ = json.NewEncoder(w).Encode([]mcpToolsetResponse{{
+					ToolsetID:   "toolset-recovered",
+					ToolsetName: "incident-response",
+				}})
+			}
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/mcp/toolset/toolset-recovered":
+			_ = json.NewEncoder(w).Encode(mcpToolsetResponse{
+				ToolsetID:   "toolset-recovered",
+				ToolsetName: "incident-response",
+			})
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	resource := testMCPToolsetResource(server)
+	data := MCPToolsetResourceModel{
+		ToolsetID:   types.StringUnknown(),
+		ToolsetName: types.StringValue("incident-response"),
+		Description: types.StringNull(),
+		Tools:       mcpToolsetToolsValue(),
+	}
+
+	if _, err := resource.createMCPToolset(context.Background(), &data); err != nil {
+		t.Fatalf("createMCPToolset returned error: %v", err)
+	}
+	if got := data.ToolsetID.ValueString(); got != "toolset-recovered" {
+		t.Fatalf("expected recovered toolset ID, got %q", got)
+	}
+	if got := atomic.LoadInt32(&listCalls); got != 3 {
+		t.Fatalf("recovery list calls = %d, want 3", got)
+	}
+}
+
+func TestCreateMCPToolsetReportsBothErrorsWhenRecoveryFindsNoMatch(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/mcp/toolset":
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`not json`))
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/mcp/toolset":
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	resource := testMCPToolsetResource(server)
+	data := MCPToolsetResourceModel{
+		ToolsetID:   types.StringUnknown(),
+		ToolsetName: types.StringValue("incident-response"),
+		Description: types.StringNull(),
+		Tools:       mcpToolsetToolsValue(),
+	}
+
+	outcome, err := resource.createMCPToolset(context.Background(), &data)
+	if err == nil {
+		t.Fatal("expected create error when recovery finds no match")
+	}
+	if outcome != mcpToolsetCreateAccepted {
+		t.Fatalf("accepted create with failed recovery outcome = %v, want accepted", outcome)
+	}
+	if !data.ToolsetID.IsUnknown() {
+		t.Fatalf("failed create changed toolset_id to %#v", data.ToolsetID)
+	}
+	if !strings.Contains(err.Error(), "recovery by name failed") {
+		t.Fatalf("error does not describe failed recovery: %v", err)
+	}
+}
+
+func TestReadMCPToolsetUsesRemoteValuesWithoutOrderingDrift(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/mcp/toolset/toolset-read" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(mcpToolsetResponse{
+			ToolsetID:   "toolset-read",
+			ToolsetName: "remote-name",
+			Tools: []mcpToolsetTool{
+				{ServerID: "server-b", ToolName: "beta"},
+				{ServerID: "server-a", ToolName: "alpha"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	resource := testMCPToolsetResource(server)
+	data := MCPToolsetResourceModel{
+		ToolsetID:   types.StringValue("toolset-read"),
+		ToolsetName: types.StringValue("old-name"),
+		Description: types.StringValue("old description"),
+		Tools:       mcpToolsetToolsValue(mcpToolsetTool{"server-a", "alpha"}, mcpToolsetTool{"server-b", "beta"}),
+	}
+	wantTools := data.Tools
+
+	if err := resource.readMCPToolset(context.Background(), &data); err != nil {
+		t.Fatalf("readMCPToolset returned error: %v", err)
+	}
+	if got := data.ToolsetName.ValueString(); got != "remote-name" {
+		t.Fatalf("expected remote name, got %q", got)
+	}
+	if !data.Description.IsNull() {
+		t.Fatalf("expected remote null description, got %#v", data.Description)
+	}
+	if !data.Tools.Equal(wantTools) {
+		t.Fatalf("tool order created drift\nwant: %#v\n got: %#v", wantTools, data.Tools)
+	}
+}
+
+func TestReadMCPToolsetErrorsDoNotChangePriorState(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range []struct {
+		name       string
+		statusCode int
+		notFound   bool
+	}{
+		{name: "not found", statusCode: http.StatusNotFound, notFound: true},
+		{name: "server error", statusCode: http.StatusInternalServerError},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "request failed", testCase.statusCode)
+			}))
+			defer server.Close()
+
+			resource := testMCPToolsetResource(server)
+			data := MCPToolsetResourceModel{
+				ToolsetID:   types.StringValue("toolset-read-error"),
+				ToolsetName: types.StringValue("prior-name"),
+				Description: types.StringValue("prior description"),
+				Tools:       mcpToolsetToolsValue(mcpToolsetTool{"server-a", "alpha"}),
+			}
+			before := data
+
+			err := resource.readMCPToolset(context.Background(), &data)
+			if err == nil {
+				t.Fatal("expected read error")
+			}
+			if IsNotFoundError(err) != testCase.notFound {
+				t.Fatalf("IsNotFoundError(%v) = %v, want %v", err, IsNotFoundError(err), testCase.notFound)
+			}
+			if !reflect.DeepEqual(data, before) {
+				t.Fatalf("failed read changed prior state\nwant: %#v\n got: %#v", before, data)
+			}
+		})
+	}
+}
+
+func TestUpdateMCPToolsetPreservesIDAndSendsFullDefinition(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodGet && r.URL.Path == "/v1/mcp/toolset/toolset-stable" {
+			_ = json.NewEncoder(w).Encode(mcpToolsetResponse{
+				ToolsetID:   "toolset-stable",
+				ToolsetName: "renamed",
+				Description: mcpToolsetStringPointer(""),
+				Tools:       []mcpToolsetTool{},
+			})
+			return
+		}
+		if r.Method != http.MethodPut || r.URL.Path != "/v1/mcp/toolset" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		var request mcpToolsetRequest
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if request.ToolsetID != "toolset-stable" || request.ToolsetName != "renamed" || request.Description == nil || *request.Description != "" || len(request.Tools) != 0 {
+			t.Fatalf("unexpected update payload: %#v", request)
+		}
+
+		_ = json.NewEncoder(w).Encode(mcpToolsetResponse{
+			ToolsetID:   "toolset-stable",
+			ToolsetName: "renamed",
+			Description: mcpToolsetStringPointer(""),
+			Tools:       []mcpToolsetTool{},
+		})
+	}))
+	defer server.Close()
+
+	resource := testMCPToolsetResource(server)
+	data := MCPToolsetResourceModel{
+		ToolsetID:   types.StringValue("toolset-stable"),
+		ToolsetName: types.StringValue("renamed"),
+		Description: types.StringNull(),
+		Tools:       mcpToolsetToolsValue(),
+	}
+
+	if err := resource.updateMCPToolset(context.Background(), &data); err != nil {
+		t.Fatalf("updateMCPToolset returned error: %v", err)
+	}
+	if got := data.ToolsetID.ValueString(); got != "toolset-stable" {
+		t.Fatalf("update changed toolset ID to %q", got)
+	}
+	if !data.Description.IsNull() {
+		t.Fatalf("empty remote description should normalize to null, got %#v", data.Description)
+	}
+}
+
+func TestUpdateMCPToolsetFailureDoesNotApplyResponseData(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_ = json.NewEncoder(w).Encode(mcpToolsetResponse{ToolsetID: "partial-id", ToolsetName: "partial-name"})
+	}))
+	defer server.Close()
+
+	resource := testMCPToolsetResource(server)
+	data := MCPToolsetResourceModel{
+		ToolsetID:   types.StringValue("toolset-stable"),
+		ToolsetName: types.StringValue("planned-name"),
+		Description: types.StringNull(),
+		Tools:       mcpToolsetToolsValue(),
+	}
+	before := data
+
+	if err := resource.updateMCPToolset(context.Background(), &data); err == nil {
+		t.Fatal("expected update error")
+	}
+	if !reflect.DeepEqual(data, before) {
+		t.Fatalf("failed update applied response data\nwant: %#v\n got: %#v", before, data)
+	}
+}
+
+func TestApplyMCPToolsetResponsePreservesConfiguredEmptyDescription(t *testing.T) {
+	t.Parallel()
+
+	data := MCPToolsetResourceModel{
+		ToolsetID:   types.StringUnknown(),
+		ToolsetName: types.StringValue("empty-description"),
+		Description: types.StringValue(""),
+		Tools:       mcpToolsetToolsValue(),
+	}
+	result := mcpToolsetResponse{
+		ToolsetID:   "toolset-empty-description",
+		ToolsetName: "empty-description",
+		Description: mcpToolsetStringPointer(""),
+		Tools:       []mcpToolsetTool{},
+	}
+
+	if err := applyMCPToolsetResponse(context.Background(), result, "", &data); err != nil {
+		t.Fatalf("applyMCPToolsetResponse returned error: %v", err)
+	}
+	if data.Description.IsNull() || data.Description.ValueString() != "" {
+		t.Fatalf("configured empty description must remain an empty string, got %#v", data.Description)
+	}
+}
+
+func TestDeleteMCPToolsetConvergesOnSuccessAndNotFound(t *testing.T) {
+	t.Parallel()
+
+	for _, statusCode := range []int{http.StatusAccepted, http.StatusNotFound} {
+		statusCode := statusCode
+		t.Run(http.StatusText(statusCode), func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodDelete || r.URL.Path != "/v1/mcp/toolset/toolset-delete" {
+					t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+				}
+				w.WriteHeader(statusCode)
+			}))
+			defer server.Close()
+
+			resource := testMCPToolsetResource(server)
+			if err := resource.deleteMCPToolset(context.Background(), "toolset-delete"); err != nil {
+				t.Fatalf("deleteMCPToolset returned error for %d: %v", statusCode, err)
+			}
+		})
+	}
+}
+
+func TestDeleteMCPToolsetPropagatesNonNotFoundFailure(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "request failed", http.StatusBadGateway)
+	}))
+	defer server.Close()
+
+	resource := testMCPToolsetResource(server)
+	if err := resource.deleteMCPToolset(context.Background(), "toolset-delete"); err == nil {
+		t.Fatal("expected delete error")
+	}
+}
+
+func TestMCPToolsetSpecialIDUsesSingleEscapedPathSegment(t *testing.T) {
+	t.Parallel()
+
+	toolsetID := "tenant:admin toolset?revision=1"
+	var requestURI string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestURI = r.RequestURI
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(mcpToolsetResponse{
+			ToolsetID: toolsetID, ToolsetName: "special", Tools: []mcpToolsetTool{},
+		})
+	}))
+	defer server.Close()
+
+	resource := testMCPToolsetResource(server)
+	data := MCPToolsetResourceModel{
+		ToolsetID:   types.StringValue(toolsetID),
+		ToolsetName: types.StringValue("special"),
+		Description: types.StringNull(),
+		Tools:       mcpToolsetToolsValue(),
+	}
+	if err := resource.readMCPToolset(context.Background(), &data); err != nil {
+		t.Fatal(err)
+	}
+	if requestURI != mcpToolsetEndpoint(toolsetID) {
+		t.Fatalf("request URI = %q, want %q", requestURI, mcpToolsetEndpoint(toolsetID))
+	}
+	if !strings.Contains(requestURI, "%3F") || !strings.Contains(requestURI, "tenant:admin") {
+		t.Fatalf("special ID was not safely represented as one path segment: %q", requestURI)
+	}
+}
+
+func TestMCPToolsetSlashIDFailsBeforeDispatch(t *testing.T) {
+	t.Parallel()
+
+	toolsetID := "tenant:admin/toolset?revision=1"
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { requests++ }))
+	defer server.Close()
+
+	resource := testMCPToolsetResource(server)
+	data := MCPToolsetResourceModel{
+		ToolsetID:   types.StringValue(toolsetID),
+		ToolsetName: types.StringValue("special"),
+		Description: types.StringNull(),
+		Tools:       mcpToolsetToolsValue(),
+	}
+	if err := resource.readMCPToolset(context.Background(), &data); err == nil || requests != 0 {
+		t.Fatalf("slash ID result: err=%v requests=%d", err, requests)
+	}
+	if err := resource.deleteMCPToolset(context.Background(), toolsetID); err == nil || requests != 0 {
+		t.Fatalf("slash ID delete result: err=%v requests=%d", err, requests)
+	}
+}
+
+func TestMCPToolsetReadRemovesExternallyDeletedResourceFromState(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	underTest := testMCPToolsetResource(server)
+	state := mcpToolsetTestState(t, MCPToolsetResourceModel{
+		ToolsetID:   types.StringValue("toolset-gone"),
+		ToolsetName: types.StringValue("gone"),
+		Description: types.StringNull(),
+		Tools:       mcpToolsetToolsValue(),
+	})
+	resp := resource.ReadResponse{State: state}
+	underTest.Read(context.Background(), resource.ReadRequest{State: state}, &resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("read returned diagnostics for a missing toolset: %v", resp.Diagnostics.Errors())
+	}
+	if !resp.State.Raw.IsNull() {
+		t.Fatalf("missing toolset remained in state: %#v", resp.State.Raw)
+	}
+}
+
+func TestMCPToolsetReadFailureLeavesResourceInState(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "request failed", http.StatusBadGateway)
+	}))
+	defer server.Close()
+
+	underTest := testMCPToolsetResource(server)
+	state := mcpToolsetTestState(t, MCPToolsetResourceModel{
+		ToolsetID:   types.StringValue("toolset-still-present"),
+		ToolsetName: types.StringValue("prior-name"),
+		Description: types.StringNull(),
+		Tools:       mcpToolsetToolsValue(),
+	})
+	resp := resource.ReadResponse{State: state}
+	underTest.Read(context.Background(), resource.ReadRequest{State: state}, &resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected read diagnostic")
+	}
+	if resp.State.Raw.IsNull() {
+		t.Fatal("non-404 read failure removed resource from state")
+	}
+}
+
+func TestMCPToolsetImportStoresToolsetIDForRefresh(t *testing.T) {
+	t.Parallel()
+
+	underTest := &MCPToolsetResource{}
+	state := mcpToolsetTestState(t, MCPToolsetResourceModel{
+		ToolsetID:   types.StringNull(),
+		ToolsetName: types.StringNull(),
+		Description: types.StringNull(),
+		Tools:       types.SetNull(types.ObjectType{AttrTypes: mcpToolsetToolAttributeTypes}),
+	})
+	resp := resource.ImportStateResponse{State: state}
+	underTest.ImportState(context.Background(), resource.ImportStateRequest{ID: "toolset-imported"}, &resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("import returned diagnostics: %v", resp.Diagnostics.Errors())
+	}
+	var imported MCPToolsetResourceModel
+	if diags := resp.State.Get(context.Background(), &imported); diags.HasError() {
+		t.Fatalf("decode imported state: %v", diags.Errors())
+	}
+	if got := imported.ToolsetID.ValueString(); got != "toolset-imported" {
+		t.Fatalf("imported toolset ID = %q, want toolset-imported", got)
+	}
+}
+
+func mcpToolsetToolValue(serverID, toolName string) types.Object {
+	return types.ObjectValueMust(mcpToolsetToolAttributeTypes, map[string]attr.Value{
+		"server_id": types.StringValue(serverID),
+		"tool_name": types.StringValue(toolName),
+	})
+}
+
+func mcpToolsetToolsValue(tools ...mcpToolsetTool) types.Set {
+	values := make([]attr.Value, 0, len(tools))
+	for _, tool := range tools {
+		values = append(values, mcpToolsetToolValue(tool.ServerID, tool.ToolName))
+	}
+	return types.SetValueMust(types.ObjectType{AttrTypes: mcpToolsetToolAttributeTypes}, values)
+}
+
+func testMCPToolsetResource(server *httptest.Server) *MCPToolsetResource {
+	return &MCPToolsetResource{
+		client: &Client{
+			APIBase:    server.URL,
+			APIKey:     "test-key",
+			HTTPClient: server.Client(),
+		},
+		createRecoveryDelay: time.Millisecond,
+	}
+}
+
+func mcpToolsetTestState(t *testing.T, model MCPToolsetResourceModel) tfsdk.State {
+	t.Helper()
+
+	underTest := &MCPToolsetResource{}
+	var schemaResp resource.SchemaResponse
+	underTest.Schema(context.Background(), resource.SchemaRequest{}, &schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("schema returned diagnostics: %v", schemaResp.Diagnostics.Errors())
+	}
+
+	state := tfsdk.State{Schema: schemaResp.Schema}
+	if diags := state.Set(context.Background(), &model); diags.HasError() {
+		t.Fatalf("initialize state: %v", diags.Errors())
+	}
+	return state
+}
+
+func mcpToolsetStringPointer(value string) *string {
+	return &value
+}
+
+// Unknown values must fail closed before dispatch instead of serializing to
+// empty or omitted wire values.
+func TestBuildMCPToolsetRequestRejectsUnknownValues(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	toolType := types.ObjectType{AttrTypes: mcpToolsetToolAttributeTypes}
+
+	base := func() MCPToolsetResourceModel {
+		return MCPToolsetResourceModel{
+			ToolsetName: types.StringValue("toolset"),
+			Description: types.StringNull(),
+			Tools:       types.SetNull(toolType),
+		}
+	}
+
+	name := base()
+	name.ToolsetName = types.StringUnknown()
+	if _, err := buildMCPToolsetRequest(ctx, &name, false); err == nil {
+		t.Fatal("unknown toolset_name did not fail closed")
+	}
+
+	description := base()
+	description.Description = types.StringUnknown()
+	if _, err := buildMCPToolsetRequest(ctx, &description, false); err == nil {
+		t.Fatal("unknown description did not fail closed")
+	}
+
+	tool := base()
+	toolValue, diags := types.ObjectValue(mcpToolsetToolAttributeTypes, map[string]attr.Value{
+		"server_id": types.StringValue("server"),
+		"tool_name": types.StringUnknown(),
+	})
+	if diags.HasError() {
+		t.Fatal(diags.Errors())
+	}
+	tools, diags := types.SetValue(toolType, []attr.Value{toolValue})
+	if diags.HasError() {
+		t.Fatal(diags.Errors())
+	}
+	tool.Tools = tools
+	if _, err := buildMCPToolsetRequest(ctx, &tool, false); err == nil {
+		t.Fatal("unknown tool attribute did not fail closed")
+	}
+}
+
+// confirmMCPToolsetDefinition accepts exact matches (tolerating duplicate and
+// unordered response tools) and rejects any name, description, or membership
+// divergence.
+func TestConfirmMCPToolsetDefinition(t *testing.T) {
+	t.Parallel()
+	description := "desc"
+	request := mcpToolsetRequest{
+		ToolsetName: "toolset",
+		Description: &description,
+		Tools: []mcpToolsetTool{
+			{ServerID: "server-a", ToolName: "tool-1"},
+			{ServerID: "server-b", ToolName: "tool-2"},
+		},
+	}
+	match := mcpToolsetResponse{
+		ToolsetID:   "toolset-1",
+		ToolsetName: "toolset",
+		Description: &description,
+		Tools: []mcpToolsetTool{
+			{ServerID: "server-b", ToolName: "tool-2"},
+			{ServerID: "server-a", ToolName: "tool-1"},
+			{ServerID: "server-a", ToolName: "tool-1"},
+		},
+	}
+	if err := confirmMCPToolsetDefinition(request, match); err != nil {
+		t.Fatalf("exact definition rejected: %v", err)
+	}
+
+	wrongName := match
+	wrongName.ToolsetName = "other"
+	if err := confirmMCPToolsetDefinition(request, wrongName); err == nil {
+		t.Fatal("wrong name accepted")
+	}
+
+	wrongDescription := match
+	other := "other"
+	wrongDescription.Description = &other
+	if err := confirmMCPToolsetDefinition(request, wrongDescription); err == nil {
+		t.Fatal("wrong description accepted")
+	}
+
+	missingTools := match
+	missingTools.Tools = []mcpToolsetTool{{ServerID: "server-a", ToolName: "tool-1"}}
+	if err := confirmMCPToolsetDefinition(request, missingTools); err == nil {
+		t.Fatal("missing tool membership accepted")
+	}
+
+	nilDescriptionRequest := request
+	nilDescriptionRequest.Description = nil
+	nilResponse := match
+	nilResponse.Description = nil
+	if err := confirmMCPToolsetDefinition(nilDescriptionRequest, nilResponse); err != nil {
+		t.Fatalf("nil description pair rejected: %v", err)
+	}
+	empty := ""
+	nilResponse.Description = &empty
+	if err := confirmMCPToolsetDefinition(nilDescriptionRequest, nilResponse); err != nil {
+		t.Fatalf("nil request description with empty response rejected: %v", err)
+	}
+}
+
+// A status-bearing terminal answer stops recovery immediately instead of
+// burning the bounded retry budget, and a canceled context stops the backoff
+// wait promptly.
+func TestRecoverMCPToolsetByNameStopsOnTerminalAndCanceled(t *testing.T) {
+	t.Parallel()
+
+	var terminalRequests atomic.Int64
+	terminalServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		terminalRequests.Add(1)
+		http.Error(w, "forbidden", http.StatusForbidden)
+	}))
+	defer terminalServer.Close()
+	underTest := &MCPToolsetResource{client: &Client{APIBase: terminalServer.URL, APIKey: "admin", HTTPClient: terminalServer.Client()}, createRecoveryDelay: time.Second}
+	data := MCPToolsetResourceModel{ToolsetName: types.StringValue("toolset")}
+	if _, err := underTest.recoverMCPToolsetByName(context.Background(), "toolset", nil, &data); err == nil {
+		t.Fatal("terminal response did not fail recovery")
+	}
+	if got := terminalRequests.Load(); got != 1 {
+		t.Fatalf("terminal response was retried: %d requests", got)
+	}
+
+	var transientRequests atomic.Int64
+	transientServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		transientRequests.Add(1)
+		http.Error(w, "unavailable", http.StatusServiceUnavailable)
+	}))
+	defer transientServer.Close()
+	underTest = &MCPToolsetResource{client: &Client{APIBase: transientServer.URL, APIKey: "admin", HTTPClient: transientServer.Client()}, createRecoveryDelay: time.Hour}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	start := time.Now()
+	if _, err := underTest.recoverMCPToolsetByName(ctx, "toolset", nil, &data); err == nil {
+		t.Fatal("canceled context did not fail recovery")
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("canceled context waited %s in backoff", elapsed)
+	}
+}
+
+// Read repair (nil definition) adopts a drifted remote definition as
+// ordinary drift instead of refusing recovery.
+func TestRecoverMCPToolsetByNameWithoutDefinitionAdoptsDrift(t *testing.T) {
+	t.Parallel()
+	drifted := mcpToolsetResponse{ToolsetID: "toolset-1", ToolsetName: "toolset", Tools: []mcpToolsetTool{{ServerID: "server-x", ToolName: "tool-x"}}}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v1/mcp/toolset":
+			_ = json.NewEncoder(w).Encode([]mcpToolsetResponse{drifted})
+		case "/v1/mcp/toolset/toolset-1":
+			_ = json.NewEncoder(w).Encode(drifted)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	underTest := &MCPToolsetResource{client: &Client{APIBase: server.URL, APIKey: "admin", HTTPClient: server.Client()}, createRecoveryDelay: time.Millisecond}
+	data := MCPToolsetResourceModel{ToolsetName: types.StringValue("toolset")}
+	recovered, err := underTest.recoverMCPToolsetByName(context.Background(), "toolset", nil, &data)
+	if err != nil {
+		t.Fatalf("drift adoption failed: %v", err)
+	}
+	if recovered.ToolsetID.ValueString() != "toolset-1" || len(recovered.Tools.Elements()) != 1 {
+		t.Fatalf("recovered = %#v, want drifted remote definition", recovered)
+	}
+}

--- a/internal/provider/resource_team.go
+++ b/internal/provider/resource_team.go
@@ -72,6 +72,7 @@ type TeamResourceModel struct {
 	TeamMemberRPMLimit    types.Int64   `tfsdk:"team_member_rpm_limit"`
 	TeamMemberTPMLimit    types.Int64   `tfsdk:"team_member_tpm_limit"`
 	RouterSettings        types.Object  `tfsdk:"router_settings"`
+	MCPToolsetIDs         types.Set     `tfsdk:"mcp_toolset_ids"`
 }
 
 func teamChangedFieldMismatch(desired, prior, actual TeamResourceModel) (string, bool) {
@@ -102,6 +103,7 @@ func teamChangedFieldMismatch(desired, prior, actual TeamResourceModel) (string,
 		{"team_member_rpm_limit", desired.TeamMemberRPMLimit, prior.TeamMemberRPMLimit, actual.TeamMemberRPMLimit},
 		{"team_member_tpm_limit", desired.TeamMemberTPMLimit, prior.TeamMemberTPMLimit, actual.TeamMemberTPMLimit},
 		{"router_settings", desired.RouterSettings, prior.RouterSettings, actual.RouterSettings},
+		{"mcp_toolset_ids", desired.MCPToolsetIDs, prior.MCPToolsetIDs, actual.MCPToolsetIDs},
 	} {
 		if !field.desired.IsUnknown() && !field.desired.Equal(field.prior) && !field.desired.Equal(field.actual) {
 			return field.name, true
@@ -145,6 +147,7 @@ func partialTeamState(teamID string) TeamResourceModel {
 		ID:                    types.StringValue(teamID),
 		TeamID:                types.StringValue(teamID),
 		AccessGroupIDs:        types.SetNull(types.StringType),
+		MCPToolsetIDs:         types.SetNull(types.StringType),
 		Metadata:              types.MapNull(types.StringType),
 		MetadataJSON:          types.StringNull(),
 		Models:                types.ListNull(types.StringType),
@@ -219,7 +222,7 @@ func (r *TeamResource) Metadata(ctx context.Context, req resource.MetadataReques
 func (r *TeamResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Description: "Manages a LiteLLM team.",
-		Version:     1,
+		Version:     2,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: "The unique identifier for this team.",
@@ -252,6 +255,14 @@ func (r *TeamResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 				Description: "Access group IDs associated with this team. Order is ignored. Set an empty collection to detach all access groups.",
 				Optional:    true,
 				Computed:    true,
+				ElementType: types.StringType,
+				Validators: []validator.Set{
+					setvalidator.ValueStringsAre(stringvalidator.LengthAtLeast(1)),
+				},
+			},
+			"mcp_toolset_ids": schema.SetAttribute{
+				Description: "MCP toolset IDs allowed for keys in this team. LiteLLM treats a nonempty set as a ceiling, not an inherited grant; a null or empty set imposes no ceiling, so an empty set removes the ceiling rather than denying all toolsets. Omit this attribute to leave the remote value unmanaged.",
+				Optional:    true,
 				ElementType: types.StringType,
 				Validators: []validator.Set{
 					setvalidator.ValueStringsAre(stringvalidator.LengthAtLeast(1)),
@@ -824,6 +835,10 @@ func (r *TeamResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		memberBudgetReinsert = reinsert
 	}
 
+	// LiteLLM persists object_permission before the team row, so a dispatched
+	// update that carries assignments may commit partially and must retain
+	// prior state until an authoritative readback confirms convergence.
+	_, assignmentMutation := teamReq["object_permission"]
 	pendingMember := changedTeamPendingMemberDefaults(data, state, teamReq)
 	clearReq := extractTeamMemberBudgetClears(teamReq, data.ID.ValueString())
 	pendingMemberPrivate, err := encodeTeamPendingMemberDefaults(ctx, pendingMember)
@@ -856,7 +871,7 @@ func (r *TeamResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	if err := r.client.DoRequestWithResponse(ctx, http.MethodPost, "/team/update", teamReq, nil); err != nil {
 		dispatched := ClassifyHTTPFailure(err).RequestDispatched
 		memberRecovery := len(pendingMember) != 0 && (memberDefaultsMayHaveCommitted || dispatched)
-		if metadataChanged || clearReq != nil || memberRecovery {
+		if metadataChanged || clearReq != nil || memberRecovery || (assignmentMutation && dispatched) {
 			retainPrior(context.WithoutCancel(ctx), dispatched, memberRecovery)
 			resp.Diagnostics.AddError("Team Update Not Confirmed", "The team update may have partially committed, but its complete outcome was not confirmed. Prior public and private state were retained.")
 		} else {
@@ -880,7 +895,7 @@ func (r *TeamResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		readOwnership.expectMemberBudgetID = memberBudgetReinsert
 	}
 	if err := r.readTeamWithOwnership(ctx, &data, false, readOwnership); err != nil {
-		if metadataChanged || clearReq != nil || memberDefaultsMayHaveCommitted {
+		if metadataChanged || clearReq != nil || memberDefaultsMayHaveCommitted || assignmentMutation {
 			retainPrior(context.WithoutCancel(ctx), true, memberDefaultsMayHaveCommitted)
 		}
 		resp.Diagnostics.AddError("Team Update Readback Failed", "LiteLLM accepted the update, but authoritative identity-bound readback did not confirm convergence. Prior state was retained.")
@@ -888,10 +903,18 @@ func (r *TeamResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	}
 	preserveTeamMutationRepresentations(planned, &data)
 	if _, mismatch := teamChangedFieldMismatch(planned, state, data); mismatch {
-		if metadataChanged || clearReq != nil || memberDefaultsMayHaveCommitted {
+		if metadataChanged || clearReq != nil || memberDefaultsMayHaveCommitted || assignmentMutation {
 			retainPrior(context.WithoutCancel(ctx), true, memberDefaultsMayHaveCommitted)
 		}
 		resp.Diagnostics.AddError("Team Update Did Not Converge", "LiteLLM accepted the update, but authoritative readback did not match the plan. Prior state was retained.")
+		return
+	}
+	// The changed-field comparison skips fields equal to prior state, but a
+	// dispatched assignment payload must converge even when the configured set
+	// did not change, because a partial write can drop the ceiling silently.
+	if assignmentMutation && !data.MCPToolsetIDs.Equal(planned.MCPToolsetIDs) {
+		retainPrior(context.WithoutCancel(ctx), true, memberDefaultsMayHaveCommitted)
+		resp.Diagnostics.AddError("MCP Toolset Assignment Did Not Converge", "LiteLLM accepted the team update, but authoritative readback did not match the planned toolset assignments. Prior state was retained.")
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -949,19 +972,25 @@ func (r *TeamResource) ImportState(ctx context.Context, req resource.ImportState
 	}
 }
 
+// UpgradeState handles direct migrations to schema v2. Version 0 initializes
+// metadata_json as an unconfigured null; every prior version initializes
+// mcp_toolset_ids as an unmanaged null and preserves the other attributes.
 func (r *TeamResource) UpgradeState(context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{0: {PriorSchema: nil, StateUpgrader: func(_ context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-		if req.RawState == nil {
-			resp.Diagnostics.AddError("Unable to Upgrade State", "Prior team state is unavailable.")
-			return
-		}
-		upgraded, err := marshalTeamUpgrade(req.RawState.JSON)
-		if err != nil {
-			resp.Diagnostics.AddError("Unable to Upgrade State", "Prior team state could not be decoded safely.")
-			return
-		}
-		resp.DynamicValue = &tfprotov6.DynamicValue{JSON: upgraded}
-	}}}
+	upgrade := func(resetMetadataJSON bool) resource.StateUpgrader {
+		return resource.StateUpgrader{PriorSchema: nil, StateUpgrader: func(_ context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+			if req.RawState == nil {
+				resp.Diagnostics.AddError("Unable to Upgrade State", "Prior team state is unavailable.")
+				return
+			}
+			upgraded, err := marshalTeamUpgrade(req.RawState.JSON, resetMetadataJSON)
+			if err != nil {
+				resp.Diagnostics.AddError("Unable to Upgrade State", "Prior team state could not be decoded safely.")
+				return
+			}
+			resp.DynamicValue = &tfprotov6.DynamicValue{JSON: upgraded}
+		}}
+	}
+	return map[int64]resource.StateUpgrader{0: upgrade(true), 1: upgrade(false)}
 }
 
 func (r *TeamResource) buildTeamRequest(ctx context.Context, data *TeamResourceModel, teamID string) (map[string]interface{}, error) {
@@ -1123,6 +1152,9 @@ func (r *TeamResource) buildTeamRequest(ctx context.Context, data *TeamResourceM
 		teamReq["router_settings"] = routerSettings
 	} else if data.RouterSettings.IsNull() {
 		teamReq["router_settings"] = map[string]interface{}{}
+	}
+	if toolsetDiagnostics := addMCPToolsetIDsToRequest(ctx, teamReq, data.MCPToolsetIDs); toolsetDiagnostics.HasError() {
+		return nil, fmt.Errorf("invalid mcp_toolset_ids collection")
 	}
 
 	return teamReq, nil

--- a/internal/provider/resource_team_semantic_dictionary.go
+++ b/internal/provider/resource_team_semantic_dictionary.go
@@ -617,11 +617,16 @@ func partialTeamSemanticRecoveryState(identity string) TeamResourceModel {
 	return partialTeamState(identity)
 }
 
-func marshalTeamUpgrade(raw []byte) ([]byte, error) {
+func marshalTeamUpgrade(raw []byte, resetMetadataJSON bool) ([]byte, error) {
 	var prior map[string]json.RawMessage
 	if err := json.Unmarshal(raw, &prior); err != nil {
 		return nil, err
 	}
-	prior["metadata_json"] = json.RawMessage("null")
+	if resetMetadataJSON {
+		prior["metadata_json"] = json.RawMessage("null")
+	}
+	if _, present := prior["mcp_toolset_ids"]; !present {
+		prior["mcp_toolset_ids"] = json.RawMessage("null")
+	}
 	return json.Marshal(prior)
 }

--- a/internal/provider/resource_team_semantic_dictionary_protocol_test.go
+++ b/internal/provider/resource_team_semantic_dictionary_protocol_test.go
@@ -38,8 +38,8 @@ func TestTeamSemanticSchemaAndDirectUpgradeProtocol(t *testing.T) {
 	defer server.Close()
 	protocolServer, schemas := configuredImportProtocolServer(t, ctx, server.URL)
 	schema := schemas.ResourceSchemas["litellm_team"]
-	if schema.Version != 1 {
-		t.Fatalf("schema version=%d want=1", schema.Version)
+	if schema.Version != 2 {
+		t.Fatalf("schema version=%d want=2", schema.Version)
 	}
 	raw, _ := json.Marshal(map[string]interface{}{"id": "team-upgrade", "team_id": "team-upgrade", "team_alias": "alias", "metadata": map[string]interface{}{"legacy": "keep"}})
 	upgraded, err := protocolServer.UpgradeResourceState(ctx, &tfprotov6.UpgradeResourceStateRequest{TypeName: "litellm_team", Version: 0, RawState: &tfprotov6.RawState{JSON: raw}})

--- a/internal/provider/resource_team_semantic_dictionary_test.go
+++ b/internal/provider/resource_team_semantic_dictionary_test.go
@@ -17,8 +17,8 @@ func TestTeamSemanticSchemaAndDirectUpgrade(t *testing.T) {
 	resourceUnderTest := &TeamResource{}
 	var schemaResponse frameworkresource.SchemaResponse
 	resourceUnderTest.Schema(ctx, frameworkresource.SchemaRequest{}, &schemaResponse)
-	if schemaResponse.Schema.Version != 1 {
-		t.Fatalf("schema version=%d want=1", schemaResponse.Schema.Version)
+	if schemaResponse.Schema.Version != 2 {
+		t.Fatalf("schema version=%d want=2", schemaResponse.Schema.Version)
 	}
 	attribute, ok := schemaResponse.Schema.Attributes["metadata_json"].(resourceschema.StringAttribute)
 	if !ok || !attribute.Optional || !attribute.Computed || !attribute.Sensitive || attribute.Required {

--- a/internal/provider/team_response.go
+++ b/internal/provider/team_response.go
@@ -142,6 +142,11 @@ func projectTeamInfoResponseWithSemantic(ctx context.Context, prior TeamResource
 	}
 	next.AccessGroupIDs = projectTeamSet(prior.AccessGroupIDs, accessGroups, presence)
 
+	next.MCPToolsetIDs, err = readMCPToolsetIDs(ctx, teamInfo, prior.MCPToolsetIDs, imported)
+	if err != nil {
+		return prior, err
+	}
+
 	for _, field := range []struct {
 		name   string
 		target *types.Int64

--- a/internal_testing/README.md
+++ b/internal_testing/README.md
@@ -132,6 +132,7 @@ internal_testing/
     guardrail_full.tf
     mcp_server_minimal.tf
     mcp_server_full.tf
+    mcp_toolset.tf                  # populated and empty toolset definitions
     vector_store_minimal.tf
     vector_store_full.tf
     search_tool_minimal.tf
@@ -194,7 +195,7 @@ make smoke resources=model_minimal.tf
 make smoke resources=agent_minimal.tf datasources=agent.tf,agents_list.tf
 ```
 
-The explicit acceptance matrix covers 23 of 24 resources; `litellm_project` is
+The explicit acceptance matrix covers 24 of 25 resources; `litellm_project` is
 excluded because its endpoint requires LiteLLM Enterprise. Credential coverage
 includes non-empty values-only, heterogeneous legacy/JSON, true model-only,
 full/by-name and by-model data sources, a two-apply nested update/removal case,

--- a/internal_testing/acceptance.sh
+++ b/internal_testing/acceptance.sh
@@ -224,6 +224,7 @@ rm -f "$mcp_evidence"
 SMOKE_MCP_EVIDENCE=$mcp_evidence run_mcp_import_case
 emit_controlled_record import litellm_mcp_server passed '' '' "$mcp_evidence"
 rm -f "$mcp_evidence"
+run_case mcp_toolset resources mcp_server_minimal.tf,mcp_toolset.tf
 run_case model resources model_minimal.tf datasources model.tf,models_list.tf
 run_case model_semantic_json resources model_semantic_json.tf
 run_case model_params_semantic_json resources model_params_semantic_json.tf
@@ -247,5 +248,5 @@ run_case vector_store resources vector_store_minimal.tf datasources vector_store
 if [ "$ASSEMBLY_ONLY" = "1" ]; then
   printf '\nAcceptance assembly passed: every matrix case produced collision-free, parseable HCL.\n'
 else
-  printf '\nAcceptance passed: 23/24 resources (project is enterprise-only).\n'
+  printf '\nAcceptance passed: 24/25 resources (project is enterprise-only).\n'
 fi

--- a/internal_testing/resources/mcp_toolset.tf
+++ b/internal_testing/resources/mcp_toolset.tf
@@ -1,0 +1,36 @@
+# litellm_mcp_toolset - Populated and empty definitions
+
+resource "litellm_mcp_toolset" "populated" {
+  toolset_name = "test-mcp-toolset-populated"
+  description  = "Acceptance lifecycle toolset"
+
+  tools = [
+    {
+      server_id = litellm_mcp_server.minimal.id
+      tool_name = "test_tool"
+    }
+  ]
+}
+
+resource "litellm_mcp_toolset" "empty" {
+  toolset_name = "test-mcp-toolset-empty"
+}
+
+resource "litellm_team" "mcp_toolset" {
+  team_alias      = "test-mcp-toolset-team"
+  mcp_toolset_ids = [litellm_mcp_toolset.populated.toolset_id]
+}
+
+resource "litellm_key" "mcp_toolset" {
+  key_alias       = "test-mcp-toolset-key"
+  team_id         = litellm_team.mcp_toolset.id
+  mcp_toolset_ids = [litellm_mcp_toolset.populated.toolset_id]
+}
+
+output "mcp_toolset_populated_id" {
+  value = litellm_mcp_toolset.populated.toolset_id
+}
+
+output "mcp_toolset_empty_id" {
+  value = litellm_mcp_toolset.empty.toolset_id
+}

--- a/internal_testing/upgrade_matrix/harness.py
+++ b/internal_testing/upgrade_matrix/harness.py
@@ -93,6 +93,7 @@ ASSERTION_CODES = {
 MODERN_MANDATORY_SKIPS = {
     ("resource_coverage", "litellm_project", "enterprise-license-required"),
     ("upgrade", "litellm_jwt_key_mapping", "previous-release-resource-unavailable"),
+    ("upgrade", "litellm_mcp_toolset", "previous-release-resource-unavailable"),
     ("upgrade", "litellm_project", "enterprise-license-required"),
     ("lifecycle", "litellm_project", "enterprise-license-required"),
     ("import", "litellm_agent", "role-redacted-state-requires-admin"),
@@ -309,8 +310,8 @@ def check_inventory(matrix: dict) -> None:
     resources = matrix["resources"]
     expected_resources = {item["type"] for item in resources}
     expected_data_sources = set(matrix["data_sources"])
-    if len(resources) != 24 or len(expected_resources) != 24:
-        raise HarnessError("resource inventory must contain exactly 24 unique types")
+    if len(resources) != 25 or len(expected_resources) != 25:
+        raise HarnessError("resource inventory must contain exactly 25 unique types")
     if len(matrix["data_sources"]) != 35 or len(expected_data_sources) != 35:
         raise HarnessError("data-source inventory must contain exactly 35 unique types")
     if expected_resources != provider_types("", "resource"):
@@ -321,7 +322,7 @@ def check_inventory(matrix: dict) -> None:
     introduced = {item["type"] for item in resources if item.get("introduced_after_previous")}
     if matrix.get("non_importable_resources") != [] or actions != sorted(matrix.get("action_resources", [])):
         raise HarnessError("importable/action resource accounting is incomplete")
-    if introduced != {"litellm_jwt_key_mapping"}:
+    if introduced != {"litellm_jwt_key_mapping", "litellm_mcp_toolset"}:
         raise HarnessError("post-v2.0.1 resource accounting is incomplete")
     for item in resources:
         for required in ("fixture", "address", "import_expression", "lane", "action"):
@@ -343,20 +344,20 @@ def check_inventory(matrix: dict) -> None:
     )}:
         raise HarnessError("fallback lifecycle skip contract changed without review")
     expected_counts = {
-        "resource_coverage": 24, "upgrade": 24, "lifecycle": 24, "import": 24,
-        "drift": 24, "replacement": 3, "failure_recovery": 2,
+        "resource_coverage": 25, "upgrade": 25, "lifecycle": 25, "import": 25,
+        "drift": 25, "replacement": 3, "failure_recovery": 2,
         "data_source": 35, "documentation": 3,
     }
     if matrix.get("scenario_counts") != expected_counts:
         raise HarnessError("scenario count contract changed without explicit accounting")
-    if sum(expected_counts.values()) + len(matrix.get("optional_features", [])) != 166:
-        raise HarnessError("execution matrix must contain exactly 166 independently reviewed scenarios")
+    if sum(expected_counts.values()) + len(matrix.get("optional_features", [])) != 171:
+        raise HarnessError("execution matrix must contain exactly 171 independently reviewed scenarios")
     expected_skips = matrix.get("terraform_1_11_4_expected_skips", [])
     skip_identities = {(item.get("category"), item.get("subject"), item.get("reason")) for item in expected_skips}
     conditional_skips = matrix.get("terraform_1_11_4_conditional_skips", [])
     conditional_identities = {(item.get("category"), item.get("subject"), item.get("reason")) for item in conditional_skips}
-    if len(expected_skips) != 10 or skip_identities != MODERN_MANDATORY_SKIPS:
-        raise HarnessError("modern CLI lanes must have the exact ten independently reviewed mandatory skips")
+    if len(expected_skips) != 11 or skip_identities != MODERN_MANDATORY_SKIPS:
+        raise HarnessError("modern CLI lanes must have the exact eleven independently reviewed mandatory skips")
     if len(conditional_skips) != 2 or conditional_identities != FALLBACK_CONDITIONAL_SKIPS:
         raise HarnessError("fallback conditional skip inventory is not exact")
     for scenario in matrix.get("replacement_scenarios", []):

--- a/internal_testing/upgrade_matrix/matrix.json
+++ b/internal_testing/upgrade_matrix/matrix.json
@@ -14,6 +14,7 @@
     {"type":"litellm_team_member","fixture":["team_minimal.tf","issue210_team_member_v201.tf"],"import_fixture":["team_minimal.tf","issue210_team_member_import.tf"],"address":"litellm_team_member.upgrade","import_expression":"litellm_team_member.upgrade.id","lane":"oss","action":false},
     {"type":"litellm_team_member_add","fixture":["team_minimal.tf","team_member_add_minimal.tf"],"address":"litellm_team_member_add.minimal","import_expression":"composite_team_member_add(litellm_team_member_add.minimal)","lane":"oss","action":false},
     {"type":"litellm_mcp_server","fixture":["mcp_server_minimal.tf"],"address":"litellm_mcp_server.minimal","import_expression":"litellm_mcp_server.minimal.id","lane":"oss","action":false},
+    {"type":"litellm_mcp_toolset","fixture":["mcp_server_minimal.tf","mcp_toolset.tf"],"address":"litellm_mcp_toolset.populated","import_expression":"litellm_mcp_toolset.populated.toolset_id","lane":"oss","action":false,"introduced_after_previous":true,"limitations":["previous-release-resource-unavailable"]},
     {"type":"litellm_credential","fixture":["issue210_credential_v201.tf"],"import_fixture":["issue210_credential_import.tf"],"address":"litellm_credential.upgrade","import_expression":"litellm_credential.upgrade.id","import_stale_outputs":["issue210_credential_upgrade_id"],"lane":"oss","action":false,"limitations":["masked-values-metadata-only-import"]},
     {"type":"litellm_vector_store","fixture":["vector_store_minimal.tf"],"address":"litellm_vector_store.minimal","import_expression":"litellm_vector_store.minimal.id","lane":"oss","action":false},
     {"type":"litellm_organization","fixture":["organization_minimal.tf"],"address":"litellm_organization.minimal","import_expression":"litellm_organization.minimal.id","lane":"oss","action":false},
@@ -43,11 +44,11 @@
     "litellm_prompts":"inventory-endpoint-may-be-unavailable"
   },
   "scenario_counts": {
-    "resource_coverage":24,
-    "upgrade":24,
-    "lifecycle":24,
-    "import":24,
-    "drift":24,
+    "resource_coverage":25,
+    "upgrade":25,
+    "lifecycle":25,
+    "import":25,
+    "drift":25,
     "replacement":3,
     "failure_recovery":2,
     "data_source":35,
@@ -72,12 +73,12 @@
     }
   },
   "upgrade_expected_schema_migrations": {
-    "litellm_key": [1, 2],
+    "litellm_key": [1, 3],
     "litellm_key_block": [0, 1],
     "litellm_mcp_server": [1, 8],
     "litellm_organization": [0, 1],
     "litellm_project": [0, 1],
-    "litellm_team": [0, 1]
+    "litellm_team": [0, 2]
   },
   "upgrade_expected_identity_migrations": {
     "litellm_key_block": "sha256-of-prior-id"
@@ -109,6 +110,7 @@
   "terraform_1_11_4_expected_skips": [
     {"category":"resource_coverage","subject":"litellm_project","reason":"enterprise-license-required"},
     {"category":"upgrade","subject":"litellm_jwt_key_mapping","reason":"previous-release-resource-unavailable"},
+    {"category":"upgrade","subject":"litellm_mcp_toolset","reason":"previous-release-resource-unavailable"},
     {"category":"upgrade","subject":"litellm_project","reason":"enterprise-license-required"},
     {"category":"lifecycle","subject":"litellm_project","reason":"enterprise-license-required"},
     {"category":"import","subject":"litellm_agent","reason":"role-redacted-state-requires-admin"},

--- a/internal_testing/upgrade_matrix/tests/test_harness.py
+++ b/internal_testing/upgrade_matrix/tests/test_harness.py
@@ -36,10 +36,10 @@ class HarnessTests(unittest.TestCase):
     def test_inventory_and_assembly_contract(self):
         matrix = harness.load_json(harness.MATRIX_PATH)
         harness.check_inventory(matrix)
-        self.assertEqual(len(matrix["resources"]), 24)
+        self.assertEqual(len(matrix["resources"]), 25)
         self.assertEqual(len(matrix["data_sources"]), 35)
-        self.assertEqual(sum(matrix["scenario_counts"].values()) + len(matrix["optional_features"]), 166)
-        self.assertEqual(len(matrix["terraform_1_11_4_expected_skips"]), 10)
+        self.assertEqual(sum(matrix["scenario_counts"].values()) + len(matrix["optional_features"]), 171)
+        self.assertEqual(len(matrix["terraform_1_11_4_expected_skips"]), 11)
         self.assertEqual(len(matrix["terraform_1_11_4_conditional_skips"]), 2)
         fallback = next(item for item in matrix["resources"] if item["type"] == "litellm_fallback")
         self.assertEqual(fallback["lifecycle_skip_reason"], "fallback-delete-not-authoritative")
@@ -50,12 +50,12 @@ class HarnessTests(unittest.TestCase):
             {"litellm_agent": ["id"]},
         )
         self.assertEqual(matrix["upgrade_expected_schema_migrations"], {
-            "litellm_key": [1, 2],
+            "litellm_key": [1, 3],
             "litellm_key_block": [0, 1],
             "litellm_mcp_server": [1, 8],
             "litellm_organization": [0, 1],
             "litellm_project": [0, 1],
-            "litellm_team": [0, 1],
+            "litellm_team": [0, 2],
         })
         self.assertEqual(matrix["upgrade_expected_computed_migrations"]["litellm_mcp_server"], [
             "alias", "available_on_public_internet", "byok_description",

--- a/internal_testing/upgrade_matrix/verify_runtime_parity.py
+++ b/internal_testing/upgrade_matrix/verify_runtime_parity.py
@@ -444,6 +444,29 @@ REVIEWED_ISSUE208_TOKEN_EXCHANGE_RUNTIME_DIFF_SHA256 = (
     "50e347c4db02128671bab10b0611592a88180dba2cf84bc176ccb994815d8b09"
 )
 
+REVIEWED_ISSUE207_TOOLSETS_BASE = "f4f369df2180805961d475866296a06c64f3a1c5"
+REVIEWED_ISSUE207_TOOLSETS_PATHS = (
+    "internal/provider/mcp_toolset_assignment_protocol_test.go",
+    "internal/provider/mcp_toolset_assignments.go",
+    "internal/provider/mcp_toolset_assignments_test.go",
+    "internal/provider/mcp_toolset_lifecycle_protocol_test.go",
+    "internal/provider/provider.go",
+    "internal/provider/provider_smoke_test.go",
+    "internal/provider/resource_key.go",
+    "internal/provider/resource_key_semantic_dictionary.go",
+    "internal/provider/resource_key_semantic_dictionary_test.go",
+    "internal/provider/resource_mcp_toolset.go",
+    "internal/provider/resource_mcp_toolset_test.go",
+    "internal/provider/resource_team.go",
+    "internal/provider/resource_team_semantic_dictionary.go",
+    "internal/provider/resource_team_semantic_dictionary_protocol_test.go",
+    "internal/provider/resource_team_semantic_dictionary_test.go",
+    "internal/provider/team_response.go",
+)
+REVIEWED_ISSUE207_TOOLSETS_RUNTIME_DIFF_SHA256 = (
+    "584b1463dfcfb418d0e5a117a1bb647261fdfa97438ce41ff09fb2da96574ef5"
+)
+
 REVIEWED_V198_RELEASE_BASE = "82b1d0ecc2ca413c39a4254c99c7f950268ea7c7"
 REVIEWED_V198_RELEASE_PATHS = (
     'internal/provider/access_group_safe_read_protocol_test.go',
@@ -915,6 +938,12 @@ def main() -> int:
             and digest == REVIEWED_ISSUE208_TOKEN_EXCHANGE_RUNTIME_DIFF_SHA256
         ):
             reviewed = "issue208-token-exchange"
+        elif (
+            comparison == REVIEWED_ISSUE207_TOOLSETS_BASE
+            and changed_paths == REVIEWED_ISSUE207_TOOLSETS_PATHS
+            and digest == REVIEWED_ISSUE207_TOOLSETS_RUNTIME_DIFF_SHA256
+        ):
+            reviewed = "issue207-toolsets"
         elif (
             comparison == REVIEWED_V198_RELEASE_BASE
             and changed_paths == REVIEWED_V198_RELEASE_PATHS


### PR DESCRIPTION
### Summary

Related to #207. LiteLLM 1.98 added MCP toolsets, but this provider could not manage their definitions or assignments. This adds `litellm_mcp_toolset` and `mcp_toolset_ids` on keys and teams.

The resource supports:

- create, read, update, and delete;
- import by `toolset_id`;
- unordered MCP server and tool pairs;
- empty toolsets;
- in-place updates that keep the LiteLLM toolset ID;
- IDs that contain a slash fail before dispatch, matching the reviewed endpoint policy; and
- removal from state when a toolset is deleted outside Terraform.

LiteLLM enforces toolset name uniqueness and generates the toolset ID server side, so an accepted mutation whose response body cannot be validated would otherwise strand a row that blocks every retry with a name conflict. The provider distinguishes the create outcomes explicitly and fails closed on every uncertain shape:

- A rejected create (status-bearing answer) never reads the collection, so the provider cannot adopt a pre-existing toolset through a name conflict.
- An accepted create with an unusable or definition-mismatched response retains a name-bound partial state plus a private accepted-create marker, then recovers the identity through positive exact-name evidence in `GET /v1/mcp/toolset` (context-aware bounded fresh-read retries) and a direct-ID read that must match the requested name, description, and tool membership exactly before it is stored. An empty collection is never absence authority because the pinned `list_mcp_toolsets()` converts database failures to `[]`.
- A dispatched create with no response status is uncertain: the row may or may not exist, and a name match could equally be a lost pre-existing-name race. The provider retains name-bound state without the marker to block a blind duplicate create, and refresh instructs reconciliation (confirm in LiteLLM, import by ID, or remove from state) instead of adopting by name.
- If accepted-create recovery does not complete, the retained marker lets the next refresh converge through the same positive-evidence read repair; identity-free state without the marker never auto-adopts.
- An accepted update is confirmed only through mandatory direct-ID readback that must match the planned definition; a mismatch errors and retains prior state. The mutation envelope is used for acceptance alone.
- Unknown `toolset_name`, `description`, or nested tool values fail closed before dispatch, and recovery stops immediately on terminal answers (401/403/404), canceled contexts, and expired deadlines while retrying only transient or inconclusive probes.

Assignment behavior follows LiteLLM 1.98:

- a key assignment is the effective grant;
- a nonempty team assignment is a ceiling that constrains its keys but is not inherited, and a null or empty team assignment imposes no ceiling, so `[]` removes the ceiling rather than denying all toolsets;
- omitting `mcp_toolset_ids` leaves remote assignments unmanaged;
- setting `mcp_toolset_ids = []` clears only toolset assignments;
- empty-string elements are rejected at plan time, matching `access_group_ids`;
- the key planner compares `mcp_toolset_ids`, so assignment-only plans (update, `[]` clear, and omission-based ownership release) are never suppressed by prior state; and
- assignment mutations are transactional: LiteLLM writes `object_permission` before the key or team row, so an accepted update publishes state only after an authoritative readback confirms the planned assignments, and team convergence now compares `mcp_toolset_ids`. The assignment convergence check is unconditional whenever the dispatched payload carried `object_permission`, so a divergent readback is caught even when the configured set equals prior state and only another field changed. Failed or divergent readbacks retain complete prior public and private state.

`litellm_key` upgrades to schema v3 and `litellm_team` to v2 with direct upgraders from every prior version: upgraded states carry a null (unmanaged) `mcp_toolset_ids` and preserve the other attributes exactly. The upgrade matrix registers `litellm_mcp_toolset` as a post-v2.1.0 resource and expects the key 1→3 and team 0→2 migrations, and `verify_runtime_parity.py` binds the reviewed runtime diff (sorted paths and digest) against the actual PR base.

User assignments are out of scope as a deliberate resource-scope decision. The legacy `/user/info` omits `object_permission`, and the live check confirmed `/v2/user/info` does return it, so a future user-assignment surface is possible but needs its own read-path and ownership design. LiteLLM 1.98 does not support toolset assignments on legacy or unified access groups per the pinned schemas.

### API contract

The provider contract includes the four toolset CRUD operations plus `GET /v1/mcp/toolset`, which backs the accepted-mutation recovery described above. That operation left the reviewed unsupported classification, and the `mcp_toolset_management` category rationale records that the collection backs recovery and is still not exposed as a data source. All manifests, goldens, and pins were regenerated from the pinned source after the rebase; no old hashes or line evidence were retained.

Two pinned raw-identity proofs changed in `internal/contractapi/contract.go`: `keyLookupIdentifier` is re-pinned because `KeyResourceModel` gained the `mcp_toolset_ids` field, which is part of the function's canonical type dependency closure (the function body is unchanged), and `mcpToolsetRecoveredIdentifier` is a new reviewed raw-identity boundary for the recovery path's collection-derived identity.

### Validation

Passed on the current head, rebased onto `issues` at the v2.1.0 tag (`f4f369d`):

- the complete destructive acceptance matrix against the pinned Docker-backed LiteLLM v1.98.0 stack (`TF_ACC=1 make testacc`, 24/25 resources; project is enterprise-only), including the `mcp_toolset` lifecycle with populated and empty toolsets plus key and team assignments;
- tfprotov6 protocol coverage for: rejected/accepted-malformed/interrupted/dispatched-uncertain creates, definition-mismatched create responses recovering the requested row, name-bound partial-state retention and marker-gated read repair, update readback definition mismatches retaining prior state, assignment-only key plans (update, `[]` clear, omission release, semantic composition), key import adoption, key and team assignment mutations with failed or divergent readbacks retaining bytes-equal prior state (including a divergent readback under an unchanged managed assignment), request-side sibling non-fabrication, stale assignments after external toolset deletion, nonempty/empty team ceiling payloads, and direct key v0/v1/v2 and team v0/v1 state upgrades;
- unit coverage for unknown-value fail-closed dispatch, definition confirmation, terminal-answer and canceled-context recovery stops, and read-repair drift adoption, each proven red before the fix and green after;
- `go test -race ./internal/provider ./internal/contractapi`;
- `go vet ./...` and `go build ./...`;
- `make contract-check` against the pinned LiteLLM v1.98 export (the pinned `openapi.json` is unchanged by this PR);
- the upgrade-matrix harness unit tests with the new inventory, counts, and expected schema migrations; and
- `gofmt` and `terraform fmt` checks.
