### PR TITLE
fix(agent): preserve structured parameters and data-source parity

### DIFF
--- a/docs/data-sources/agent.md
+++ b/docs/data-sources/agent.md
@@ -21,8 +21,11 @@ output "agent_name" {
 ## Attribute Reference
 
 * `agent_name` - The name of the agent.
-* `agent_card_params` - The agent card parameters as a flat string map.
-* `litellm_params` - (Sensitive) LiteLLM-specific parameters for the agent. Redacted in normal CLI output but still present in state.
+* `agent_card_params` - (Sensitive) Historical flat `map(string)` compatibility projection; nested card values use deterministic JSON rendering.
+* `agent_card_params_json` - (Sensitive) Canonical lossless JSON for every observable card field, including provider, capabilities, skills, skill security, and ordered signatures.
+* `litellm_params` - (Sensitive) Historical `map(string)` compatibility projection. API strings remain literal; non-string API values use deterministic exact JSON rendering while `litellm_params_json` preserves their authoritative wire types.
+* `litellm_params_json` - (Sensitive) Canonical lossless JSON for every observable heterogeneous LiteLLM parameter.
+* `object_permission_json` - Canonical lossless JSON for every observable permission field, including native MCP tool arrays.
 * `tpm_limit` - Tokens per minute limit.
 * `rpm_limit` - Requests per minute limit.
 * `session_tpm_limit` - Per-session tokens per minute limit.
@@ -35,4 +38,4 @@ output "agent_name" {
 * `created_by` - User who created the agent.
 * `updated_by` - User who last updated the agent.
 
-> **Upgrade note:** `litellm_params` and `static_headers` now propagate Terraform sensitivity. Root outputs exposing them must set `sensitive = true` or deliberately use `nonsensitive(...)`. Use a LiteLLM `PROXY_ADMIN` credential when reading secret-bearing agent configuration; lower-privilege responses redact or omit those fields.
+> **Role and sensitivity note:** Agent-card JSON, both LiteLLM parameter projections, and static headers propagate Terraform sensitivity. Root outputs exposing them must set `sensitive = true` or deliberately use `nonsensitive(...)`. Use a LiteLLM `PROXY_ADMIN` credential for secret-bearing configuration. Present fields are strictly type-validated, but endpoint-observable partial cards do not need the resource-only card `name`/`url` identity pair. A present malformed or unrecoverably masked value fails the read. Fields omitted by role sanitization are reported as null for this data-source read; no prior data-source value is reused.

--- a/docs/data-sources/agents.md
+++ b/docs/data-sources/agents.md
@@ -17,6 +17,13 @@ output "agent_names" {
 * `agents` - List of agents. Each agent has the following attributes:
   * `agent_id` - The unique agent ID.
   * `agent_name` - The name of the agent.
+  * `agent_card_params` - (Sensitive) Historical flat `map(string)` compatibility projection; nested card values use deterministic JSON rendering.
+  * `agent_card_params_json` - (Sensitive) Canonical lossless JSON for every observable card/provider/skill/security/signature field.
+  * `litellm_params` - (Sensitive) Historical `map(string)` compatibility projection; heterogeneous API values use deterministic exact JSON rendering.
+  * `litellm_params_json` - (Sensitive) Canonical lossless JSON for heterogeneous LiteLLM parameters.
+  * `object_permission_json` - Canonical lossless JSON for every observable permission field.
+  * `static_headers` - (Sensitive) Static request headers.
+  * `extra_headers` - Forwarded request-header names.
   * `tpm_limit` - Tokens per minute limit.
   * `rpm_limit` - Requests per minute limit.
   * `session_tpm_limit` - Per-session tokens per minute limit.
@@ -26,3 +33,5 @@ output "agent_names" {
   * `updated_at` - Timestamp when the agent was last updated.
   * `created_by` - User who created the agent.
   * `updated_by` - User who last updated the agent.
+
+Single and list data sources use the same strict projection. Present fields are type-validated, while endpoint-observable partial cards may omit the resource-only card `name`/`url` identity pair. Present malformed values fail the complete read. Role-sanitized omissions are null for that item and never reuse prior data-source state.

--- a/docs/resources/agent.md
+++ b/docs/resources/agent.md
@@ -63,9 +63,16 @@ resource "litellm_agent" "full" {
   session_tpm_limit = 5000
   session_rpm_limit = 50
 
+  # Legacy map values remain literal strings. Use the additive JSON bridge for
+  # heterogeneous nested values; non-overlapping keys from both surfaces merge.
   litellm_params = {
     model = "gpt-4o"
   }
+  litellm_params_json = jsonencode({
+    stream = false
+    retries = 3
+    routing = { regions = ["us-east-1", "us-west-2"] }
+  })
 
   static_headers = {
     "X-Custom-Header" = "value"
@@ -78,7 +85,7 @@ resource "litellm_agent" "full" {
     description      = "An agent that reviews code for quality and best practices"
     url              = "https://agent.example.com/a2a"
     version          = "1.0.0"
-    protocol_version = "0.2.6"
+    protocol_version = "0.3"
 
     default_input_modes  = ["application/json"]
     default_output_modes = ["application/json", "text/plain"]
@@ -107,6 +114,16 @@ resource "litellm_agent" "full" {
       examples    = ["Review this Go function", "Check this Python script"]
       input_modes = ["application/json"]
       output_modes = ["text/plain"]
+      security = [
+        { oauth2 = ["code:read", "code:review"] },
+        { api_key = [] },
+      ]
+    }
+
+    signatures {
+      protected = "eyJhbGciOiJFUzI1NiJ9"
+      signature = "base64url-signature"
+      header    = jsonencode({ kid = "reviewer-key", critical = ["kid"] })
     }
 
     skills {
@@ -137,7 +154,8 @@ resource "litellm_agent" "full" {
 ### Top-level
 
 * `agent_name` - (Required) The name of the agent.
-* `litellm_params` - (Optional, Sensitive) Map of LiteLLM-specific parameters (e.g. `model`, `api_key`). Prefer proxy workload identity over static credentials. Sensitive values remain present in Terraform state.
+* `litellm_params` - (Optional, Sensitive) Legacy `map(string)` of literal LiteLLM parameters. Values such as `"false"`, `"001"`, and JSON-looking text are sent as strings without guessing or coercion.
+* `litellm_params_json` - (Optional, Computed, Sensitive) A lossless JSON object for arbitrary string, boolean, exact number, null, list, and object values. It merges with non-overlapping legacy keys. An overlap is valid only when the JSON value is the identical string; otherwise planning fails. Each explicitly configured JSON key transfers only that key's ownership; legacy-only configurations are not rewritten or silently migrated.
 * `tpm_limit` - (Optional) Tokens per minute limit for the agent.
 * `rpm_limit` - (Optional) Requests per minute limit for the agent.
 * `session_tpm_limit` - (Optional) Per-session tokens per minute limit.
@@ -151,13 +169,20 @@ resource "litellm_agent" "full" {
 * `url` - (Required) The URL endpoint for the agent. Set it to an empty string for provider-backed agents such as Bedrock AgentCore, where LiteLLM derives the endpoint from `litellm_params`.
 * `description` - (Optional) Human-readable description of the agent.
 * `version` - (Optional) Version of the agent.
-* `protocol_version` - (Optional) A2A protocol version (e.g. `0.2.6`).
+* `protocol_version` - (Optional) A2A protocol version. LiteLLM's supported served families are `0.3` and `1.0`; the registry request itself accepts a string, so the provider does not invent a narrower enum.
 * `default_input_modes` - (Optional) List of default input MIME types.
 * `default_output_modes` - (Optional) List of default output MIME types.
 * `preferred_transport` - (Optional) Preferred transport protocol (e.g. `httpsse`, `websocket`).
 * `icon_url` - (Optional) URL for the agent's icon.
 * `documentation_url` - (Optional) URL for the agent's documentation.
 * `supports_authenticated_extended_card` - (Optional) Whether the agent supports an authenticated extended A2A card.
+
+### signatures Block (Optional, repeatable, inside agent_card)
+
+* `protected` - (Required, Sensitive) JWS protected header.
+* `signature` - (Required, Sensitive) JWS signature value.
+* `header` - (Optional, Sensitive) Arbitrary non-null header object encoded as JSON. Exact numbers and nested values are preserved. Conflicts with `header_json`.
+* `header_json` - (Optional, Sensitive) Strict JSON bridge accepting either an object or explicit JSON `null`. Use `header_json = jsonencode(null)` when wire-level null must differ from omission. Conflicts with `header`. Signature order and duplicates are significant; an explicitly empty signatures list clears the list on full-card replacement.
 
 ### capabilities Block (Optional, inside agent_card)
 
@@ -181,6 +206,8 @@ Configured capability values are read authoritatively. If LiteLLM accepts a flag
 * `examples` - (Optional) List of example inputs.
 * `input_modes` - (Optional) List of supported input MIME types.
 * `output_modes` - (Optional) List of supported output MIME types.
+* `security` - (Optional) Ordered non-null `list(map(list(string)))` of A2A security requirements. Requirement and scope ordering and duplicates are preserved; an explicit empty list clears the skill security field. Conflicts with `security_json`.
+* `security_json` - (Optional, Sensitive) Strict JSON bridge accepting either the same ordered security list or explicit JSON `null`. Use `security_json = jsonencode(null)` when wire-level null must differ from omission. Conflicts with `security`.
 
 ### object_permission Block (Optional)
 
@@ -221,12 +248,12 @@ Removing previously configured values emits endpoint-specific clears instead of 
 * `tpm_limit`, `rpm_limit`, `session_tpm_limit`, and `session_rpm_limit` use JSON `null` through `PATCH`.
 * `static_headers` uses `{}` and `extra_headers` uses `[]`.
 * `object_permission` sends empty arrays for MCP servers, MCP access groups, models, and agents, plus an empty object for MCP tool permissions. Removing the whole Terraform block clears only fields Terraform previously owned; imported or otherwise unowned siblings remain remote-owned.
-* Agent-card optional scalars, capabilities, individual provider fields, and nested skill fields/collections are cleared through a complete card replacement. Any card-changing update first samples the authoritative complete card immediately before PATCH, overlays only exact configured/owned changes, and preserves API-owned provider, capability, and skill leaves. Removing an individual Terraform-owned skill sends and confirms its absence; removing a skill with any API-owned leaf is rejected before PATCH. If required preservation or unique nonblank skill identity cannot be proved, PATCH is not sent.
-* Removing keys from `litellm_params` is supported while at least one key remains; the nonempty object replaces the prior parameter document.
+* Agent-card optional scalars, capabilities, signatures, individual provider fields, and nested skill fields/collections are cleared through a complete card replacement. Any card-changing update first samples the raw authoritative complete card immediately before PATCH, overlays only exact configured/owned paths, and preserves all other keys, types, exact numbers, nulls, and omission. Unowned signature headers and skill security never pass through typed reconstruction. Omitting an API-owned skill preserves it; after HCL has transferred every wire-present leaf, a later omission safely removes it. If required preservation or unique nonblank skill identity cannot be proved, PATCH is not sent.
+* Removing keys from `litellm_params` is supported while at least one key remains. Every legacy or structured parameter PATCH starts from a stable fresh authoritative raw object and overlays/removes only exact Terraform-owned keys; unowned values and presence remain byte-semantically exact JSON values.
 
 LiteLLM v1.98 substitutes defaults instead of persisting several empty values. To prevent a false successful apply, the provider rejects these transitions before mutation: clearing the complete `litellm_params` object; removing the complete `agent_card`; clearing `agent_card.version` or `protocol_version`; emptying `default_input_modes` or `default_output_modes`; and removing the complete provider block. An explicitly empty Terraform-owned skills list is allowed because confirmation proves every removed skill ID is absent even if LiteLLM injects a separate unmanaged default chat skill. Keep other defaulted values configured. Direct database changes are outside this API-only provider's safety boundary.
 
-Import records private leaf-level ownership provenance plus separate structural scope for API-owned collections. Imported/API-owned map keys, card fields, provider/capability children, object-permission fields, and skill leaves remain adopted and refresh from API; later API-added or removed collection members are reconciled without transferring ownership to configured siblings. Ordinary configured resources never adopt an omitted leaf merely because LiteLLM returns an injected default. Configured JSON-bearing map values preserve their spelling when each value is semantically equal. Explicit HCL transfers only its exact configured leaves after authoritative apply; configuring one provider, capability, or skill child does not claim its siblings or consume structural API scope. Optional-only unconfigured object-permission siblings are not adopted on ordinary configured-resource reads. Parent removal is rejected only when fresh ownership proves it would discard an API-owned child. Secret-bearing omitted leaves are preserved by `PATCH`; masked values still require the proxy-admin preflight before mutation.
+Import records private leaf-level ownership provenance plus separate structural scope for API-owned collections. Imports populate `litellm_params_json` with the complete canonical API object and retain the historical `map(string)` state projection for every legacy key. The JSON bridge and private ownership marker remain the wire authority, so imported booleans, numbers, nulls, lists, and objects cannot be sent back as their compatibility strings. A legacy-only configured resource keeps `litellm_params_json` null and is not rewritten during upgrade. Configuring the JSON bridge transfers only its explicitly present keys after verified apply; configuring either JSON or a legacy key preserves imported structured siblings. Imported/API-owned map keys, card fields, provider/capability children, object-permission fields, and skill leaves remain adopted and refresh from API; later API-added or removed collection members are reconciled without transferring ownership to configured siblings. Ordinary configured resources never adopt an omitted leaf merely because LiteLLM returns an injected default. Configured JSON-bearing map values preserve their spelling when each value is semantically equal. Explicit HCL transfers only its exact configured leaves after authoritative apply; configuring one provider, capability, or skill child does not claim its siblings or consume structural API scope. Optional-only unconfigured object-permission siblings are not adopted on ordinary configured-resource reads. Parent removal is rejected only when fresh ownership proves it would discard an API-owned child. Secret-bearing omitted leaves are preserved by `PATCH`; masked values still require the proxy-admin preflight before mutation.
 
 ## Upgrade Note: MCP Tool Permission JSON Values
 

--- a/internal/contract/manifest.json
+++ b/internal/contract/manifest.json
@@ -16,7 +16,7 @@
   "provider_golden": {
     "operation_count": 108,
     "path": "internal/contractapi/testdata/provider-operations.golden.json",
-    "sha256": "aca11a58978fde722ff99abb4256d2be769fd4cea3ce518c8e86950589c99731"
+    "sha256": "da2a2c5dc5bbf20450280c9abcd8dab407a767b405ee6856ab0dd23f2856eade"
   },
   "provider_operations": [
     {
@@ -1521,11 +1521,11 @@
       "evidence": [
         {
           "file": "internal/provider/datasource_agents_list.go",
-          "line": 130
+          "line": 89
         },
         {
           "file": "internal/provider/resource_agent_lifecycle.go",
-          "line": 633
+          "line": 747
         }
       ],
       "method": "GET",
@@ -1537,7 +1537,7 @@
       "evidence": [
         {
           "file": "internal/provider/resource_agent.go",
-          "line": 361
+          "line": 408
         }
       ],
       "method": "POST",
@@ -1549,7 +1549,7 @@
       "evidence": [
         {
           "file": "internal/provider/resource_agent.go",
-          "line": 542
+          "line": 622
         }
       ],
       "method": "DELETE",
@@ -1562,20 +1562,24 @@
     {
       "evidence": [
         {
+          "file": "internal/provider/agent_patch.go",
+          "line": 139
+        },
+        {
           "file": "internal/provider/datasource_agent.go",
-          "line": 143
+          "line": 221
         },
         {
           "file": "internal/provider/resource_agent.go",
-          "line": 650
+          "line": 730
         },
         {
           "file": "internal/provider/resource_agent.go",
-          "line": 1043
+          "line": 1204
         },
         {
           "file": "internal/provider/resource_agent.go",
-          "line": 1045
+          "line": 1206
         }
       ],
       "method": "GET",
@@ -1589,7 +1593,7 @@
       "evidence": [
         {
           "file": "internal/provider/resource_agent.go",
-          "line": 503
+          "line": 582
         }
       ],
       "method": "PATCH",

--- a/internal/contract/reviewed-pins.json
+++ b/internal/contract/reviewed-pins.json
@@ -9,7 +9,7 @@
     },
     "manifest": {
       "path": "internal/contract/manifest.json",
-      "sha256": "a65d27dcd78561974aa5c056c238cc408e68083680e3b00a2b5e12863dc7ad56"
+      "sha256": "f44de55ad30de67674682b5ed4cf65b91262ec36892574fed3d41e91c467b7a7"
     },
     "openapi": {
       "operation_count": 800,
@@ -20,7 +20,7 @@
     "provider_golden": {
       "operation_count": 108,
       "path": "internal/contractapi/testdata/provider-operations.golden.json",
-      "sha256": "aca11a58978fde722ff99abb4256d2be769fd4cea3ce518c8e86950589c99731"
+      "sha256": "da2a2c5dc5bbf20450280c9abcd8dab407a767b405ee6856ab0dd23f2856eade"
     },
     "supplemental": {
       "operation_count": 1,

--- a/internal/contractapi/testdata/provider-operations.golden.json
+++ b/internal/contractapi/testdata/provider-operations.golden.json
@@ -1505,11 +1505,11 @@
     "evidence": [
       {
         "file": "internal/provider/datasource_agents_list.go",
-        "line": 130
+        "line": 89
       },
       {
         "file": "internal/provider/resource_agent_lifecycle.go",
-        "line": 633
+        "line": 747
       }
     ]
   },
@@ -1521,7 +1521,7 @@
     "evidence": [
       {
         "file": "internal/provider/resource_agent.go",
-        "line": 361
+        "line": 408
       }
     ]
   },
@@ -1535,7 +1535,7 @@
     "evidence": [
       {
         "file": "internal/provider/resource_agent.go",
-        "line": 542
+        "line": 622
       }
     ]
   },
@@ -1548,20 +1548,24 @@
     "query_parameters": [],
     "evidence": [
       {
+        "file": "internal/provider/agent_patch.go",
+        "line": 139
+      },
+      {
         "file": "internal/provider/datasource_agent.go",
-        "line": 143
+        "line": 221
       },
       {
         "file": "internal/provider/resource_agent.go",
-        "line": 650
+        "line": 730
       },
       {
         "file": "internal/provider/resource_agent.go",
-        "line": 1043
+        "line": 1204
       },
       {
         "file": "internal/provider/resource_agent.go",
-        "line": 1045
+        "line": 1206
       }
     ]
   },
@@ -1575,7 +1579,7 @@
     "evidence": [
       {
         "file": "internal/provider/resource_agent.go",
-        "line": 503
+        "line": 582
       }
     ]
   },

--- a/internal/provider/agent_ownership_pending_protocol_test.go
+++ b/internal/provider/agent_ownership_pending_protocol_test.go
@@ -1,0 +1,308 @@
+package provider
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+type agentOwnershipProtocolAPI struct {
+	mu                 sync.Mutex
+	tpm                int64
+	getTPMShape        string
+	patchStatus        int
+	confirmationOldTPM bool
+	requests           atomic.Int64
+	patches            atomic.Int64
+}
+
+func (a *agentOwnershipProtocolAPI) handler(w http.ResponseWriter, r *http.Request) {
+	a.requests.Add(1)
+	w.Header().Set("Content-Type", "application/json")
+	if r.URL.Path != "/v1/agents/ownership" {
+		http.NotFound(w, r)
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	switch r.Method {
+	case http.MethodGet:
+		tmp := a.tpm
+		if a.confirmationOldTPM {
+			tmp = 10
+		}
+		tpm := fmt.Sprintf(`,"tpm_limit":%d`, tmp)
+		if a.getTPMShape == "omitted" {
+			tpm = ""
+		} else if a.getTPMShape == "null" {
+			tpm = `,"tpm_limit":null`
+		}
+		_, _ = fmt.Fprintf(w, `{"agent_id":"ownership","agent_name":"agent"%s,"agent_card_params":{"name":"Agent","url":"https://agent.invalid"}}`, tpm)
+	case http.MethodPatch:
+		a.patches.Add(1)
+		if a.patchStatus != 0 && a.patchStatus != http.StatusOK {
+			http.Error(w, `{"detail":"rejected"}`, a.patchStatus)
+			return
+		}
+		var request map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			http.Error(w, `{"detail":"malformed"}`, http.StatusBadRequest)
+			return
+		}
+		if raw, ok := request[agentFieldTPM].(float64); ok {
+			a.tpm = int64(raw)
+		}
+		_, _ = io.WriteString(w, `{}`)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (a *agentOwnershipProtocolAPI) setReadShape(shape string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.getTPMShape = shape
+}
+
+func (a *agentOwnershipProtocolAPI) setPatch(status int, confirmationOldTPM bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.patchStatus = status
+	a.confirmationOldTPM = confirmationOldTPM
+}
+
+func agentOwnershipProtocolFixture(t *testing.T, api *agentOwnershipProtocolAPI) (context.Context, tfprotov6.ProviderServer, *tfprotov6.Schema, *tfprotov6.ReadResourceResponse) {
+	t.Helper()
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(api.handler))
+	t.Cleanup(server.Close)
+	protocolServer, schemas := configuredImportProtocolServer(t, ctx, server.URL)
+	const typeName = "litellm_agent"
+	imported, err := protocolServer.ImportResourceState(ctx, &tfprotov6.ImportResourceStateRequest{TypeName: typeName, ID: "ownership"})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(imported.Diagnostics) || len(imported.ImportedResources) != 1 {
+		t.Fatalf("import: err=%v diagnostics=%s", err, agentProtocolDiagnosticsText(imported.Diagnostics))
+	}
+	read, err := protocolServer.ReadResource(ctx, &tfprotov6.ReadResourceRequest{TypeName: typeName, CurrentState: imported.ImportedResources[0].State, Private: imported.ImportedResources[0].Private})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(read.Diagnostics) {
+		t.Fatalf("import read: err=%v diagnostics=%s", err, agentProtocolDiagnosticsText(read.Diagnostics))
+	}
+	committed, err := decodeAgentFieldSet(protocolPrivateValue(t, read.Private, agentImportedFieldsPrivateKey))
+	if err != nil || !committed[agentFieldTPM] || protocolPrivateHasKey(t, read.Private, agentOwnershipPendingPrivateKey) {
+		t.Fatalf("initial ownership: committed=%#v err=%v private=%s", committed, err, read.Private)
+	}
+	return ctx, protocolServer, schemas.ResourceSchemas[typeName], read
+}
+
+func agentOwnershipProtocolPlan(t *testing.T, ctx context.Context, protocolServer tfprotov6.ProviderServer, schema *tfprotov6.Schema, prior *tfprotov6.DynamicValue, private []byte, desiredTPM int64) (*tfprotov6.DynamicValue, *tfprotov6.PlanResourceChangeResponse) {
+	t.Helper()
+	config := agentProtocolDynamicValue(t, schema, map[string]interface{}{
+		"agent_name": "agent",
+		"tpm_limit":  desiredTPM,
+		"agent_card": map[string]interface{}{"name": "Agent", "url": "https://agent.invalid"},
+	})
+	proposed := organizationProjectProtocolReplace(t, schema, prior, map[string]interface{}{agentFieldTPM: desiredTPM})
+	planned, err := protocolServer.PlanResourceChange(ctx, &tfprotov6.PlanResourceChangeRequest{
+		TypeName: "litellm_agent", Config: config, PriorState: prior, ProposedNewState: proposed, PriorPrivate: private,
+	})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(planned.Diagnostics) || organizationProjectProtocolPlannedAction(t, schema, prior, planned) != organizationProjectProtocolActionUpdate {
+		t.Fatalf("ownership plan: err=%v diagnostics=%s action=%s", err, agentProtocolDiagnosticsText(planned.Diagnostics), organizationProjectProtocolPlannedAction(t, schema, prior, planned))
+	}
+	committed, committedErr := decodeAgentFieldSet(protocolPrivateValue(t, planned.PlannedPrivate, agentImportedFieldsPrivateKey))
+	pending, pendingErr := decodeAgentFieldSet(protocolPrivateValue(t, planned.PlannedPrivate, agentOwnershipPendingPrivateKey))
+	if committedErr != nil || pendingErr != nil || !committed[agentFieldTPM] || pending[agentFieldTPM] {
+		t.Fatalf("planned ownership: committed=%#v pending=%#v errors=%v/%v private=%s", committed, pending, committedErr, pendingErr, planned.PlannedPrivate)
+	}
+	return config, planned
+}
+
+func assertAgentProtocolPrivateUnchanged(t *testing.T, want, got []byte) {
+	t.Helper()
+	if !bytes.Equal(want, got) {
+		t.Fatalf("private ownership changed during unconfirmed lifecycle step:\nwant %s\n got %s", want, got)
+	}
+}
+
+func assertAgentProtocolStateUnchanged(t *testing.T, schema *tfprotov6.Schema, want, got *tfprotov6.DynamicValue) {
+	t.Helper()
+	wantValue, wantErr := want.Unmarshal(schema.ValueType())
+	gotValue, gotErr := got.Unmarshal(schema.ValueType())
+	if wantErr != nil || gotErr != nil || !wantValue.Equal(gotValue) {
+		t.Fatalf("public state changed during failed apply: wantErr=%v gotErr=%v", wantErr, gotErr)
+	}
+}
+
+func TestAgentProtocolCreateFinalizesOwnershipOnlyAfterExplicitConfirmation(t *testing.T) {
+	ctx := context.Background()
+	var confirmationReads atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/agents":
+			_, _ = io.WriteString(w, `{"agent_id":"ownership"}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/agents/ownership":
+			tpm := int64(10)
+			if confirmationReads.Add(1) == 1 {
+				tpm = 9
+			}
+			_, _ = fmt.Fprintf(w, `{"agent_id":"ownership","agent_name":"agent","tpm_limit":%d,"agent_card_params":{"name":"Agent","url":"https://agent.invalid"}}`, tpm)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	protocolServer, schemas := configuredImportProtocolServer(t, ctx, server.URL)
+	schema := schemas.ResourceSchemas["litellm_agent"]
+	values := map[string]interface{}{
+		"agent_name": "agent", "tpm_limit": int64(10),
+		"agent_card": map[string]interface{}{"name": "Agent", "url": "https://agent.invalid"},
+	}
+	config := agentProtocolDynamicValue(t, schema, values)
+	proposed := agentProtocolDynamicValue(t, schema, map[string]interface{}{
+		"id": tftypes.UnknownValue, "agent_name": "agent", "tpm_limit": int64(10), "agent_card": values["agent_card"],
+		"litellm_params": tftypes.UnknownValue, "static_headers": tftypes.UnknownValue, "extra_headers": tftypes.UnknownValue,
+		"created_at": tftypes.UnknownValue, "updated_at": tftypes.UnknownValue, "created_by": tftypes.UnknownValue, "updated_by": tftypes.UnknownValue,
+	})
+	nullState := accessGroupProtocolDynamicValue(t, schema, tftypes.NewValue(schema.ValueType(), nil))
+	planned, err := protocolServer.PlanResourceChange(ctx, &tfprotov6.PlanResourceChangeRequest{TypeName: "litellm_agent", Config: config, PriorState: nullState, ProposedNewState: proposed})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(planned.Diagnostics) {
+		t.Fatalf("create plan: err=%v diagnostics=%s", err, agentProtocolDiagnosticsText(planned.Diagnostics))
+	}
+	applied, err := protocolServer.ApplyResourceChange(ctx, &tfprotov6.ApplyResourceChangeRequest{TypeName: "litellm_agent", Config: config, PriorState: nullState, PlannedState: planned.PlannedState, PlannedPrivate: planned.PlannedPrivate})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(applied.Diagnostics) || confirmationReads.Load() != 3 {
+		t.Fatalf("create apply: err=%v diagnostics=%s confirmation reads=%d", err, agentProtocolDiagnosticsText(applied.Diagnostics), confirmationReads.Load())
+	}
+	committed, decodeErr := decodeAgentFieldSet(protocolPrivateValue(t, applied.Private, agentImportedFieldsPrivateKey))
+	if decodeErr != nil || len(committed) != 0 || protocolPrivateHasKey(t, applied.Private, agentOwnershipPendingPrivateKey) {
+		t.Fatalf("create ownership: committed=%#v err=%v private=%s", committed, decodeErr, applied.Private)
+	}
+}
+
+func TestAgentProtocolRejectedPatchRefreshNeverPromotesPending(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		status int
+	}{
+		{name: "failed patch", status: http.StatusInternalServerError},
+		{name: "rejected patch", status: http.StatusBadRequest},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			api := &agentOwnershipProtocolAPI{tpm: 10}
+			ctx, protocolServer, schema, imported := agentOwnershipProtocolFixture(t, api)
+			config, planned := agentOwnershipProtocolPlan(t, ctx, protocolServer, schema, imported.NewState, imported.Private, 20)
+			api.setPatch(test.status, false)
+			applied, err := protocolServer.ApplyResourceChange(ctx, &tfprotov6.ApplyResourceChangeRequest{
+				TypeName: "litellm_agent", Config: config, PriorState: imported.NewState, PlannedState: planned.PlannedState, PlannedPrivate: planned.PlannedPrivate,
+			})
+			if err != nil || !accessGroupProtocolDiagnosticsHaveError(applied.Diagnostics) || api.patches.Load() != 1 {
+				t.Fatalf("failed apply: err=%v diagnostics=%s patches=%d", err, agentProtocolDiagnosticsText(applied.Diagnostics), api.patches.Load())
+			}
+			assertAgentProtocolPrivateUnchanged(t, planned.PlannedPrivate, applied.Private)
+			assertAgentProtocolStateUnchanged(t, schema, imported.NewState, applied.NewState)
+
+			state, private := applied.NewState, applied.Private
+			for _, shape := range []string{"omitted", "null", "present", "present"} {
+				api.setReadShape(shape)
+				refreshed, readErr := protocolServer.ReadResource(ctx, &tfprotov6.ReadResourceRequest{TypeName: "litellm_agent", CurrentState: state, Private: private})
+				if readErr != nil || accessGroupProtocolDiagnosticsHaveError(refreshed.Diagnostics) {
+					t.Fatalf("%s refresh: err=%v diagnostics=%s", shape, readErr, agentProtocolDiagnosticsText(refreshed.Diagnostics))
+				}
+				assertAgentProtocolPrivateUnchanged(t, planned.PlannedPrivate, refreshed.Private)
+				state, private = refreshed.NewState, refreshed.Private
+			}
+		})
+	}
+}
+
+func TestAgentProtocolFailedConfirmationRefreshAndRetryPromotesOnce(t *testing.T) {
+	api := &agentOwnershipProtocolAPI{tpm: 10}
+	ctx, protocolServer, schema, imported := agentOwnershipProtocolFixture(t, api)
+	config, planned := agentOwnershipProtocolPlan(t, ctx, protocolServer, schema, imported.NewState, imported.Private, 20)
+
+	api.setPatch(http.StatusOK, true)
+	applyCtx, cancel := context.WithTimeout(ctx, 150*time.Millisecond)
+	failed, err := protocolServer.ApplyResourceChange(applyCtx, &tfprotov6.ApplyResourceChangeRequest{
+		TypeName: "litellm_agent", Config: config, PriorState: imported.NewState, PlannedState: planned.PlannedState, PlannedPrivate: planned.PlannedPrivate,
+	})
+	cancel()
+	if err != nil || !accessGroupProtocolDiagnosticsHaveError(failed.Diagnostics) || api.patches.Load() != 1 {
+		t.Fatalf("unconfirmed mutation: err=%v diagnostics=%s patches=%d", err, agentProtocolDiagnosticsText(failed.Diagnostics), api.patches.Load())
+	}
+	assertAgentProtocolPrivateUnchanged(t, planned.PlannedPrivate, failed.Private)
+	assertAgentProtocolStateUnchanged(t, schema, imported.NewState, failed.NewState)
+
+	api.setPatch(http.StatusOK, false)
+	refreshed, err := protocolServer.ReadResource(ctx, &tfprotov6.ReadResourceRequest{TypeName: "litellm_agent", CurrentState: failed.NewState, Private: failed.Private})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(refreshed.Diagnostics) {
+		t.Fatalf("post-failure refresh: err=%v diagnostics=%s", err, agentProtocolDiagnosticsText(refreshed.Diagnostics))
+	}
+	assertAgentProtocolPrivateUnchanged(t, planned.PlannedPrivate, refreshed.Private)
+
+	config, retry := agentOwnershipProtocolPlan(t, ctx, protocolServer, schema, refreshed.NewState, refreshed.Private, 20)
+	promoted, err := protocolServer.ApplyResourceChange(ctx, &tfprotov6.ApplyResourceChangeRequest{
+		TypeName: "litellm_agent", Config: config, PriorState: refreshed.NewState, PlannedState: retry.PlannedState, PlannedPrivate: retry.PlannedPrivate,
+	})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(promoted.Diagnostics) || api.patches.Load() != 2 {
+		t.Fatalf("confirmed retry: err=%v diagnostics=%s patches=%d", err, agentProtocolDiagnosticsText(promoted.Diagnostics), api.patches.Load())
+	}
+	committed, decodeErr := decodeAgentFieldSet(protocolPrivateValue(t, promoted.Private, agentImportedFieldsPrivateKey))
+	if decodeErr != nil || committed[agentFieldTPM] || protocolPrivateHasKey(t, promoted.Private, agentOwnershipPendingPrivateKey) {
+		t.Fatalf("retry did not promote exactly once: committed=%#v err=%v private=%s", committed, decodeErr, promoted.Private)
+	}
+
+	stable := promoted
+	for range 2 {
+		refreshedAgain, readErr := protocolServer.ReadResource(ctx, &tfprotov6.ReadResourceRequest{TypeName: "litellm_agent", CurrentState: stable.NewState, Private: stable.Private})
+		if readErr != nil || accessGroupProtocolDiagnosticsHaveError(refreshedAgain.Diagnostics) {
+			t.Fatalf("post-promotion refresh: err=%v diagnostics=%s", readErr, agentProtocolDiagnosticsText(refreshedAgain.Diagnostics))
+		}
+		assertAgentProtocolPrivateUnchanged(t, promoted.Private, refreshedAgain.Private)
+		stable = &tfprotov6.ApplyResourceChangeResponse{NewState: refreshedAgain.NewState, Private: refreshedAgain.Private}
+	}
+	noOpConfig := agentProtocolDynamicValue(t, schema, map[string]interface{}{
+		"agent_name": "agent", "tpm_limit": int64(20),
+		"agent_card": map[string]interface{}{"name": "Agent", "url": "https://agent.invalid"},
+	})
+	noOp, planErr := protocolServer.PlanResourceChange(ctx, &tfprotov6.PlanResourceChangeRequest{
+		TypeName: "litellm_agent", Config: noOpConfig, PriorState: stable.NewState, ProposedNewState: stable.NewState, PriorPrivate: stable.Private,
+	})
+	if planErr != nil || accessGroupProtocolDiagnosticsHaveError(noOp.Diagnostics) || organizationProjectProtocolPlannedAction(t, schema, stable.NewState, noOp) != organizationProjectProtocolActionNoOp || api.patches.Load() != 2 {
+		t.Fatalf("post-promotion plan: err=%v diagnostics=%s action=%s patches=%d", planErr, agentProtocolDiagnosticsText(noOp.Diagnostics), organizationProjectProtocolPlannedAction(t, schema, stable.NewState, noOp), api.patches.Load())
+	}
+}
+
+func TestAgentProtocolMalformedPendingFailsClosedBeforeRequests(t *testing.T) {
+	api := &agentOwnershipProtocolAPI{tpm: 10}
+	ctx, protocolServer, schema, imported := agentOwnershipProtocolFixture(t, api)
+	config, planned := agentOwnershipProtocolPlan(t, ctx, protocolServer, schema, imported.NewState, imported.Private, 20)
+	privateValues := map[string][]byte{}
+	if err := json.Unmarshal(planned.PlannedPrivate, &privateValues); err != nil {
+		t.Fatal(err)
+	}
+	privateValues[agentOwnershipPendingPrivateKey] = []byte(`["tpm_limit","tpm_limit"]`)
+	malformed, err := json.Marshal(privateValues)
+	if err != nil {
+		t.Fatal(err)
+	}
+	before := api.requests.Load()
+	read, readErr := protocolServer.ReadResource(ctx, &tfprotov6.ReadResourceRequest{TypeName: "litellm_agent", CurrentState: imported.NewState, Private: malformed})
+	if readErr != nil || !accessGroupProtocolDiagnosticsHaveError(read.Diagnostics) || api.requests.Load() != before {
+		t.Fatalf("malformed read: err=%v diagnostics=%s requests=%d/%d", readErr, agentProtocolDiagnosticsText(read.Diagnostics), api.requests.Load(), before)
+	}
+	applied, applyErr := protocolServer.ApplyResourceChange(ctx, &tfprotov6.ApplyResourceChangeRequest{
+		TypeName: "litellm_agent", Config: config, PriorState: imported.NewState, PlannedState: planned.PlannedState, PlannedPrivate: malformed,
+	})
+	if applyErr != nil || !accessGroupProtocolDiagnosticsHaveError(applied.Diagnostics) || api.requests.Load() != before {
+		t.Fatalf("malformed apply: err=%v diagnostics=%s requests=%d/%d", applyErr, agentProtocolDiagnosticsText(applied.Diagnostics), api.requests.Load(), before)
+	}
+}

--- a/internal/provider/agent_patch.go
+++ b/internal/provider/agent_patch.go
@@ -126,6 +126,38 @@ func agentWireObjectsEqual(left, right map[string]interface{}) bool {
 	return exactJSONValuesEqual(left, right)
 }
 
+// LiteLLM v1.98's merge_agent_card filters every full-card PATCH through this
+// exact source allowlist and filters capabilities to truthy streaming only.
+// Reject before PATCH when a fresh authoritative path would therefore be lost.
+func validateAgentCardV198RoundTrip(card map[string]interface{}) error {
+	allowed := map[string]bool{
+		"protocolVersion": true, "name": true, "description": true, "version": true,
+		"capabilities": true, "defaultInputModes": true, "defaultOutputModes": true,
+		"skills": true, "preferredTransport": true, "supportedInterfaces": true,
+		"iconUrl": true, "provider": true, "documentationUrl": true,
+		"securitySchemes": true, "security": true, "supportsAuthenticatedExtendedCard": true,
+		"signatures": true, "url": true,
+	}
+	for key := range card {
+		if !allowed[key] {
+			return fmt.Errorf("authoritative agent card contains a path LiteLLM v1.98 cannot round-trip")
+		}
+	}
+	if raw, present := card["capabilities"]; present {
+		capabilities, ok := raw.(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("authoritative agent card contains a path LiteLLM v1.98 cannot round-trip")
+		}
+		for key, value := range capabilities {
+			streaming, isBool := value.(bool)
+			if key != "streaming" || !isBool || !streaming {
+				return fmt.Errorf("authoritative agent card contains a path LiteLLM v1.98 cannot round-trip")
+			}
+		}
+	}
+	return nil
+}
+
 func (r *AgentResource) sampleFreshAgentUpdateBase(ctx context.Context, state AgentResourceModel, needParams, needCard bool, maxAttempts int) (map[string]interface{}, map[string]interface{}, error) {
 	if maxAttempts < 2 {
 		maxAttempts = 2
@@ -136,6 +168,7 @@ func (r *AgentResource) sampleFreshAgentUpdateBase(ctx context.Context, state Ag
 	matched := false
 	for attempt := 0; attempt < maxAttempts; attempt++ {
 		var result map[string]interface{}
+//line internal/provider/agent_patch.go:139
 		err := r.client.doFreshRequestWithResponse(ctx, "GET", endpoint, nil, &result)
 		if err == nil {
 			err = validateImportedObjectIdentity(true, "agent", result, "agent_id", state.ID.ValueString())
@@ -240,11 +273,35 @@ func agentImportedFieldsFromWire(data AgentResourceModel, raw map[string]interfa
 	fields := agentImportedFieldsFromState(data)
 	card, _ := raw["agent_card_params"].(map[string]interface{})
 	for marker := range fields {
-		if strings.HasPrefix(marker, agentFieldCardSkills+"[") || strings.HasPrefix(marker, agentFieldCardSignatures+"[") {
+		if strings.HasPrefix(marker, "agent_card.") {
 			delete(fields, marker)
 		}
 	}
 	if card != nil {
+		for field, wire := range map[string]string{
+			agentFieldCardName: "name", agentFieldCardURL: "url", agentFieldCardDescription: "description", agentFieldCardVersion: "version",
+			agentFieldCardProtocol: "protocolVersion", agentFieldCardInputModes: "defaultInputModes", agentFieldCardOutputModes: "defaultOutputModes",
+			agentFieldCardTransport: "preferredTransport", agentFieldCardIcon: "iconUrl", agentFieldCardDocumentation: "documentationUrl",
+			agentFieldCardAuthenticated: "supportsAuthenticatedExtendedCard",
+		} {
+			if _, present := card[wire]; present {
+				fields[field] = true
+			}
+		}
+		if capabilities, present := card["capabilities"].(map[string]interface{}); present {
+			for field, wire := range map[string]string{agentFieldCardCapStreaming: "streaming", agentFieldCardCapPush: "pushNotifications", agentFieldCardCapHistory: "stateTransitionHistory"} {
+				if _, present := capabilities[wire]; present {
+					fields[field] = true
+				}
+			}
+		}
+		if provider, present := card["provider"].(map[string]interface{}); present {
+			for field, wire := range map[string]string{agentFieldCardProviderOrg: "organization", agentFieldCardProviderURL: "url"} {
+				if _, present := provider[wire]; present {
+					fields[field] = true
+				}
+			}
+		}
 		for id, skill := range agentSkillRawByID(card) {
 			markAgentSkillWireLeaves(fields, id, skill)
 		}
@@ -257,7 +314,6 @@ func agentImportedFieldsFromWire(data AgentResourceModel, raw map[string]interfa
 				}
 			}
 		}
-		delete(fields, agentFieldCardSignatures)
 	}
 	return fields
 }
@@ -329,11 +385,11 @@ func overlayAgentCardRaw(base map[string]interface{}, plan, prior, config AgentR
 			if index < len(baseSignatures) {
 				current = cloneAgentWireObject(baseSignatures[index])
 			}
-			setAgentWireField(current, desiredSignature, "protected")
-			setAgentWireField(current, desiredSignature, "signature")
-			headerMarker := agentSignatureLeaf(index, "header")
-			if configured[headerMarker] || (index < priorSignatureCount && !imported[headerMarker]) {
-				setAgentWireField(current, desiredSignature, "header")
+			for _, wire := range []string{"protected", "signature", "header"} {
+				marker := agentSignatureLeaf(index, wire)
+				if configured[marker] || (priorFields[marker] && !imported[marker] && !configured[marker]) {
+					setAgentWireField(current, desiredSignature, wire)
+				}
 			}
 			merged = append(merged, current)
 		}
@@ -366,10 +422,9 @@ func overlayAgentCardRaw(base map[string]interface{}, plan, prior, config AgentR
 				current = map[string]interface{}{}
 			}
 			desiredSkill := desiredByID[id]
-			setAgentWireField(current, desiredSkill, "id")
-			for field, wire := range map[string]string{"name": "name", "description": "description", "tags": "tags", "examples": "examples", "input_modes": "inputModes", "output_modes": "outputModes", "security": "security"} {
+			for field, wire := range map[string]string{"id": "id", "name": "name", "description": "description", "tags": "tags", "examples": "examples", "input_modes": "inputModes", "output_modes": "outputModes", "security": "security"} {
 				marker := agentSkillLeaf(id, field)
-				if configured[marker] || (priorIDs[id] && !imported[marker] && !configured[marker]) {
+				if configured[marker] || (priorFields[marker] && !imported[marker] && !configured[marker]) {
 					setAgentWireField(current, desiredSkill, wire)
 				}
 			}
@@ -384,6 +439,22 @@ func overlayAgentCardRaw(base map[string]interface{}, plan, prior, config AgentR
 			if agentFieldSetHasPrefix(imported, agentLeaf(agentFieldCardSkills, id)+".") || (imported[agentScopeCardSkills] && !priorIDs[id]) {
 				merged = append(merged, cloneAgentWireObject(remote))
 			}
+		}
+		patch["skills"] = merged
+	} else if prior.AgentCard != nil && prior.AgentCard.Skills != nil {
+		merged := make([]interface{}, 0, len(agentWireObjectList(patch["skills"])))
+		priorIDs := map[string]bool{}
+		for _, skill := range prior.AgentCard.Skills {
+			if !skill.ID.IsNull() && !skill.ID.IsUnknown() {
+				priorIDs[skill.ID.ValueString()] = true
+			}
+		}
+		for _, remote := range agentWireObjectList(patch["skills"]) {
+			id, _ := remote["id"].(string)
+			if priorIDs[id] && !agentFieldSetHasPrefix(imported, agentLeaf(agentFieldCardSkills, id)+".") {
+				continue
+			}
+			merged = append(merged, cloneAgentWireObject(remote))
 		}
 		patch["skills"] = merged
 	}

--- a/internal/provider/agent_patch.go
+++ b/internal/provider/agent_patch.go
@@ -1,0 +1,513 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type agentPatchPreservation struct {
+	paramsBase  map[string]interface{}
+	paramsPatch map[string]interface{}
+	cardBase    map[string]interface{}
+	cardPatch   map[string]interface{}
+}
+
+func cloneAgentWireObject(source map[string]interface{}) map[string]interface{} {
+	if source == nil {
+		return nil
+	}
+	out := make(map[string]interface{}, len(source))
+	for key, value := range source {
+		out[key] = cloneAgentWireValue(value)
+	}
+	return out
+}
+
+func cloneAgentWireValue(value interface{}) interface{} {
+	switch typed := value.(type) {
+	case map[string]interface{}:
+		return cloneAgentWireObject(typed)
+	case []interface{}:
+		out := make([]interface{}, len(typed))
+		for index, item := range typed {
+			out[index] = cloneAgentWireValue(item)
+		}
+		return out
+	default:
+		return value
+	}
+}
+
+func agentParamsConfiguredKeys(data AgentResourceModel) (map[string]interface{}, error) {
+	values, _, err := configuredAgentParams(data.LiteLLMParams, data.LiteLLMParamsJSON)
+	return values, err
+}
+
+func agentParamsUpdateTouched(plan, prior, config AgentResourceModel, imported agentFieldSet) bool {
+	desired, err := agentParamsConfiguredKeys(config)
+	if err != nil {
+		return true
+	}
+	priorObject := map[string]interface{}{}
+	if !prior.LiteLLMParamsJSON.IsNull() && !prior.LiteLLMParamsJSON.IsUnknown() {
+		priorObject, _ = decodeAgentJSONObject(prior.LiteLLMParamsJSON.ValueString())
+	}
+	if !prior.LiteLLMParams.IsNull() && !prior.LiteLLMParams.IsUnknown() {
+		for key, raw := range prior.LiteLLMParams.Elements() {
+			if value, ok := raw.(types.String); ok && !value.IsNull() && !value.IsUnknown() {
+				if _, exists := priorObject[key]; !exists {
+					priorObject[key] = value.ValueString()
+				}
+			}
+		}
+	}
+	for key, value := range desired {
+		priorValue, present := priorObject[key]
+		if !present || !exactJSONValuesEqual(value, priorValue) {
+			return true
+		}
+	}
+	for key := range priorObject {
+		if imported[agentLeaf(agentFieldParams, key)] {
+			continue
+		}
+		if _, retained := desired[key]; !retained {
+			return true
+		}
+	}
+	_ = plan
+	return false
+}
+
+func overlayAgentParamsWire(base map[string]interface{}, prior, config AgentResourceModel, imported agentFieldSet) (map[string]interface{}, error) {
+	patch := cloneAgentWireObject(stripAgentSyntheticParams(base))
+	desired, err := agentParamsConfiguredKeys(config)
+	if err != nil {
+		return nil, err
+	}
+	priorKeys := map[string]bool{}
+	if !prior.LiteLLMParamsJSON.IsNull() && !prior.LiteLLMParamsJSON.IsUnknown() {
+		object, decodeErr := decodeAgentJSONObject(prior.LiteLLMParamsJSON.ValueString())
+		if decodeErr != nil {
+			return nil, decodeErr
+		}
+		for key := range object {
+			priorKeys[key] = true
+		}
+	}
+	if !prior.LiteLLMParams.IsNull() && !prior.LiteLLMParams.IsUnknown() {
+		for key := range prior.LiteLLMParams.Elements() {
+			priorKeys[key] = true
+		}
+	}
+	for key := range priorKeys {
+		if imported[agentLeaf(agentFieldParams, key)] {
+			continue
+		}
+		if _, retained := desired[key]; !retained {
+			delete(patch, key)
+		}
+	}
+	for key, value := range desired {
+		patch[key] = cloneAgentWireValue(value)
+	}
+	if err := validateAgentCorePair(patch); err != nil {
+		return nil, err
+	}
+	return patch, nil
+}
+
+func agentWireObjectsEqual(left, right map[string]interface{}) bool {
+	return exactJSONValuesEqual(left, right)
+}
+
+func (r *AgentResource) sampleFreshAgentUpdateBase(ctx context.Context, state AgentResourceModel, needParams, needCard bool, maxAttempts int) (map[string]interface{}, map[string]interface{}, error) {
+	if maxAttempts < 2 {
+		maxAttempts = 2
+	}
+	endpoint := fmt.Sprintf("/v1/agents/%s", url.PathEscape(state.ID.ValueString()))
+	delay := 250 * time.Millisecond
+	var priorParams, priorCard map[string]interface{}
+	matched := false
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		var result map[string]interface{}
+		err := r.client.doFreshRequestWithResponse(ctx, "GET", endpoint, nil, &result)
+		if err == nil {
+			err = validateImportedObjectIdentity(true, "agent", result, "agent_id", state.ID.ValueString())
+		}
+		if err == nil {
+			err = requireImportedStringField(true, "agent", result, "agent_name")
+		}
+		var params, card map[string]interface{}
+		if err == nil && needParams {
+			raw, present := result["litellm_params"]
+			var ok bool
+			params, ok = raw.(map[string]interface{})
+			if !present || !ok || params == nil {
+				err = fmt.Errorf("fresh agent parameters are not an authoritative object")
+			} else {
+				params = stripAgentSyntheticParams(params)
+			}
+		}
+		if err == nil && needCard {
+			raw, present := result["agent_card_params"]
+			var ok bool
+			card, ok = raw.(map[string]interface{})
+			if !present || !ok || card == nil || validateAgentCardResponse(card, true) != nil {
+				err = fmt.Errorf("fresh agent card is not an authoritative object")
+			}
+		}
+		if err == nil {
+			if matched && (!needParams || agentWireObjectsEqual(priorParams, params)) && (!needCard || agentWireObjectsEqual(priorCard, card)) {
+				return cloneAgentWireObject(params), cloneAgentWireObject(card), nil
+			}
+			priorParams, priorCard = cloneAgentWireObject(params), cloneAgentWireObject(card)
+			matched = true
+		} else {
+			matched = false
+		}
+		if attempt < maxAttempts-1 {
+			if err := waitAgentFreshSample(ctx, delay); err != nil {
+				return nil, nil, err
+			}
+			delay *= 2
+			if delay > 2*time.Second {
+				delay = 2 * time.Second
+			}
+		}
+	}
+	return nil, nil, fmt.Errorf("fresh agent update base did not converge")
+}
+
+func setAgentWireField(target map[string]interface{}, source map[string]interface{}, key string) {
+	if value, present := source[key]; present {
+		target[key] = cloneAgentWireValue(value)
+	} else {
+		delete(target, key)
+	}
+}
+
+func agentWireObject(raw interface{}) map[string]interface{} {
+	object, _ := raw.(map[string]interface{})
+	return object
+}
+
+func agentWireObjectList(raw interface{}) []map[string]interface{} {
+	result := []map[string]interface{}{}
+	switch items := raw.(type) {
+	case []interface{}:
+		for _, item := range items {
+			if object, ok := item.(map[string]interface{}); ok {
+				result = append(result, object)
+			}
+		}
+	case []map[string]interface{}:
+		result = append(result, items...)
+	}
+	return result
+}
+
+func agentSkillRawByID(card map[string]interface{}) map[string]map[string]interface{} {
+	result := map[string]map[string]interface{}{}
+	for _, skill := range agentWireObjectList(card["skills"]) {
+		if id, ok := skill["id"].(string); ok {
+			result[id] = skill
+		}
+	}
+	return result
+}
+
+func markAgentSkillWireLeaves(fields agentFieldSet, id string, raw map[string]interface{}) {
+	if raw == nil {
+		return
+	}
+	for field, wire := range map[string]string{
+		"id": "id", "name": "name", "description": "description", "tags": "tags", "examples": "examples",
+		"input_modes": "inputModes", "output_modes": "outputModes", "security": "security",
+	} {
+		if _, present := raw[wire]; present {
+			fields[agentSkillLeaf(id, field)] = true
+		}
+	}
+}
+
+func agentImportedFieldsFromWire(data AgentResourceModel, raw map[string]interface{}) agentFieldSet {
+	fields := agentImportedFieldsFromState(data)
+	card, _ := raw["agent_card_params"].(map[string]interface{})
+	for marker := range fields {
+		if strings.HasPrefix(marker, agentFieldCardSkills+"[") || strings.HasPrefix(marker, agentFieldCardSignatures+"[") {
+			delete(fields, marker)
+		}
+	}
+	if card != nil {
+		for id, skill := range agentSkillRawByID(card) {
+			markAgentSkillWireLeaves(fields, id, skill)
+		}
+		if rawSignatures, present := card["signatures"]; present {
+			for index, signature := range agentWireObjectList(rawSignatures) {
+				for _, field := range []string{"protected", "signature", "header"} {
+					if _, wirePresent := signature[field]; wirePresent {
+						fields[agentSignatureLeaf(index, field)] = true
+					}
+				}
+			}
+		}
+		delete(fields, agentFieldCardSignatures)
+	}
+	return fields
+}
+
+func overlayAgentCardRaw(base map[string]interface{}, plan, prior, config AgentResourceModel, imported agentFieldSet) (map[string]interface{}, error) {
+	patch := cloneAgentWireObject(base)
+	if plan.AgentCard == nil || config.AgentCard == nil {
+		return patch, nil
+	}
+	builder := &AgentResource{}
+	model := cloneAgentResourceModel(plan)
+	model.LiteLLMParams = types.MapNull(types.StringType)
+	model.LiteLLMParamsJSON = types.StringNull()
+	built, err := builder.buildAgentRequest(&model)
+	if err != nil {
+		return nil, err
+	}
+	desired, ok := built["agent_card_params"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("configured agent card could not be represented")
+	}
+	configured, priorFields := agentConfiguredFields(config), agentConfiguredFields(prior)
+	usePlan := func(field string) bool {
+		return configured[field] || (priorFields[field] && !imported[field] && !configured[field])
+	}
+	for field, wire := range map[string]string{
+		agentFieldCardName: "name", agentFieldCardURL: "url", agentFieldCardDescription: "description", agentFieldCardVersion: "version",
+		agentFieldCardProtocol: "protocolVersion", agentFieldCardInputModes: "defaultInputModes", agentFieldCardOutputModes: "defaultOutputModes",
+		agentFieldCardTransport: "preferredTransport", agentFieldCardIcon: "iconUrl", agentFieldCardDocumentation: "documentationUrl",
+		agentFieldCardAuthenticated: "supportsAuthenticatedExtendedCard",
+	} {
+		if usePlan(field) {
+			setAgentWireField(patch, desired, wire)
+		}
+	}
+	for _, wire := range map[string]struct {
+		wire   string
+		leaves map[string]string
+	}{
+		agentFieldCardCapabilities: {"capabilities", map[string]string{agentFieldCardCapStreaming: "streaming", agentFieldCardCapPush: "pushNotifications", agentFieldCardCapHistory: "stateTransitionHistory"}},
+		agentFieldCardProvider:     {"provider", map[string]string{agentFieldCardProviderOrg: "organization", agentFieldCardProviderURL: "url"}},
+	} {
+		current := cloneAgentWireObject(agentWireObject(patch[wire.wire]))
+		if current == nil {
+			current = map[string]interface{}{}
+		}
+		desiredObject := agentWireObject(desired[wire.wire])
+		for field, childWire := range wire.leaves {
+			if usePlan(field) {
+				setAgentWireField(current, desiredObject, childWire)
+			}
+		}
+		if len(current) == 0 {
+			delete(patch, wire.wire)
+		} else {
+			patch[wire.wire] = current
+		}
+	}
+	if config.AgentCard.Signatures != nil {
+		baseSignatures := agentWireObjectList(patch["signatures"])
+		desiredSignatures := agentWireObjectList(desired["signatures"])
+		merged := make([]interface{}, 0, len(baseSignatures)+len(desiredSignatures))
+		priorSignatureCount := 0
+		if prior.AgentCard != nil {
+			priorSignatureCount = len(prior.AgentCard.Signatures)
+		}
+		for index, desiredSignature := range desiredSignatures {
+			current := map[string]interface{}{}
+			if index < len(baseSignatures) {
+				current = cloneAgentWireObject(baseSignatures[index])
+			}
+			setAgentWireField(current, desiredSignature, "protected")
+			setAgentWireField(current, desiredSignature, "signature")
+			headerMarker := agentSignatureLeaf(index, "header")
+			if configured[headerMarker] || (index < priorSignatureCount && !imported[headerMarker]) {
+				setAgentWireField(current, desiredSignature, "header")
+			}
+			merged = append(merged, current)
+		}
+		for index := len(desiredSignatures); index < len(baseSignatures); index++ {
+			if agentFieldSetHasPrefix(imported, fmt.Sprintf("%s[%d].", agentFieldCardSignatures, index)) || (imported[agentScopeCardSignatures] && index >= priorSignatureCount) {
+				merged = append(merged, cloneAgentWireObject(baseSignatures[index]))
+			}
+		}
+		patch["signatures"] = merged
+	} else if prior.AgentCard != nil && prior.AgentCard.Signatures != nil && !agentFieldSetHasPrefix(imported, agentFieldCardSignatures+"[") {
+		delete(patch, "signatures")
+	}
+	if config.AgentCard.Skills != nil {
+		freshByID := agentSkillRawByID(patch)
+		desiredByID := agentSkillRawByID(desired)
+		priorIDs := map[string]bool{}
+		if prior.AgentCard != nil {
+			for _, skill := range prior.AgentCard.Skills {
+				if !skill.ID.IsNull() && !skill.ID.IsUnknown() {
+					priorIDs[skill.ID.ValueString()] = true
+				}
+			}
+		}
+		merged := make([]interface{}, 0, len(freshByID)+len(plan.AgentCard.Skills))
+		seen := map[string]bool{}
+		for _, desiredModel := range plan.AgentCard.Skills {
+			id := desiredModel.ID.ValueString()
+			current := cloneAgentWireObject(freshByID[id])
+			if current == nil {
+				current = map[string]interface{}{}
+			}
+			desiredSkill := desiredByID[id]
+			setAgentWireField(current, desiredSkill, "id")
+			for field, wire := range map[string]string{"name": "name", "description": "description", "tags": "tags", "examples": "examples", "input_modes": "inputModes", "output_modes": "outputModes", "security": "security"} {
+				marker := agentSkillLeaf(id, field)
+				if configured[marker] || (priorIDs[id] && !imported[marker] && !configured[marker]) {
+					setAgentWireField(current, desiredSkill, wire)
+				}
+			}
+			merged = append(merged, current)
+			seen[id] = true
+		}
+		for _, remote := range agentWireObjectList(patch["skills"]) {
+			id, _ := remote["id"].(string)
+			if seen[id] {
+				continue
+			}
+			if agentFieldSetHasPrefix(imported, agentLeaf(agentFieldCardSkills, id)+".") || (imported[agentScopeCardSkills] && !priorIDs[id]) {
+				merged = append(merged, cloneAgentWireObject(remote))
+			}
+		}
+		patch["skills"] = merged
+	}
+	return patch, nil
+}
+
+func agentPreservedValueMatches(base, patch, observed interface{}, path string) bool {
+	if exactJSONValuesEqual(base, patch) {
+		return exactJSONValuesEqual(base, observed)
+	}
+	baseObject, baseOK := base.(map[string]interface{})
+	patchObject, patchOK := patch.(map[string]interface{})
+	observedObject, observedOK := observed.(map[string]interface{})
+	if baseOK && patchOK {
+		if !observedOK {
+			return false
+		}
+		keys := map[string]bool{}
+		for key := range baseObject {
+			keys[key] = true
+		}
+		for key := range patchObject {
+			keys[key] = true
+		}
+		for key := range observedObject {
+			keys[key] = true
+		}
+		for key := range keys {
+			baseValue, basePresent := baseObject[key]
+			patchValue, patchPresent := patchObject[key]
+			observedValue, observedPresent := observedObject[key]
+			if basePresent == patchPresent && (!basePresent || exactJSONValuesEqual(baseValue, patchValue)) {
+				if basePresent != observedPresent || (basePresent && !exactJSONValuesEqual(baseValue, observedValue)) {
+					return false
+				}
+				continue
+			}
+			if basePresent && patchPresent && !agentPreservedValueMatches(baseValue, patchValue, observedValue, path+"."+key) {
+				return false
+			}
+		}
+		return true
+	}
+	if path == "agent_card_params.skills" {
+		return agentPreservedSkillsMatch(base, patch, observed)
+	}
+	if path == "agent_card_params.signatures" {
+		return agentPreservedSignaturesMatch(base, patch, observed)
+	}
+	return true
+}
+
+func agentPreservedSignaturesMatch(base, patch, observed interface{}) bool {
+	baseList, patchList, observedList := agentWireObjectList(base), agentWireObjectList(patch), agentWireObjectList(observed)
+	max := len(baseList)
+	if len(patchList) > max {
+		max = len(patchList)
+	}
+	if len(observedList) > max {
+		max = len(observedList)
+	}
+	for index := 0; index < max; index++ {
+		bp, pp, op := index < len(baseList), index < len(patchList), index < len(observedList)
+		if bp == pp && (!bp || exactJSONValuesEqual(baseList[index], patchList[index])) {
+			if bp != op || (bp && !exactJSONValuesEqual(baseList[index], observedList[index])) {
+				return false
+			}
+			continue
+		}
+		if bp && pp && (!op || !agentPreservedValueMatches(baseList[index], patchList[index], observedList[index], fmt.Sprintf("agent_card_params.signatures.%d", index))) {
+			return false
+		}
+	}
+	return true
+}
+
+func agentPreservedSkillsMatch(base, patch, observed interface{}) bool {
+	asMap := func(value interface{}) map[string]map[string]interface{} {
+		card := map[string]interface{}{"skills": value}
+		return agentSkillRawByID(card)
+	}
+	baseByID, patchByID, observedByID := asMap(base), asMap(patch), asMap(observed)
+	ids := map[string]bool{}
+	for id := range baseByID {
+		ids[id] = true
+	}
+	for id := range patchByID {
+		ids[id] = true
+	}
+	for id := range observedByID {
+		ids[id] = true
+	}
+	for id := range ids {
+		baseSkill, bp := baseByID[id]
+		patchSkill, pp := patchByID[id]
+		observedSkill, op := observedByID[id]
+		if bp == pp && (!bp || exactJSONValuesEqual(baseSkill, patchSkill)) {
+			if bp != op || (bp && !exactJSONValuesEqual(baseSkill, observedSkill)) {
+				return false
+			}
+			continue
+		}
+		if bp && pp && (!op || !agentPreservedValueMatches(baseSkill, patchSkill, observedSkill, "agent_card_params.skills."+id)) {
+			return false
+		}
+	}
+	return true
+}
+
+func (e *agentPatchPreservation) matches(raw map[string]interface{}) bool {
+	if e == nil {
+		return true
+	}
+	if e.paramsBase != nil {
+		rawParams, ok := raw["litellm_params"].(map[string]interface{})
+		if !ok || !agentPreservedValueMatches(e.paramsBase, e.paramsPatch, stripAgentSyntheticParams(rawParams), "litellm_params") {
+			return false
+		}
+	}
+	if e.cardBase != nil {
+		rawCard, ok := raw["agent_card_params"].(map[string]interface{})
+		if !ok || validateAgentCardResponse(rawCard, true) != nil || !agentPreservedValueMatches(e.cardBase, e.cardPatch, rawCard, "agent_card_params") {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/provider/agent_structured.go
+++ b/internal/provider/agent_structured.go
@@ -1,0 +1,356 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// Wire evidence (read-only): LiteLLM v1.98 commit
+// d8f71d7bdbd7c9873d98293f83d64c6db72847e6, litellm/types/agents.py,
+// declares AgentConfig/PatchAgentRequest.litellm_params as dict[str, Any],
+// AgentSkill.security as list[dict[str, list[str]]], and AgentCard.signatures as
+// list[AgentCardSignature] with an arbitrary dict[str, Any] header. The same
+// commit's proxy/agent_endpoints/agent_registry.py serializes those dictionaries
+// directly and PATCHes a supplied complete agent_card_params object.
+//
+// agentJSONObjectValidator is deliberately attached only to the additive JSON
+// bridge. The legacy map(string) surface remains completely literal.
+type agentJSONObjectValidator struct{}
+
+var _ validator.String = agentJSONObjectValidator{}
+
+func (agentJSONObjectValidator) Description(context.Context) string {
+	return "Value must encode exactly one non-null JSON object."
+}
+
+func (v agentJSONObjectValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (agentJSONObjectValidator) ValidateString(_ context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+	if _, err := decodeAgentJSONObject(req.ConfigValue.ValueString()); err != nil {
+		resp.Diagnostics.AddAttributeError(req.Path, "Invalid Agent JSON Object", "The value must encode exactly one non-null JSON object.")
+	}
+}
+
+func decodeAgentJSONObject(value string) (map[string]interface{}, error) {
+	var decoded interface{}
+	if err := decodeJSONUseNumber([]byte(value), &decoded); err != nil {
+		return nil, errors.New("invalid JSON")
+	}
+	object, ok := decoded.(map[string]interface{})
+	if !ok || object == nil {
+		return nil, errors.New("expected JSON object")
+	}
+	return object, nil
+}
+
+type agentJSONNullOrObjectValidator struct{}
+
+var _ validator.String = agentJSONNullOrObjectValidator{}
+
+func (agentJSONNullOrObjectValidator) Description(context.Context) string {
+	return "Value must encode JSON null or exactly one JSON object."
+}
+func (v agentJSONNullOrObjectValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+func (agentJSONNullOrObjectValidator) ValidateString(_ context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+	var decoded interface{}
+	if decodeJSONUseNumber([]byte(req.ConfigValue.ValueString()), &decoded) != nil {
+		resp.Diagnostics.AddAttributeError(req.Path, "Invalid Agent JSON Value", "The value must encode JSON null or exactly one JSON object.")
+		return
+	}
+	if decoded == nil {
+		return
+	}
+	if object, ok := decoded.(map[string]interface{}); !ok || object == nil {
+		resp.Diagnostics.AddAttributeError(req.Path, "Invalid Agent JSON Value", "The value must encode JSON null or exactly one JSON object.")
+	}
+}
+
+type agentJSONNullOrSecurityValidator struct{}
+
+var _ validator.String = agentJSONNullOrSecurityValidator{}
+
+func (agentJSONNullOrSecurityValidator) Description(context.Context) string {
+	return "Value must encode JSON null or an ordered A2A security-requirement list."
+}
+func (v agentJSONNullOrSecurityValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+func (agentJSONNullOrSecurityValidator) ValidateString(_ context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+	value, err := decodeAgentSecurityJSON(req.ConfigValue.ValueString())
+	if err != nil || (value != nil && reflect.ValueOf(value).Kind() != reflect.Slice) {
+		resp.Diagnostics.AddAttributeError(req.Path, "Invalid Agent Security JSON", "The value must encode JSON null or an ordered list of objects whose values are string lists.")
+	}
+}
+
+func decodeAgentNullOrObject(value string) (interface{}, error) {
+	var decoded interface{}
+	if err := decodeJSONUseNumber([]byte(value), &decoded); err != nil {
+		return nil, errors.New("invalid JSON")
+	}
+	if decoded == nil {
+		return nil, nil
+	}
+	object, ok := decoded.(map[string]interface{})
+	if !ok || object == nil {
+		return nil, errors.New("expected JSON null or object")
+	}
+	return object, nil
+}
+
+func decodeAgentSecurityJSON(value string) (interface{}, error) {
+	var decoded interface{}
+	if err := decodeJSONUseNumber([]byte(value), &decoded); err != nil {
+		return nil, errors.New("invalid JSON")
+	}
+	if decoded == nil {
+		return nil, nil
+	}
+	items, ok := decoded.([]interface{})
+	if !ok || items == nil {
+		return nil, errors.New("expected JSON null or list")
+	}
+	for _, rawItem := range items {
+		item, ok := rawItem.(map[string]interface{})
+		if !ok || item == nil {
+			return nil, errors.New("security must contain objects")
+		}
+		for _, rawScopes := range item {
+			scopes, ok := rawScopes.([]interface{})
+			if !ok {
+				return nil, errors.New("security scopes must be string lists")
+			}
+			for _, rawScope := range scopes {
+				if _, ok := rawScope.(string); !ok {
+					return nil, errors.New("security scopes must be string lists")
+				}
+			}
+		}
+	}
+	return items, nil
+}
+
+func canonicalAgentJSON(value interface{}) (string, error) {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return "", errors.New("value cannot be represented as JSON")
+	}
+	return string(encoded), nil
+}
+
+// configuredAgentParams merges the two additive surfaces without interpreting
+// legacy strings. A legacy value "false" is the JSON string "false", never a
+// boolean; JSON-looking legacy text is likewise sent as text. Overlap is
+// accepted only when the JSON value is the identical string.
+func configuredAgentParams(legacy types.Map, structured types.String) (map[string]interface{}, bool, error) {
+	result := map[string]interface{}{}
+	configured := false
+	if !legacy.IsNull() && !legacy.IsUnknown() {
+		configured = true
+		for key, raw := range legacy.Elements() {
+			value, ok := raw.(types.String)
+			if !ok || value.IsNull() || value.IsUnknown() {
+				return nil, false, errors.New("litellm_params contains a non-string value")
+			}
+			result[key] = value.ValueString()
+		}
+	}
+	if !structured.IsNull() && !structured.IsUnknown() {
+		configured = true
+		object, err := decodeAgentJSONObject(structured.ValueString())
+		if err != nil {
+			return nil, false, err
+		}
+		for key, value := range object {
+			if prior, exists := result[key]; exists && !reflect.DeepEqual(prior, value) {
+				return nil, false, fmt.Errorf("litellm_params and litellm_params_json configure different values for key %q", key)
+			}
+			result[key] = value
+		}
+	}
+	return result, configured, nil
+}
+
+func agentStringProjection(object map[string]interface{}, excludeSynthetic bool) (types.Map, error) {
+	values := map[string]attr.Value{}
+	for key, raw := range object {
+		if excludeSynthetic && key == "is_public" {
+			continue
+		}
+		// Preserve the historical computed map(string) projection for state and
+		// imports. The JSON bridge, not this compatibility projection, is the
+		// authority for the original wire type.
+		values[key] = types.StringValue(metadataValueToString(raw))
+	}
+	result, diagnostics := types.MapValue(types.StringType, values)
+	if diagnostics.HasError() {
+		return types.MapNull(types.StringType), errors.New("could not project string values")
+	}
+	return result, nil
+}
+
+func stripAgentSyntheticParams(object map[string]interface{}) map[string]interface{} {
+	result := make(map[string]interface{}, len(object))
+	for key, value := range object {
+		if key != "is_public" {
+			result[key] = value
+		}
+	}
+	return result
+}
+
+func restoreMaskedAgentLeaves(remote, prior interface{}, key string) (interface{}, error) {
+	if isMaskedAgentAPIValue(key, remote) {
+		priorString, ok := prior.(string)
+		if !ok {
+			return nil, errors.New("masked structured agent value changed shape")
+		}
+		return priorString, nil
+	}
+	switch value := remote.(type) {
+	case map[string]interface{}:
+		priorObject, _ := prior.(map[string]interface{})
+		out := make(map[string]interface{}, len(value))
+		for childKey, child := range value {
+			restored, err := restoreMaskedAgentLeaves(child, priorObject[childKey], childKey)
+			if err != nil {
+				return nil, err
+			}
+			out[childKey] = restored
+		}
+		return out, nil
+	case []interface{}:
+		priorList, _ := prior.([]interface{})
+		out := make([]interface{}, len(value))
+		for index, child := range value {
+			var priorChild interface{}
+			if index < len(priorList) {
+				priorChild = priorList[index]
+			}
+			restored, err := restoreMaskedAgentLeaves(child, priorChild, key)
+			if err != nil {
+				return nil, err
+			}
+			out[index] = restored
+		}
+		return out, nil
+	default:
+		return remote, nil
+	}
+}
+
+func reconcileAgentJSONObject(current types.String, remote map[string]interface{}) (types.String, error) {
+	remote = stripAgentSyntheticParams(remote)
+	var prior map[string]interface{}
+	if !current.IsNull() && !current.IsUnknown() {
+		var err error
+		prior, err = decodeAgentJSONObject(current.ValueString())
+		if err != nil {
+			return current, err
+		}
+	}
+	value, err := restoreMaskedAgentLeaves(remote, prior, "litellm_params")
+	if err != nil {
+		return current, err
+	}
+	canonical, err := canonicalAgentJSON(value)
+	if err != nil {
+		return current, err
+	}
+	if !current.IsNull() && !current.IsUnknown() && jsonSemanticallyEqual(current.ValueString(), canonical) {
+		return current, nil
+	}
+	return types.StringValue(canonical), nil
+}
+
+func decodeAgentSecurity(value types.List) ([]map[string][]string, error) {
+	if value.IsNull() || value.IsUnknown() {
+		return nil, nil
+	}
+	result := make([]map[string][]string, 0, len(value.Elements()))
+	for _, raw := range value.Elements() {
+		mapping, ok := raw.(types.Map)
+		if !ok || mapping.IsNull() || mapping.IsUnknown() {
+			return nil, errors.New("security must contain known maps")
+		}
+		item := make(map[string][]string, len(mapping.Elements()))
+		for name, scopesRaw := range mapping.Elements() {
+			scopes, ok := scopesRaw.(types.List)
+			if !ok || scopes.IsNull() || scopes.IsUnknown() {
+				return nil, errors.New("security scopes must be known string lists")
+			}
+			item[name] = listToStringSlice(scopes)
+		}
+		result = append(result, item)
+	}
+	return result, nil
+}
+
+func readAgentSecurity(raw interface{}) (types.List, error) {
+	items, ok := raw.([]interface{})
+	if !ok {
+		return types.ListNull(types.MapType{ElemType: types.ListType{ElemType: types.StringType}}), errors.New("security must be a list")
+	}
+	values := make([]attr.Value, 0, len(items))
+	for _, rawItem := range items {
+		item, ok := rawItem.(map[string]interface{})
+		if !ok {
+			return types.ListNull(types.MapType{ElemType: types.ListType{ElemType: types.StringType}}), errors.New("security must contain objects")
+		}
+		mapped := map[string]attr.Value{}
+		for name, rawScopes := range item {
+			scopes, ok := rawScopes.([]interface{})
+			if !ok {
+				return types.ListNull(types.MapType{ElemType: types.ListType{ElemType: types.StringType}}), errors.New("security scopes must be string lists")
+			}
+			list := make([]attr.Value, 0, len(scopes))
+			for _, rawScope := range scopes {
+				scope, ok := rawScope.(string)
+				if !ok {
+					return types.ListNull(types.MapType{ElemType: types.ListType{ElemType: types.StringType}}), errors.New("security scopes must be string lists")
+				}
+				list = append(list, types.StringValue(scope))
+			}
+			mapped[name] = types.ListValueMust(types.StringType, list)
+		}
+		values = append(values, types.MapValueMust(types.ListType{ElemType: types.StringType}, mapped))
+	}
+	result, diagnostics := types.ListValue(types.MapType{ElemType: types.ListType{ElemType: types.StringType}}, values)
+	if diagnostics.HasError() {
+		return types.ListNull(types.MapType{ElemType: types.ListType{ElemType: types.StringType}}), errors.New("security could not be represented")
+	}
+	return result, nil
+}
+
+// A2AProviderConfigManager at the pinned source commit selects AgentCore only
+// for custom_llm_provider == "bedrock" with an "agentcore" model. Absence is
+// left to LiteLLM's permissive registry, but an explicit contradiction is
+// rejected before it creates a registry entry that cannot select AgentCore.
+func validateAgentCorePair(params map[string]interface{}) error {
+	model, _ := params["model"].(string)
+	provider, _ := params["custom_llm_provider"].(string)
+	if strings.Contains(model, "agentcore") && provider != "" && provider != "bedrock" {
+		return errors.New("Bedrock AgentCore models require custom_llm_provider = \"bedrock\"")
+	}
+	return nil
+}

--- a/internal/provider/agent_structured.go
+++ b/internal/provider/agent_structured.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -343,14 +342,7 @@ func readAgentSecurity(raw interface{}) (types.List, error) {
 }
 
 // A2AProviderConfigManager at the pinned source commit selects AgentCore only
-// for custom_llm_provider == "bedrock" with an "agentcore" model. Absence is
-// left to LiteLLM's permissive registry, but an explicit contradiction is
-// rejected before it creates a registry entry that cannot select AgentCore.
-func validateAgentCorePair(params map[string]interface{}) error {
-	model, _ := params["model"].(string)
-	provider, _ := params["custom_llm_provider"].(string)
-	if strings.Contains(model, "agentcore") && provider != "" && provider != "bedrock" {
-		return errors.New("Bedrock AgentCore models require custom_llm_provider = \"bedrock\"")
-	}
-	return nil
-}
+// when custom_llm_provider is "bedrock" and model contains "agentcore". That
+// predicate is selection logic, not request validation: other providers remain
+// valid even when their model name happens to contain the same substring.
+func validateAgentCorePair(map[string]interface{}) error { return nil }

--- a/internal/provider/agent_structured_test.go
+++ b/internal/provider/agent_structured_test.go
@@ -1,0 +1,408 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	datasourceschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	resourceschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestConfiguredAgentParamsIsLiteralAndLossless(t *testing.T) {
+	legacy := stringMapValue(map[string]string{
+		"false_text": "false", "leading": "001", "json_text": `{"x":1}`,
+	})
+	structured := types.StringValue(`{
+		"boolean":false,"integer":9007199254740993,"fraction":1.0000000000000001,
+		"nothing":null,"empty_list":[],"empty_object":{},"nested":{"items":[true,"001",null]}
+	}`)
+	params, configured, err := configuredAgentParams(legacy, structured)
+	if err != nil || !configured {
+		t.Fatalf("configured=%v err=%v", configured, err)
+	}
+	for key, want := range map[string]string{"false_text": "false", "leading": "001", "json_text": `{"x":1}`} {
+		if got, ok := params[key].(string); !ok || got != want {
+			t.Fatalf("%s=%#v", key, params[key])
+		}
+	}
+	encoded, err := canonicalAgentJSON(params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded map[string]interface{}
+	if err := decodeJSONUseNumber([]byte(encoded), &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded["integer"].(json.Number).String() != "9007199254740993" || decoded["fraction"].(json.Number).String() != "1.0000000000000001" {
+		t.Fatalf("numbers=%s", encoded)
+	}
+	if decoded["nothing"] != nil || len(decoded["empty_list"].([]interface{})) != 0 || len(decoded["empty_object"].(map[string]interface{})) != 0 {
+		t.Fatalf("null/empty=%s", encoded)
+	}
+}
+
+func TestConfiguredAgentParamsConflictDoesNotCoerce(t *testing.T) {
+	for _, structured := range []string{`{"value":false}`, `{"value":1}`, `{"value":{"x":1}}`} {
+		if _, _, err := configuredAgentParams(stringMapValue(map[string]string{"value": "false"}), types.StringValue(structured)); err == nil {
+			t.Fatalf("conflict accepted: %s", structured)
+		}
+	}
+	params, _, err := configuredAgentParams(stringMapValue(map[string]string{"value": "false"}), types.StringValue(`{"value":"false"}`))
+	if err != nil || params["value"] != "false" {
+		t.Fatalf("equal string conflict: %#v %v", params, err)
+	}
+}
+
+func TestImportedLegacyProjectionNeverBecomesWireType(t *testing.T) {
+	resource := &AgentResource{}
+	state := emptyKnownAgentResourceModel()
+	state.ID = types.StringValue("agent")
+	state.AgentName = types.StringValue("Agent")
+	state.LiteLLMParams = stringMapValue(map[string]string{"number": "9007199254740993", "flag": "false", "text": "remote"})
+	state.LiteLLMParamsJSON = types.StringValue(`{"number":9007199254740993,"flag":false,"text":"remote"}`)
+	plan := cloneAgentResourceModel(state)
+	config := emptyKnownAgentResourceModel()
+	config.AgentName = types.StringValue("Agent")
+	config.LiteLLMParams = stringMapValue(map[string]string{"text": "configured"})
+	request, err := resource.buildAgentUpdateRequest(&plan, &state, &config, agentFieldSet{
+		agentFieldParamsJSON:                  true,
+		agentLeaf(agentFieldParams, "number"): true,
+		agentLeaf(agentFieldParams, "flag"):   true,
+		agentLeaf(agentFieldParams, "text"):   true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	params := request["litellm_params"].(map[string]interface{})
+	if params["number"].(json.Number).String() != "9007199254740993" || params["flag"] != false || params["text"] != "configured" {
+		t.Fatalf("import compatibility projection changed wire types: %#v", params)
+	}
+}
+
+func TestAgentCoreProviderModelPairing(t *testing.T) {
+	if err := validateAgentCorePair(map[string]interface{}{"model": "bedrock/agentcore/runtime", "custom_llm_provider": "openai"}); err == nil {
+		t.Fatal("contradictory AgentCore provider pairing accepted")
+	}
+	if err := validateAgentCorePair(map[string]interface{}{"model": "bedrock/agentcore/runtime", "custom_llm_provider": "bedrock"}); err != nil {
+		t.Fatalf("source-supported AgentCore pairing rejected: %v", err)
+	}
+	// CRUD accepts arbitrary dictionaries and does not itself require the
+	// routing hint; do not invent a stronger API enum/required-field contract.
+	if err := validateAgentCorePair(map[string]interface{}{"model": "bedrock/agentcore/runtime"}); err != nil {
+		t.Fatalf("provider invented a registry restriction: %v", err)
+	}
+	if err := validateAgentCorePair(map[string]interface{}{"model": "bedrock/AgentCore/runtime", "custom_llm_provider": "openai"}); err != nil {
+		t.Fatalf("provider broadened v1.98's case-sensitive AgentCore detection: %v", err)
+	}
+}
+
+func TestAgentStructuredMaskingAndSemanticSpelling(t *testing.T) {
+	prior := types.StringValue(`{ "token": "secret", "nested": { "api_key": "value" }, "large": 9007199254740993 }`)
+	remote := map[string]interface{}{
+		"token": "litellm_enc::ciphertext", "nested": map[string]interface{}{"api_key": "va****ue"}, "large": json.Number("9.007199254740993e15"),
+	}
+	observed, err := reconcileAgentJSONObject(prior, remote)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if observed.ValueString() != prior.ValueString() {
+		t.Fatalf("spelling changed: %q", observed.ValueString())
+	}
+	if _, err := reconcileAgentJSONObject(types.StringNull(), map[string]interface{}{"api_key": "*****"}); err == nil {
+		t.Fatal("masked import succeeded without prior plaintext")
+	}
+}
+
+func TestAgentSkillSecurityAndSignaturesWirePreserveOrderDuplicates(t *testing.T) {
+	securityRaw := []interface{}{
+		map[string]interface{}{"oauth": []interface{}{"b", "a", "a"}},
+		map[string]interface{}{"oauth": []interface{}{"b", "a", "a"}},
+	}
+	security, err := readAgentSecurity(securityRaw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resource := &AgentResource{}
+	model := emptyKnownAgentResourceModel()
+	model.AgentName = types.StringValue("agent")
+	model.AgentCard = &AgentCardModel{
+		Name: types.StringValue("Agent"), URL: types.StringValue("https://agent.invalid"),
+		Skills: []AgentSkillModel{{ID: types.StringValue("skill"), Name: types.StringValue("Skill"), Security: security}},
+		Signatures: []AgentCardSignatureModel{
+			{Protected: types.StringValue("p"), Signature: types.StringValue("s"), Header: types.StringValue(`{ "n": 9007199254740993 }`)},
+			{Protected: types.StringValue("p"), Signature: types.StringValue("s"), Header: types.StringNull()},
+			{Protected: types.StringValue("p"), Signature: types.StringValue("s"), Header: types.StringNull()},
+		},
+	}
+	request, err := resource.buildAgentRequest(&model)
+	if err != nil {
+		t.Fatal(err)
+	}
+	card := request["agent_card_params"].(map[string]interface{})
+	signatures := card["signatures"].([]map[string]interface{})
+	if len(signatures) != 3 || signatures[0]["protected"] != signatures[1]["protected"] || signatures[1]["protected"] != signatures[2]["protected"] || len(signatures[1]) != len(signatures[2]) {
+		t.Fatalf("signatures=%#v", signatures)
+	}
+	if signatures[0]["header"].(map[string]interface{})["n"].(json.Number).String() != "9007199254740993" {
+		t.Fatalf("header=%#v", signatures[0])
+	}
+	skills := card["skills"].([]map[string]interface{})
+	got := skills[0]["security"].([]map[string][]string)
+	if len(got) != 2 || got[0]["oauth"][1] != "a" || got[0]["oauth"][2] != "a" {
+		t.Fatalf("security=%#v", got)
+	}
+}
+
+func TestAgentDataSourceSchemaParityAndProjection(t *testing.T) {
+	var singleResponse datasource.SchemaResponse
+	(&AgentDataSource{}).Schema(context.Background(), datasource.SchemaRequest{}, &singleResponse)
+	var listResponse datasource.SchemaResponse
+	(&AgentsListDataSource{}).Schema(context.Background(), datasource.SchemaRequest{}, &listResponse)
+	listAttribute := listResponse.Schema.Attributes["agents"].(datasourceschema.ListNestedAttribute)
+	for name := range singleResponse.Schema.Attributes {
+		if name == "id" {
+			continue
+		}
+		if _, ok := listAttribute.NestedObject.Attributes[name]; !ok {
+			t.Fatalf("list data source missing single field %s", name)
+		}
+	}
+	for name := range listAttribute.NestedObject.Attributes {
+		if name == "agent_id" {
+			continue
+		}
+		if _, ok := singleResponse.Schema.Attributes[name]; !ok {
+			t.Fatalf("single data source missing list field %s", name)
+		}
+	}
+
+	item := map[string]interface{}{
+		"agent_id": "agent", "agent_name": "Agent",
+		"agent_card_params": map[string]interface{}{"name": "Card", "url": "https://agent.invalid", "signatures": []interface{}{map[string]interface{}{"protected": "p", "signature": "s", "header": map[string]interface{}{"n": json.Number("9007199254740993")}}}},
+		"litellm_params":    map[string]interface{}{"text": "001", "flag": false, "nested": map[string]interface{}{"empty": []interface{}{}}},
+		"object_permission": map[string]interface{}{"mcp_tool_permissions": map[string]interface{}{"server": []interface{}{"a", "a"}}},
+	}
+	projected, err := projectAgentData(item, "agent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(projected.LiteLLMParams.Elements()) != 3 || projected.LiteLLMParams.Elements()["text"].(types.String).ValueString() != "001" || projected.LiteLLMParams.Elements()["flag"].(types.String).ValueString() != "false" {
+		t.Fatalf("legacy compatibility projection=%#v", projected.LiteLLMParams.Elements())
+	}
+	if !jsonSemanticallyEqual(projected.LiteLLMParamsJSON.ValueString(), `{"text":"001","flag":false,"nested":{"empty":[]}}`) {
+		t.Fatalf("json=%s", projected.LiteLLMParamsJSON.ValueString())
+	}
+
+	malformed := map[string]interface{}{"agent_id": "agent", "agent_name": "Agent", "agent_card_params": map[string]interface{}{"signatures": []interface{}{map[string]interface{}{"protected": true}}}}
+	if _, err := projectAgentData(malformed, "agent"); err == nil {
+		t.Fatal("malformed present signature accepted")
+	}
+	if _, err := projectAgentData(item, "other"); err == nil {
+		t.Fatal("identity mismatch accepted")
+	}
+	roleOmitted, err := projectAgentData(map[string]interface{}{
+		"agent_id": "agent", "agent_name": "Agent",
+		"agent_card_params": map[string]interface{}{"description": "endpoint-observable partial card", "signatures": []interface{}{map[string]interface{}{"header": nil}}},
+	}, "agent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !roleOmitted.LiteLLMParamsJSON.IsNull() || !roleOmitted.ObjectPermissionJSON.IsNull() || !roleOmitted.StaticHeaders.IsNull() {
+		t.Fatalf("role omission retained stale data: %#v", roleOmitted)
+	}
+}
+
+func TestAgentAuthoritativeParamsOverlayPreservesUnownedWireValues(t *testing.T) {
+	base := map[string]interface{}{
+		"owned": "before", "api_large": json.Number("9007199254740993"), "api_null": nil,
+		"api_nested": map[string]interface{}{"present": nil, "items": []interface{}{json.Number("1.0000000000000001")}},
+	}
+	prior := emptyKnownAgentResourceModel()
+	prior.LiteLLMParams = stringMapValue(map[string]string{"owned": "before", "api_large": "9007199254740993", "api_null": "null", "api_nested": `{"present":null,"items":[1.0000000000000001]}`})
+	prior.LiteLLMParamsJSON = types.StringValue(`{"owned":"before","api_large":9007199254740993,"api_null":null,"api_nested":{"present":null,"items":[1.0000000000000001]}}`)
+	config := emptyKnownAgentResourceModel()
+	config.LiteLLMParams = stringMapValue(map[string]string{"owned": "after"})
+	imported := agentFieldSet{
+		agentLeaf(agentFieldParams, "api_large"):  true,
+		agentLeaf(agentFieldParams, "api_null"):   true,
+		agentLeaf(agentFieldParams, "api_nested"): true,
+	}
+	patch, err := overlayAgentParamsWire(base, prior, config, imported)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if patch["owned"] != "after" || patch["api_large"].(json.Number).String() != "9007199254740993" || patch["api_null"] != nil || !exactJSONValuesEqual(base["api_nested"], patch["api_nested"]) {
+		t.Fatalf("lossy parameter overlay: %#v", patch)
+	}
+	evidence := &agentPatchPreservation{paramsBase: base, paramsPatch: patch}
+	if !evidence.matches(map[string]interface{}{"litellm_params": patch}) {
+		t.Fatal("unchanged unowned values did not confirm")
+	}
+	drifted := cloneAgentWireObject(patch)
+	drifted["api_large"] = json.Number("9007199254740992")
+	if evidence.matches(map[string]interface{}{"litellm_params": drifted}) {
+		t.Fatal("changed unowned exact number confirmed")
+	}
+	delete(drifted, "api_null")
+	if evidence.matches(map[string]interface{}{"litellm_params": drifted}) {
+		t.Fatal("changed unowned null presence confirmed")
+	}
+}
+
+func TestAgentRawCardOverlayPreservesNullAndOmission(t *testing.T) {
+	base := map[string]interface{}{
+		"name": "Agent", "url": "https://agent.invalid", "description": "before", "x-api": map[string]interface{}{"n": json.Number("9007199254740993")},
+		"signatures": []interface{}{
+			map[string]interface{}{"protected": "p-null", "signature": "s", "header": nil},
+			map[string]interface{}{"protected": "p-omitted", "signature": "s"},
+		},
+		"skills": []interface{}{
+			map[string]interface{}{"id": "null", "name": "Null", "security": nil, "x": true},
+			map[string]interface{}{"id": "omitted", "name": "Omitted", "x": false},
+		},
+	}
+	prior := emptyKnownAgentResourceModel()
+	prior.AgentCard = &AgentCardModel{Name: types.StringValue("Agent"), URL: types.StringValue("https://agent.invalid"), Description: types.StringValue("before")}
+	plan := cloneAgentResourceModel(prior)
+	plan.AgentCard.Description = types.StringValue("after")
+	config := emptyKnownAgentResourceModel()
+	config.AgentCard = &AgentCardModel{Name: types.StringValue("Agent"), URL: types.StringValue("https://agent.invalid"), Description: types.StringValue("after")}
+	imported := agentFieldSet{agentFieldCardSignatures: true, agentScopeCardSkills: true}
+	for id, raw := range agentSkillRawByID(base) {
+		markAgentSkillWireLeaves(imported, id, raw)
+	}
+	patch, err := overlayAgentCardRaw(base, plan, prior, config, imported)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if patch["description"] != "after" || !exactJSONValuesEqual(base["signatures"], patch["signatures"]) || !exactJSONValuesEqual(base["skills"], patch["skills"]) || !exactJSONValuesEqual(base["x-api"], patch["x-api"]) {
+		t.Fatalf("lossy card overlay: %#v", patch)
+	}
+	evidence := &agentPatchPreservation{cardBase: base, cardPatch: patch}
+	if !evidence.matches(map[string]interface{}{"agent_card_params": patch}) {
+		t.Fatal("preserved card did not confirm")
+	}
+	drifted := cloneAgentWireObject(patch)
+	signatures := drifted["signatures"].([]interface{})
+	delete(signatures[0].(map[string]interface{}), "header")
+	if evidence.matches(map[string]interface{}{"agent_card_params": drifted}) {
+		t.Fatal("header null-to-omitted drift confirmed")
+	}
+	drifted = cloneAgentWireObject(patch)
+	skills := drifted["skills"].([]interface{})
+	skills[1].(map[string]interface{})["security"] = nil
+	if evidence.matches(map[string]interface{}{"agent_card_params": drifted}) {
+		t.Fatal("security omitted-to-null drift confirmed")
+	}
+}
+
+func TestAgentSignatureLeafOverlayPreservesUnownedHeader(t *testing.T) {
+	base := map[string]interface{}{"name": "Agent", "url": "https://agent.invalid", "signatures": []interface{}{
+		map[string]interface{}{"protected": "before", "signature": "s", "header": nil},
+		map[string]interface{}{"protected": "api", "signature": "api"},
+	}}
+	prior := emptyKnownAgentResourceModel()
+	prior.AgentCard = &AgentCardModel{Name: types.StringValue("Agent"), URL: types.StringValue("https://agent.invalid"), Signatures: []AgentCardSignatureModel{
+		{Protected: types.StringValue("before"), Signature: types.StringValue("s"), Header: types.StringNull(), HeaderJSON: types.StringValue("null")},
+		{Protected: types.StringValue("api"), Signature: types.StringValue("api"), Header: types.StringNull(), HeaderJSON: types.StringNull()},
+	}}
+	plan := cloneAgentResourceModel(prior)
+	plan.AgentCard.Signatures = []AgentCardSignatureModel{{Protected: types.StringValue("after"), Signature: types.StringValue("s"), Header: types.StringNull(), HeaderJSON: types.StringNull()}}
+	config := emptyKnownAgentResourceModel()
+	config.AgentCard = &AgentCardModel{Name: types.StringValue("Agent"), URL: types.StringValue("https://agent.invalid"), Signatures: append([]AgentCardSignatureModel(nil), plan.AgentCard.Signatures...)}
+	imported := agentFieldSet{
+		agentSignatureLeaf(0, "header"):    true,
+		agentSignatureLeaf(1, "protected"): true, agentSignatureLeaf(1, "signature"): true,
+		agentScopeCardSignatures: true,
+	}
+	patch, err := overlayAgentCardRaw(base, plan, prior, config, imported)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signatures := agentWireObjectList(patch["signatures"])
+	if len(signatures) != 2 || signatures[0]["protected"] != "after" {
+		t.Fatalf("signature overlay=%#v", signatures)
+	}
+	if header, present := signatures[0]["header"]; !present || header != nil {
+		t.Fatalf("unowned explicit-null header changed: %#v", signatures[0])
+	}
+	if !exactJSONValuesEqual(signatures[1], base["signatures"].([]interface{})[1]) {
+		t.Fatalf("API-owned trailing signature changed: %#v", signatures[1])
+	}
+	evidence := &agentPatchPreservation{cardBase: base, cardPatch: patch}
+	if !evidence.matches(map[string]interface{}{"agent_card_params": patch}) {
+		t.Fatal("signature leaf preservation did not confirm")
+	}
+	drifted := cloneAgentWireObject(patch)
+	delete(drifted["signatures"].([]interface{})[0].(map[string]interface{}), "header")
+	if evidence.matches(map[string]interface{}{"agent_card_params": drifted}) {
+		t.Fatal("unowned header omission confirmed")
+	}
+}
+
+func TestAgentExplicitNullJSONBridges(t *testing.T) {
+	model := emptyKnownAgentResourceModel()
+	model.AgentName = types.StringValue("agent")
+	model.AgentCard = &AgentCardModel{
+		Name: types.StringValue("Agent"), URL: types.StringValue("https://agent.invalid"),
+		Signatures: []AgentCardSignatureModel{{Protected: types.StringValue("p"), Signature: types.StringValue("s"), Header: types.StringNull(), HeaderJSON: types.StringValue("null")}},
+		Skills:     []AgentSkillModel{{ID: types.StringValue("skill"), Name: types.StringValue("Skill"), Security: types.ListNull(types.MapType{ElemType: types.ListType{ElemType: types.StringType}}), SecurityJSON: types.StringValue("null")}},
+	}
+	request, err := (&AgentResource{}).buildAgentRequest(&model)
+	if err != nil {
+		t.Fatal(err)
+	}
+	card := request["agent_card_params"].(map[string]interface{})
+	if _, present := card["signatures"].([]map[string]interface{})[0]["header"]; !present || card["signatures"].([]map[string]interface{})[0]["header"] != nil {
+		t.Fatal("explicit null header was not emitted")
+	}
+	if _, present := card["skills"].([]map[string]interface{})[0]["security"]; !present || card["skills"].([]map[string]interface{})[0]["security"] != nil {
+		t.Fatal("explicit null security was not emitted")
+	}
+	model.AgentCard.Signatures[0].Header = types.StringValue(`{}`)
+	if _, err := (&AgentResource{}).buildAgentRequest(&model); err == nil {
+		t.Fatal("header/header_json conflict accepted")
+	}
+	model.AgentCard.Signatures[0].Header = types.StringNull()
+	model.AgentCard.Skills[0].SecurityJSON = types.StringValue(`[{"oauth":[1]}]`)
+	if _, err := (&AgentResource{}).buildAgentRequest(&model); err == nil {
+		t.Fatal("malformed security_json accepted")
+	}
+}
+
+func TestAgentImportSkillOwnershipUsesWirePresence(t *testing.T) {
+	data := emptyKnownAgentResourceModel()
+	data.AgentCard = &AgentCardModel{Name: types.StringValue("Agent"), URL: types.StringValue("https://agent.invalid"), Skills: []AgentSkillModel{
+		{ID: types.StringValue("null"), Name: types.StringValue("Null"), Security: types.ListNull(types.MapType{ElemType: types.ListType{ElemType: types.StringType}}), SecurityJSON: types.StringValue("null")},
+		{ID: types.StringValue("omitted"), Name: types.StringValue("Omitted"), Security: types.ListNull(types.MapType{ElemType: types.ListType{ElemType: types.StringType}}), SecurityJSON: types.StringNull()},
+	}}
+	raw := map[string]interface{}{"agent_card_params": map[string]interface{}{"skills": []interface{}{
+		map[string]interface{}{"id": "null", "name": "Null", "security": nil},
+		map[string]interface{}{"id": "omitted", "name": "Omitted"},
+	}}}
+	owned := agentImportedFieldsFromWire(data, raw)
+	if !owned[agentSkillLeaf("null", "security")] || owned[agentSkillLeaf("omitted", "security")] {
+		t.Fatalf("wire security ownership=%#v", owned)
+	}
+}
+
+func TestAgentResourceStructuredSchemaCompatibility(t *testing.T) {
+	var response resource.SchemaResponse
+	(&AgentResource{}).Schema(context.Background(), resource.SchemaRequest{}, &response)
+	legacy := response.Schema.Attributes["litellm_params"].(resourceschema.MapAttribute)
+	if legacy.ElementType != types.StringType || !legacy.Optional || !legacy.Computed || !legacy.Sensitive {
+		t.Fatalf("legacy schema changed: %#v", legacy)
+	}
+	structured := response.Schema.Attributes["litellm_params_json"].(resourceschema.StringAttribute)
+	if !structured.Optional || !structured.Computed || !structured.Sensitive {
+		t.Fatalf("structured schema=%#v", structured)
+	}
+	params, _, err := configuredAgentParams(types.MapNull(types.StringType), types.StringValue(`{}`))
+	if err != nil || len(params) != 0 {
+		t.Fatalf("empty structured object: %#v %v", params, err)
+	}
+}

--- a/internal/provider/agent_structured_test.go
+++ b/internal/provider/agent_structured_test.go
@@ -7,10 +7,17 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	datasourceschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	resourceschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
+
+type agentTestPrivate map[string][]byte
+
+func (p agentTestPrivate) GetKey(_ context.Context, key string) ([]byte, diag.Diagnostics) {
+	return p[key], nil
+}
 
 func TestConfiguredAgentParamsIsLiteralAndLossless(t *testing.T) {
 	legacy := stringMapValue(map[string]string{
@@ -84,8 +91,8 @@ func TestImportedLegacyProjectionNeverBecomesWireType(t *testing.T) {
 }
 
 func TestAgentCoreProviderModelPairing(t *testing.T) {
-	if err := validateAgentCorePair(map[string]interface{}{"model": "bedrock/agentcore/runtime", "custom_llm_provider": "openai"}); err == nil {
-		t.Fatal("contradictory AgentCore provider pairing accepted")
+	if err := validateAgentCorePair(map[string]interface{}{"model": "bedrock/agentcore/runtime", "custom_llm_provider": "openai"}); err != nil {
+		t.Fatalf("provider mistook v1.98 AgentCore selection logic for request validation: %v", err)
 	}
 	if err := validateAgentCorePair(map[string]interface{}{"model": "bedrock/agentcore/runtime", "custom_llm_provider": "bedrock"}); err != nil {
 		t.Fatalf("source-supported AgentCore pairing rejected: %v", err)
@@ -387,6 +394,151 @@ func TestAgentImportSkillOwnershipUsesWirePresence(t *testing.T) {
 	owned := agentImportedFieldsFromWire(data, raw)
 	if !owned[agentSkillLeaf("null", "security")] || owned[agentSkillLeaf("omitted", "security")] {
 		t.Fatalf("wire security ownership=%#v", owned)
+	}
+}
+
+func TestAgentConfiguredChildrenDoNotClaimFreshHeaderOrSecurity(t *testing.T) {
+	base := map[string]interface{}{"name": "Agent", "url": "https://agent.invalid",
+		"signatures": []interface{}{map[string]interface{}{"protected": "p", "signature": "s", "header": nil}},
+		"skills":     []interface{}{map[string]interface{}{"id": "skill", "name": "Skill", "security": nil}},
+	}
+	prior := emptyKnownAgentResourceModel()
+	prior.AgentCard = &AgentCardModel{Name: types.StringValue("Agent"), URL: types.StringValue("https://agent.invalid"),
+		Signatures: []AgentCardSignatureModel{{Protected: types.StringValue("p"), Signature: types.StringValue("s"), Header: types.StringNull(), HeaderJSON: types.StringNull()}},
+		Skills:     []AgentSkillModel{{ID: types.StringValue("skill"), Name: types.StringValue("Skill"), Security: types.ListNull(types.MapType{ElemType: types.ListType{ElemType: types.StringType}}), SecurityJSON: types.StringNull()}},
+	}
+	plan, config := cloneAgentResourceModel(prior), cloneAgentResourceModel(prior)
+	plan.AgentCard.Description, config.AgentCard.Description = types.StringValue("changed"), types.StringValue("changed")
+	patch, err := overlayAgentCardRaw(base, plan, prior, config, agentFieldSet{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if header, present := agentWireObjectList(patch["signatures"])[0]["header"]; !present || header != nil {
+		t.Fatalf("fresh signature header changed: %#v", patch)
+	}
+	if security, present := agentWireObjectList(patch["skills"])[0]["security"]; !present || security != nil {
+		t.Fatalf("fresh skill security changed: %#v", patch)
+	}
+}
+
+func TestAgentRemoveOwnedSkillsPreservesAPISiblings(t *testing.T) {
+	base := map[string]interface{}{"name": "Agent", "url": "https://agent.invalid", "skills": []interface{}{
+		map[string]interface{}{"id": "owned", "name": "Owned"}, map[string]interface{}{"id": "imported", "name": "Imported"}, map[string]interface{}{"id": "fresh", "name": "Fresh"},
+	}}
+	prior := emptyKnownAgentResourceModel()
+	prior.AgentCard = &AgentCardModel{Name: types.StringValue("Agent"), URL: types.StringValue("https://agent.invalid"), Skills: []AgentSkillModel{
+		{ID: types.StringValue("owned"), Name: types.StringValue("Owned")}, {ID: types.StringValue("imported"), Name: types.StringValue("Imported")},
+	}}
+	plan, config := cloneAgentResourceModel(prior), cloneAgentResourceModel(prior)
+	plan.AgentCard.Skills, config.AgentCard.Skills = nil, nil
+	patch, err := overlayAgentCardRaw(base, plan, prior, config, agentFieldSet{agentScopeCardSkills: true, agentSkillLeaf("imported", "id"): true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	byID := agentSkillRawByID(map[string]interface{}{"skills": patch["skills"]})
+	if byID["owned"] != nil || byID["imported"] == nil || byID["fresh"] == nil {
+		t.Fatalf("skill removal overlay=%#v", byID)
+	}
+	observedSkills := agentWireModelsForSkillsForTest(byID)
+	unconfirmed := append(append([]AgentSkillModel(nil), observedSkills...), AgentSkillModel{ID: types.StringValue("owned"), Name: types.StringValue("Owned")})
+	ownership := agentFieldSet{agentScopeCardSkills: true, agentSkillLeaf("imported", "id"): true}
+	if agentSkillsMutationMatch(nil, prior.AgentCard, nil, unconfirmed, ownership) {
+		t.Fatal("unconfirmed owned skill removal accepted")
+	}
+	observed := cloneAgentResourceModel(plan)
+	observed.AgentCard.Skills = observedSkills
+	confirmed := reconcileConfirmedAgentState(plan, observed, config, prior, ownership)
+	confirmedByID := map[string]bool{}
+	for _, skill := range confirmed.AgentCard.Skills {
+		confirmedByID[skill.ID.ValueString()] = true
+	}
+	if confirmedByID["owned"] || !confirmedByID["imported"] || !confirmedByID["fresh"] {
+		t.Fatalf("confirmed state forgot preserved siblings: %#v", confirmedByID)
+	}
+}
+
+func agentWireModelsForSkillsForTest(byID map[string]map[string]interface{}) []AgentSkillModel {
+	result := make([]AgentSkillModel, 0, len(byID))
+	for id, raw := range byID {
+		result = append(result, AgentSkillModel{ID: types.StringValue(id), Name: types.StringValue(raw["name"].(string))})
+	}
+	return result
+}
+
+func TestAgentV198RoundTripPreflightRejectsFilteredPaths(t *testing.T) {
+	for _, card := range []map[string]interface{}{
+		{"name": "Agent", "url": "https://agent.invalid", "x-unknown": true},
+		{"name": "Agent", "url": "https://agent.invalid", "additionalInterfaces": []interface{}{}},
+		{"name": "Agent", "url": "https://agent.invalid", "capabilities": map[string]interface{}{"pushNotifications": true}},
+	} {
+		if err := validateAgentCardV198RoundTrip(card); err == nil {
+			t.Fatalf("filtered path accepted: %#v", card)
+		}
+	}
+	if err := validateAgentCardV198RoundTrip(map[string]interface{}{"name": "Agent", "url": "https://agent.invalid", "capabilities": map[string]interface{}{"streaming": true}}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAgentCardStrictPresentShapesAndPartialAbsence(t *testing.T) {
+	malformed := []map[string]interface{}{
+		{"signatures": []interface{}{map[string]interface{}{"protected": nil}}},
+		{"signatures": []interface{}{map[string]interface{}{"signature": true}}},
+		{"skills": []interface{}{map[string]interface{}{"security": []interface{}{map[string]interface{}{"oauth": []interface{}{true}}}}}},
+		{"capabilities": map[string]interface{}{"extensions": []interface{}{map[string]interface{}{"uri": nil}}}},
+		{"securitySchemes": map[string]interface{}{"key": map[string]interface{}{"type": "http", "scheme": nil}}},
+	}
+	for _, card := range malformed {
+		if validateAgentCardResponse(card, false) == nil {
+			t.Fatalf("malformed present field accepted: %#v", card)
+		}
+	}
+	if err := validateAgentCardResponse(map[string]interface{}{"signatures": []interface{}{map[string]interface{}{"header": nil}}}, false); err != nil {
+		t.Fatalf("valid role-partial card rejected: %v", err)
+	}
+}
+
+func TestAgentImportCardOwnershipUsesRawNullPresence(t *testing.T) {
+	data := emptyKnownAgentResourceModel()
+	data.AgentCard = &AgentCardModel{Name: types.StringNull(), URL: types.StringNull(), Capabilities: &AgentCapabilitiesModel{Streaming: types.BoolNull()}, Provider: &AgentProviderModel{Organization: types.StringNull()}}
+	owned := agentImportedFieldsFromWire(data, map[string]interface{}{"agent_card_params": map[string]interface{}{"name": nil, "capabilities": map[string]interface{}{"streaming": nil}, "provider": map[string]interface{}{"organization": nil}}})
+	if !owned[agentFieldCardName] || !owned[agentFieldCardCapStreaming] || !owned[agentFieldCardProviderOrg] || owned[agentFieldCardURL] {
+		t.Fatalf("raw card presence ownership=%#v", owned)
+	}
+}
+
+func TestAgentOwnershipMarkerCanonicalGrammar(t *testing.T) {
+	valid := agentFieldSet{agentScopeCardSkills: true, agentSkillLeaf("skill", "security"): true, agentSignatureLeaf(0, "header"): true}
+	raw := encodeAgentFieldSet(valid)
+	decoded, err := decodeAgentFieldSet(raw)
+	if err != nil || !agentFieldSetsEqual(valid, decoded) {
+		t.Fatalf("canonical ownership rejected: %#v %v", decoded, err)
+	}
+	for _, corrupt := range [][]byte{[]byte(`null`), []byte(`["unknown"]`), []byte(`["agent_card.name","agent_card.name"]`), append([]byte(" "), raw...)} {
+		if _, err := decodeAgentFieldSet(corrupt); err == nil {
+			t.Fatalf("corrupt ownership accepted: %s", corrupt)
+		}
+	}
+}
+
+func TestAgentOwnershipBundleIsAllOrNothing(t *testing.T) {
+	committed := agentFieldSet{agentScopeCardSkills: true, agentSkillLeaf("skill", "id"): true}
+	pending := agentFieldSet{agentScopeCardSkills: true}
+	valid := agentTestPrivate{agentOwnershipInitializedPrivateKey: []byte("true"), agentImportedFieldsPrivateKey: encodeAgentFieldSet(committed), agentOwnershipPendingPrivateKey: encodeAgentFieldSet(pending)}
+	bundle, diagnostics := readAgentOwnershipBundle(context.Background(), valid)
+	if diagnostics.HasError() || !bundle.versioned || !agentFieldSetsEqual(bundle.pending, pending) {
+		t.Fatalf("valid bundle rejected: %#v %#v", bundle, diagnostics)
+	}
+	corrupt := []agentTestPrivate{
+		{agentOwnershipInitializedPrivateKey: []byte("true")},
+		{agentImportedFieldsPrivateKey: encodeAgentFieldSet(committed)},
+		{agentOwnershipInitializedPrivateKey: []byte("1"), agentImportedFieldsPrivateKey: encodeAgentFieldSet(committed)},
+		{agentOwnershipInitializedPrivateKey: []byte("true"), agentImportedFieldsPrivateKey: encodeAgentFieldSet(committed), agentOwnershipPendingPrivateKey: encodeAgentFieldSet(agentFieldSet{agentFieldCardName: true})},
+	}
+	for _, private := range corrupt {
+		if _, diagnostics := readAgentOwnershipBundle(context.Background(), private); !diagnostics.HasError() {
+			t.Fatalf("partial/overlapping bundle accepted: %#v", private)
+		}
 	}
 }
 

--- a/internal/provider/datasource_agent.go
+++ b/internal/provider/datasource_agent.go
@@ -13,225 +13,219 @@ import (
 
 var _ datasource.DataSource = &AgentDataSource{}
 
-func NewAgentDataSource() datasource.DataSource {
-	return &AgentDataSource{}
-}
+func NewAgentDataSource() datasource.DataSource { return &AgentDataSource{} }
 
-type AgentDataSource struct {
-	client *Client
-}
+type AgentDataSource struct{ client *Client }
 
 type AgentDataSourceModel struct {
-	ID              types.String  `tfsdk:"id"`
-	AgentName       types.String  `tfsdk:"agent_name"`
-	AgentCardParams types.Map     `tfsdk:"agent_card_params"`
-	LiteLLMParams   types.Map     `tfsdk:"litellm_params"`
-	TPMLimit        types.Int64   `tfsdk:"tpm_limit"`
-	RPMLimit        types.Int64   `tfsdk:"rpm_limit"`
-	SessionTPMLimit types.Int64   `tfsdk:"session_tpm_limit"`
-	SessionRPMLimit types.Int64   `tfsdk:"session_rpm_limit"`
-	StaticHeaders   types.Map     `tfsdk:"static_headers"`
-	ExtraHeaders    types.List    `tfsdk:"extra_headers"`
-	Spend           types.Float64 `tfsdk:"spend"`
-	CreatedAt       types.String  `tfsdk:"created_at"`
-	UpdatedAt       types.String  `tfsdk:"updated_at"`
-	CreatedBy       types.String  `tfsdk:"created_by"`
-	UpdatedBy       types.String  `tfsdk:"updated_by"`
+	ID                   types.String  `tfsdk:"id"`
+	AgentName            types.String  `tfsdk:"agent_name"`
+	AgentCardParams      types.Map     `tfsdk:"agent_card_params"`
+	AgentCardParamsJSON  types.String  `tfsdk:"agent_card_params_json"`
+	LiteLLMParams        types.Map     `tfsdk:"litellm_params"`
+	LiteLLMParamsJSON    types.String  `tfsdk:"litellm_params_json"`
+	ObjectPermissionJSON types.String  `tfsdk:"object_permission_json"`
+	TPMLimit             types.Int64   `tfsdk:"tpm_limit"`
+	RPMLimit             types.Int64   `tfsdk:"rpm_limit"`
+	SessionTPMLimit      types.Int64   `tfsdk:"session_tpm_limit"`
+	SessionRPMLimit      types.Int64   `tfsdk:"session_rpm_limit"`
+	StaticHeaders        types.Map     `tfsdk:"static_headers"`
+	ExtraHeaders         types.List    `tfsdk:"extra_headers"`
+	Spend                types.Float64 `tfsdk:"spend"`
+	CreatedAt            types.String  `tfsdk:"created_at"`
+	UpdatedAt            types.String  `tfsdk:"updated_at"`
+	CreatedBy            types.String  `tfsdk:"created_by"`
+	UpdatedBy            types.String  `tfsdk:"updated_by"`
 }
 
-func (d *AgentDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + "_agent"
-}
-
-func (d *AgentDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
-	resp.Schema = schema.Schema{
-		Description: "Retrieves information about a LiteLLM Agent (A2A).",
-		Attributes: map[string]schema.Attribute{
-			"id": schema.StringAttribute{
-				Description: "The agent ID to look up.",
-				Required:    true,
-			},
-			"agent_name": schema.StringAttribute{
-				Description: "The name of the agent.",
-				Computed:    true,
-			},
-			"agent_card_params": schema.MapAttribute{
-				Description: "The agent card parameters as a flat string map.",
-				Computed:    true,
-				ElementType: types.StringType,
-			},
-			"litellm_params": schema.MapAttribute{
-				Description: "LiteLLM-specific parameters for the agent. Marked sensitive because it can contain JWTs or AWS credentials.",
-				Computed:    true,
-				Sensitive:   true,
-				ElementType: types.StringType,
-			},
-			"tpm_limit": schema.Int64Attribute{
-				Description: "Tokens per minute limit.",
-				Computed:    true,
-			},
-			"rpm_limit": schema.Int64Attribute{
-				Description: "Requests per minute limit.",
-				Computed:    true,
-			},
-			"session_tpm_limit": schema.Int64Attribute{
-				Description: "Per-session tokens per minute limit.",
-				Computed:    true,
-			},
-			"session_rpm_limit": schema.Int64Attribute{
-				Description: "Per-session requests per minute limit.",
-				Computed:    true,
-			},
-			"static_headers": schema.MapAttribute{
-				Description: "Static headers sent with agent requests. Marked sensitive because headers commonly contain authorization credentials.",
-				Computed:    true,
-				Sensitive:   true,
-				ElementType: types.StringType,
-			},
-			"extra_headers": schema.ListAttribute{
-				Description: "Extra header names forwarded from incoming requests.",
-				Computed:    true,
-				ElementType: types.StringType,
-			},
-			"spend": schema.Float64Attribute{
-				Description: "Total spend for this agent.",
-				Computed:    true,
-			},
-			"created_at": schema.StringAttribute{
-				Description: "Timestamp when the agent was created.",
-				Computed:    true,
-			},
-			"updated_at": schema.StringAttribute{
-				Description: "Timestamp when the agent was last updated.",
-				Computed:    true,
-			},
-			"created_by": schema.StringAttribute{
-				Description: "User who created the agent.",
-				Computed:    true,
-			},
-			"updated_by": schema.StringAttribute{
-				Description: "User who last updated the agent.",
-				Computed:    true,
-			},
-		},
+func agentDataComputedAttributes() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"agent_name":             schema.StringAttribute{Description: "The name of the agent.", Computed: true},
+		"agent_card_params":      schema.MapAttribute{Description: "Historical flat map(string) compatibility projection; nested card values use deterministic JSON rendering.", Computed: true, Sensitive: true, ElementType: types.StringType},
+		"agent_card_params_json": schema.StringAttribute{Description: "Canonical lossless JSON object containing every observable agent-card field.", Computed: true, Sensitive: true},
+		"litellm_params":         schema.MapAttribute{Description: "Historical map(string) compatibility projection; heterogeneous API values use deterministic exact JSON rendering while litellm_params_json preserves wire types.", Computed: true, Sensitive: true, ElementType: types.StringType},
+		"litellm_params_json":    schema.StringAttribute{Description: "Canonical lossless JSON object containing every observable heterogeneous LiteLLM parameter.", Computed: true, Sensitive: true},
+		"object_permission_json": schema.StringAttribute{Description: "Canonical lossless JSON object containing every observable object-permission field.", Computed: true},
+		"tpm_limit":              schema.Int64Attribute{Description: "Tokens per minute limit.", Computed: true},
+		"rpm_limit":              schema.Int64Attribute{Description: "Requests per minute limit.", Computed: true},
+		"session_tpm_limit":      schema.Int64Attribute{Description: "Per-session tokens per minute limit.", Computed: true},
+		"session_rpm_limit":      schema.Int64Attribute{Description: "Per-session requests per minute limit.", Computed: true},
+		"static_headers":         schema.MapAttribute{Description: "Static headers sent with agent requests.", Computed: true, Sensitive: true, ElementType: types.StringType},
+		"extra_headers":          schema.ListAttribute{Description: "Extra header names forwarded from incoming requests.", Computed: true, ElementType: types.StringType},
+		"spend":                  schema.Float64Attribute{Description: "Total spend for this agent.", Computed: true},
+		"created_at":             schema.StringAttribute{Description: "Timestamp when the agent was created.", Computed: true},
+		"updated_at":             schema.StringAttribute{Description: "Timestamp when the agent was last updated.", Computed: true},
+		"created_by":             schema.StringAttribute{Description: "User who created the agent.", Computed: true},
+		"updated_by":             schema.StringAttribute{Description: "User who last updated the agent.", Computed: true},
 	}
 }
 
-func (d *AgentDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+func (d *AgentDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_agent"
+}
+
+func (d *AgentDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	attributes := agentDataComputedAttributes()
+	attributes["id"] = schema.StringAttribute{Description: "The exact agent ID to look up.", Required: true}
+	resp.Schema = schema.Schema{Description: "Retrieves a lossless, strictly validated LiteLLM Agent (A2A) projection.", Attributes: attributes}
+}
+
+func (d *AgentDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
 	if req.ProviderData == nil {
 		return
 	}
 	client, ok := req.ProviderData.(*Client)
 	if !ok {
-		resp.Diagnostics.AddError("Unexpected DataSource Configure Type",
-			fmt.Sprintf("Expected *Client, got: %T.", req.ProviderData))
+		resp.Diagnostics.AddError("Unexpected DataSource Configure Type", fmt.Sprintf("Expected *Client, got: %T.", req.ProviderData))
 		return
 	}
 	d.client = client
 }
 
-func (d *AgentDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
-	var data AgentDataSourceModel
-	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
-	if resp.Diagnostics.HasError() {
-		return
+func nullAgentDataProjection(id types.String) AgentDataSourceModel {
+	return AgentDataSourceModel{
+		ID: id, AgentName: types.StringNull(), AgentCardParams: types.MapNull(types.StringType), AgentCardParamsJSON: types.StringNull(),
+		LiteLLMParams: types.MapNull(types.StringType), LiteLLMParamsJSON: types.StringNull(), ObjectPermissionJSON: types.StringNull(),
+		TPMLimit: types.Int64Null(), RPMLimit: types.Int64Null(), SessionTPMLimit: types.Int64Null(), SessionRPMLimit: types.Int64Null(),
+		StaticHeaders: types.MapNull(types.StringType), ExtraHeaders: types.ListNull(types.StringType), Spend: types.Float64Null(),
+		CreatedAt: types.StringNull(), UpdatedAt: types.StringNull(), CreatedBy: types.StringNull(), UpdatedBy: types.StringNull(),
 	}
+}
 
-	endpoint := fmt.Sprintf("/v1/agents/%s", url.PathEscape(data.ID.ValueString()))
-
-	var result map[string]interface{}
-	if err := d.client.DoRequestWithResponse(ctx, "GET", endpoint, nil, &result); err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read agent: %s", err))
-		return
+func projectAgentData(item map[string]interface{}, expectedID string) (AgentDataSourceModel, error) {
+	data := nullAgentDataProjection(types.StringValue(expectedID))
+	if err := validateImportedObjectIdentity(true, "agent", item, "agent_id", expectedID); err != nil {
+		return data, err
 	}
-
-	if v, ok := result["agent_id"].(string); ok {
-		data.ID = types.StringValue(v)
+	if err := requireImportedStringField(true, "agent", item, "agent_name"); err != nil {
+		return data, err
 	}
-	if v, ok := result["agent_name"].(string); ok {
-		data.AgentName = types.StringValue(v)
-	}
+	data.ID = types.StringValue(item["agent_id"].(string))
+	data.AgentName = types.StringValue(item["agent_name"].(string))
 
-	// Flatten agent_card_params to a string map for datasource simplicity
-	if cardRaw, ok := result["agent_card_params"].(map[string]interface{}); ok {
-		cardMap := map[string]attr.Value{}
-		for k, v := range cardRaw {
-			cardMap[k] = types.StringValue(fmt.Sprintf("%v", v))
+	if raw, present := item["agent_card_params"]; present && raw != nil {
+		card, ok := raw.(map[string]interface{})
+		if !ok {
+			return data, fmt.Errorf("invalid agent_card_params")
 		}
-		data.AgentCardParams, _ = types.MapValue(types.StringType, cardMap)
-	} else {
-		data.AgentCardParams = types.MapNull(types.StringType)
-	}
-
-	// LiteLLM params
-	if params, ok := result["litellm_params"].(map[string]interface{}); ok && len(params) > 0 {
-		paramMap := map[string]attr.Value{}
-		for k, v := range params {
-			paramMap[k] = types.StringValue(fmt.Sprintf("%v", v))
+		if err := validateAgentCardResponse(card, false); err != nil {
+			return data, err
 		}
-		data.LiteLLMParams, _ = types.MapValue(types.StringType, paramMap)
-	} else {
-		data.LiteLLMParams = types.MapNull(types.StringType)
+		legacy, err := agentStringProjection(card, false)
+		if err != nil {
+			return data, err
+		}
+		data.AgentCardParams = legacy
+		encoded, err := canonicalAgentJSON(card)
+		if err != nil {
+			return data, err
+		}
+		data.AgentCardParamsJSON = types.StringValue(encoded)
 	}
-
-	// Rate limits
+	if raw, present := item["litellm_params"]; present && raw != nil {
+		params, ok := raw.(map[string]interface{})
+		if !ok {
+			return data, fmt.Errorf("invalid litellm_params")
+		}
+		legacy, err := agentStringProjection(params, true)
+		if err != nil {
+			return data, err
+		}
+		data.LiteLLMParams = legacy
+		structured, err := reconcileAgentJSONObject(types.StringNull(), params)
+		if err != nil {
+			return data, fmt.Errorf("unrecoverable masked litellm_params")
+		}
+		data.LiteLLMParamsJSON = structured
+	}
+	if raw, present := item["object_permission"]; present && raw != nil {
+		permission, ok := raw.(map[string]interface{})
+		if !ok {
+			return data, fmt.Errorf("invalid object_permission")
+		}
+		temporary := emptyKnownAgentResourceModel()
+		if err := (&AgentResource{}).readObjectPermission(permission, &temporary); err != nil {
+			return data, err
+		}
+		encoded, err := canonicalAgentJSON(permission)
+		if err != nil {
+			return data, err
+		}
+		data.ObjectPermissionJSON = types.StringValue(encoded)
+	}
 	for _, field := range []struct {
 		name   string
 		target *types.Int64
 	}{
-		{"tpm_limit", &data.TPMLimit},
-		{"rpm_limit", &data.RPMLimit},
-		{"session_tpm_limit", &data.SessionTPMLimit},
-		{"session_rpm_limit", &data.SessionRPMLimit},
+		{"tpm_limit", &data.TPMLimit}, {"rpm_limit", &data.RPMLimit}, {"session_tpm_limit", &data.SessionTPMLimit}, {"session_rpm_limit", &data.SessionRPMLimit},
 	} {
-		if err := updateInt64FromAPI(field.target, result, true, true, field.name); err != nil {
-			resp.Diagnostics.AddError("Invalid API Response", err.Error())
-			return
+		if err := updateInt64FromAPI(field.target, item, true, true, field.name); err != nil {
+			return data, err
 		}
 	}
-
-	if err := updateFloat64FromAPI(&data.Spend, result, true, true, "spend"); err != nil {
-		resp.Diagnostics.AddError("Invalid API Response", err.Error())
-		return
+	if err := updateFloat64FromAPI(&data.Spend, item, true, true, "spend"); err != nil {
+		return data, err
 	}
-
-	// Static headers
-	if headers, ok := result["static_headers"].(map[string]interface{}); ok && len(headers) > 0 {
-		headerMap := map[string]attr.Value{}
-		for k, v := range headers {
-			headerMap[k] = types.StringValue(fmt.Sprintf("%v", v))
+	if raw, present := item["static_headers"]; present && raw != nil {
+		headers, ok := raw.(map[string]interface{})
+		if !ok {
+			return data, fmt.Errorf("invalid static_headers")
 		}
-		data.StaticHeaders, _ = types.MapValue(types.StringType, headerMap)
-	} else {
-		data.StaticHeaders = types.MapNull(types.StringType)
+		values := map[string]attr.Value{}
+		for key, rawValue := range headers {
+			value, ok := rawValue.(string)
+			if !ok {
+				return data, fmt.Errorf("invalid static_headers")
+			}
+			values[key] = types.StringValue(value)
+		}
+		data.StaticHeaders = types.MapValueMust(types.StringType, values)
 	}
-
-	// Extra headers
-	if headers, ok := result["extra_headers"].([]interface{}); ok && len(headers) > 0 {
-		vals := make([]attr.Value, 0, len(headers))
-		for _, h := range headers {
-			if s, ok := h.(string); ok {
-				vals = append(vals, types.StringValue(s))
+	if raw, present := item["extra_headers"]; present && raw != nil {
+		headers, ok := raw.([]interface{})
+		if !ok {
+			return data, fmt.Errorf("invalid extra_headers")
+		}
+		for _, value := range headers {
+			if _, ok := value.(string); !ok {
+				return data, fmt.Errorf("invalid extra_headers")
 			}
 		}
-		data.ExtraHeaders, _ = types.ListValue(types.StringType, vals)
-	} else {
-		data.ExtraHeaders = types.ListNull(types.StringType)
+		data.ExtraHeaders = interfaceSliceToStringList(headers)
 	}
+	for _, field := range []struct {
+		name   string
+		target *types.String
+	}{
+		{"created_at", &data.CreatedAt}, {"updated_at", &data.UpdatedAt}, {"created_by", &data.CreatedBy}, {"updated_by", &data.UpdatedBy},
+	} {
+		if raw, present := item[field.name]; present && raw != nil {
+			value, ok := raw.(string)
+			if !ok {
+				return data, fmt.Errorf("invalid %s", field.name)
+			}
+			*field.target = types.StringValue(value)
+		}
+	}
+	return data, nil
+}
 
-	// Computed timestamps
-	if v, ok := result["created_at"].(string); ok {
-		data.CreatedAt = types.StringValue(v)
+func (d *AgentDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var config AgentDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
-	if v, ok := result["updated_at"].(string); ok {
-		data.UpdatedAt = types.StringValue(v)
+	var result map[string]interface{}
+	endpoint := fmt.Sprintf("/v1/agents/%s", url.PathEscape(config.ID.ValueString()))
+	if err := d.client.DoRequestWithResponse(ctx, "GET", endpoint, nil, &result); err != nil {
+		resp.Diagnostics.AddError("Client Error", "Unable to read the requested agent authoritatively.")
+		return
 	}
-	if v, ok := result["created_by"].(string); ok {
-		data.CreatedBy = types.StringValue(v)
+	data, err := projectAgentData(result, config.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", "LiteLLM returned a malformed or identity-mismatched agent.")
+		return
 	}
-	if v, ok := result["updated_by"].(string); ok {
-		data.UpdatedBy = types.StringValue(v)
-	}
-
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/provider/datasource_agents_list.go
+++ b/internal/provider/datasource_agents_list.go
@@ -12,13 +12,9 @@ import (
 
 var _ datasource.DataSource = &AgentsListDataSource{}
 
-func NewAgentsListDataSource() datasource.DataSource {
-	return &AgentsListDataSource{}
-}
+func NewAgentsListDataSource() datasource.DataSource { return &AgentsListDataSource{} }
 
-type AgentsListDataSource struct {
-	client *Client
-}
+type AgentsListDataSource struct{ client *Client }
 
 type AgentsListDataSourceModel struct {
 	ID     types.String         `tfsdk:"id"`
@@ -26,98 +22,62 @@ type AgentsListDataSourceModel struct {
 }
 
 type AgentListItemModel struct {
-	AgentID         types.String  `tfsdk:"agent_id"`
-	AgentName       types.String  `tfsdk:"agent_name"`
-	TPMLimit        types.Int64   `tfsdk:"tpm_limit"`
-	RPMLimit        types.Int64   `tfsdk:"rpm_limit"`
-	SessionTPMLimit types.Int64   `tfsdk:"session_tpm_limit"`
-	SessionRPMLimit types.Int64   `tfsdk:"session_rpm_limit"`
-	Spend           types.Float64 `tfsdk:"spend"`
-	CreatedAt       types.String  `tfsdk:"created_at"`
-	UpdatedAt       types.String  `tfsdk:"updated_at"`
-	CreatedBy       types.String  `tfsdk:"created_by"`
-	UpdatedBy       types.String  `tfsdk:"updated_by"`
+	AgentID              types.String  `tfsdk:"agent_id"`
+	AgentName            types.String  `tfsdk:"agent_name"`
+	AgentCardParams      types.Map     `tfsdk:"agent_card_params"`
+	AgentCardParamsJSON  types.String  `tfsdk:"agent_card_params_json"`
+	LiteLLMParams        types.Map     `tfsdk:"litellm_params"`
+	LiteLLMParamsJSON    types.String  `tfsdk:"litellm_params_json"`
+	ObjectPermissionJSON types.String  `tfsdk:"object_permission_json"`
+	TPMLimit             types.Int64   `tfsdk:"tpm_limit"`
+	RPMLimit             types.Int64   `tfsdk:"rpm_limit"`
+	SessionTPMLimit      types.Int64   `tfsdk:"session_tpm_limit"`
+	SessionRPMLimit      types.Int64   `tfsdk:"session_rpm_limit"`
+	StaticHeaders        types.Map     `tfsdk:"static_headers"`
+	ExtraHeaders         types.List    `tfsdk:"extra_headers"`
+	Spend                types.Float64 `tfsdk:"spend"`
+	CreatedAt            types.String  `tfsdk:"created_at"`
+	UpdatedAt            types.String  `tfsdk:"updated_at"`
+	CreatedBy            types.String  `tfsdk:"created_by"`
+	UpdatedBy            types.String  `tfsdk:"updated_by"`
 }
 
-func (d *AgentsListDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+func (d *AgentsListDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_agents"
 }
 
-func (d *AgentsListDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+func (d *AgentsListDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	itemAttributes := agentDataComputedAttributes()
+	itemAttributes["agent_id"] = schema.StringAttribute{Description: "The unique agent ID.", Computed: true}
 	resp.Schema = schema.Schema{
-		Description: "Fetches a list of all LiteLLM Agents (A2A).",
+		Description: "Fetches lossless, strictly validated projections of all visible LiteLLM Agents (A2A). Role-sanitized omitted fields are null for that item.",
 		Attributes: map[string]schema.Attribute{
-			"id": schema.StringAttribute{
-				Description: "Placeholder identifier for this data source.",
-				Computed:    true,
-			},
-			"agents": schema.ListNestedAttribute{
-				Description: "List of agents.",
-				Computed:    true,
-				NestedObject: schema.NestedAttributeObject{
-					Attributes: map[string]schema.Attribute{
-						"agent_id": schema.StringAttribute{
-							Description: "The unique agent ID.",
-							Computed:    true,
-						},
-						"agent_name": schema.StringAttribute{
-							Description: "The name of the agent.",
-							Computed:    true,
-						},
-						"tpm_limit": schema.Int64Attribute{
-							Description: "Tokens per minute limit.",
-							Computed:    true,
-						},
-						"rpm_limit": schema.Int64Attribute{
-							Description: "Requests per minute limit.",
-							Computed:    true,
-						},
-						"session_tpm_limit": schema.Int64Attribute{
-							Description: "Per-session tokens per minute limit.",
-							Computed:    true,
-						},
-						"session_rpm_limit": schema.Int64Attribute{
-							Description: "Per-session requests per minute limit.",
-							Computed:    true,
-						},
-						"spend": schema.Float64Attribute{
-							Description: "Total spend for this agent.",
-							Computed:    true,
-						},
-						"created_at": schema.StringAttribute{
-							Description: "Timestamp when the agent was created.",
-							Computed:    true,
-						},
-						"updated_at": schema.StringAttribute{
-							Description: "Timestamp when the agent was last updated.",
-							Computed:    true,
-						},
-						"created_by": schema.StringAttribute{
-							Description: "User who created the agent.",
-							Computed:    true,
-						},
-						"updated_by": schema.StringAttribute{
-							Description: "User who last updated the agent.",
-							Computed:    true,
-						},
-					},
-				},
-			},
+			"id":     schema.StringAttribute{Description: "Stable data-source identifier.", Computed: true},
+			"agents": schema.ListNestedAttribute{Description: "Agents sorted by agent_id.", Computed: true, NestedObject: schema.NestedAttributeObject{Attributes: itemAttributes}},
 		},
 	}
 }
 
-func (d *AgentsListDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+func (d *AgentsListDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
 	if req.ProviderData == nil {
 		return
 	}
 	client, ok := req.ProviderData.(*Client)
 	if !ok {
-		resp.Diagnostics.AddError("Unexpected DataSource Configure Type",
-			fmt.Sprintf("Expected *Client, got: %T.", req.ProviderData))
+		resp.Diagnostics.AddError("Unexpected DataSource Configure Type", fmt.Sprintf("Expected *Client, got: %T.", req.ProviderData))
 		return
 	}
 	d.client = client
+}
+
+func agentListItem(projected AgentDataSourceModel) AgentListItemModel {
+	return AgentListItemModel{
+		AgentID: projected.ID, AgentName: projected.AgentName, AgentCardParams: projected.AgentCardParams, AgentCardParamsJSON: projected.AgentCardParamsJSON,
+		LiteLLMParams: projected.LiteLLMParams, LiteLLMParamsJSON: projected.LiteLLMParamsJSON, ObjectPermissionJSON: projected.ObjectPermissionJSON,
+		TPMLimit: projected.TPMLimit, RPMLimit: projected.RPMLimit, SessionTPMLimit: projected.SessionTPMLimit, SessionRPMLimit: projected.SessionRPMLimit,
+		StaticHeaders: projected.StaticHeaders, ExtraHeaders: projected.ExtraHeaders, Spend: projected.Spend,
+		CreatedAt: projected.CreatedAt, UpdatedAt: projected.UpdatedAt, CreatedBy: projected.CreatedBy, UpdatedBy: projected.UpdatedBy,
+	}
 }
 
 func (d *AgentsListDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
@@ -126,63 +86,27 @@ func (d *AgentsListDataSource) Read(ctx context.Context, req datasource.ReadRequ
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
 	result, err := fetchTopLevelListObjects(ctx, d.client, "/v1/agents", "agent item")
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to list agents: %s", err))
+		resp.Diagnostics.AddError("Client Error", "Unable to list agents authoritatively.")
 		return
 	}
-
 	agents := make([]AgentListItemModel, 0, len(result))
 	for _, item := range result {
-		agent := AgentListItemModel{}
-		if v, ok := item["agent_id"].(string); ok && v != "" {
-			agent.AgentID = types.StringValue(v)
-		} else {
-			resp.Diagnostics.AddError("Invalid API Response", "/v1/agents returned an agent object without agent_id")
+		id, ok := item["agent_id"].(string)
+		if !ok || id == "" {
+			resp.Diagnostics.AddError("Invalid API Response", "/v1/agents returned an agent object without a valid agent_id.")
 			return
 		}
-		if v, ok := item["agent_name"].(string); ok {
-			agent.AgentName = types.StringValue(v)
-		}
-		for _, field := range []struct {
-			name   string
-			target *types.Int64
-		}{
-			{"tpm_limit", &agent.TPMLimit},
-			{"rpm_limit", &agent.RPMLimit},
-			{"session_tpm_limit", &agent.SessionTPMLimit},
-			{"session_rpm_limit", &agent.SessionRPMLimit},
-		} {
-			if err := updateInt64FromAPI(field.target, item, true, true, field.name); err != nil {
-				resp.Diagnostics.AddError("Invalid API Response", err.Error())
-				return
-			}
-		}
-		if err := updateFloat64FromAPI(&agent.Spend, item, true, true, "spend"); err != nil {
-			resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		projected, err := projectAgentData(item, id)
+		if err != nil {
+			resp.Diagnostics.AddError("Invalid API Response", "/v1/agents returned a malformed agent object.")
 			return
 		}
-		if v, ok := item["created_at"].(string); ok {
-			agent.CreatedAt = types.StringValue(v)
-		}
-		if v, ok := item["updated_at"].(string); ok {
-			agent.UpdatedAt = types.StringValue(v)
-		}
-		if v, ok := item["created_by"].(string); ok {
-			agent.CreatedBy = types.StringValue(v)
-		}
-		if v, ok := item["updated_by"].(string); ok {
-			agent.UpdatedBy = types.StringValue(v)
-		}
-		agents = append(agents, agent)
+		agents = append(agents, agentListItem(projected))
 	}
-	sort.SliceStable(agents, func(i, j int) bool {
-		return agents[i].AgentID.ValueString() < agents[j].AgentID.ValueString()
-	})
-
+	sort.SliceStable(agents, func(i, j int) bool { return agents[i].AgentID.ValueString() < agents[j].AgentID.ValueString() })
 	data.ID = types.StringValue("agents-list")
 	data.Agents = agents
-
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/provider/resource_agent.go
+++ b/internal/provider/resource_agent.go
@@ -44,13 +44,22 @@ type AgentCapabilitiesModel struct {
 }
 
 type AgentSkillModel struct {
-	ID          types.String `tfsdk:"id"`
-	Name        types.String `tfsdk:"name"`
-	Description types.String `tfsdk:"description"`
-	Tags        types.List   `tfsdk:"tags"`
-	Examples    types.List   `tfsdk:"examples"`
-	InputModes  types.List   `tfsdk:"input_modes"`
-	OutputModes types.List   `tfsdk:"output_modes"`
+	ID           types.String `tfsdk:"id"`
+	Name         types.String `tfsdk:"name"`
+	Description  types.String `tfsdk:"description"`
+	Tags         types.List   `tfsdk:"tags"`
+	Examples     types.List   `tfsdk:"examples"`
+	InputModes   types.List   `tfsdk:"input_modes"`
+	OutputModes  types.List   `tfsdk:"output_modes"`
+	Security     types.List   `tfsdk:"security"`
+	SecurityJSON types.String `tfsdk:"security_json"`
+}
+
+type AgentCardSignatureModel struct {
+	Protected  types.String `tfsdk:"protected"`
+	Signature  types.String `tfsdk:"signature"`
+	Header     types.String `tfsdk:"header"`
+	HeaderJSON types.String `tfsdk:"header_json"`
 }
 
 type AgentObjectPermissionModel struct {
@@ -62,34 +71,36 @@ type AgentObjectPermissionModel struct {
 }
 
 type AgentCardModel struct {
-	Name                              types.String            `tfsdk:"name"`
-	Description                       types.String            `tfsdk:"description"`
-	URL                               types.String            `tfsdk:"url"`
-	Version                           types.String            `tfsdk:"version"`
-	ProtocolVersion                   types.String            `tfsdk:"protocol_version"`
-	DefaultInputModes                 types.List              `tfsdk:"default_input_modes"`
-	DefaultOutputModes                types.List              `tfsdk:"default_output_modes"`
-	Capabilities                      *AgentCapabilitiesModel `tfsdk:"capabilities"`
-	Skills                            []AgentSkillModel       `tfsdk:"skills"`
-	Provider                          *AgentProviderModel     `tfsdk:"provider"`
-	PreferredTransport                types.String            `tfsdk:"preferred_transport"`
-	IconURL                           types.String            `tfsdk:"icon_url"`
-	DocumentationURL                  types.String            `tfsdk:"documentation_url"`
-	SupportsAuthenticatedExtendedCard types.Bool              `tfsdk:"supports_authenticated_extended_card"`
+	Name                              types.String              `tfsdk:"name"`
+	Description                       types.String              `tfsdk:"description"`
+	URL                               types.String              `tfsdk:"url"`
+	Version                           types.String              `tfsdk:"version"`
+	ProtocolVersion                   types.String              `tfsdk:"protocol_version"`
+	DefaultInputModes                 types.List                `tfsdk:"default_input_modes"`
+	DefaultOutputModes                types.List                `tfsdk:"default_output_modes"`
+	Capabilities                      *AgentCapabilitiesModel   `tfsdk:"capabilities"`
+	Skills                            []AgentSkillModel         `tfsdk:"skills"`
+	Provider                          *AgentProviderModel       `tfsdk:"provider"`
+	PreferredTransport                types.String              `tfsdk:"preferred_transport"`
+	IconURL                           types.String              `tfsdk:"icon_url"`
+	DocumentationURL                  types.String              `tfsdk:"documentation_url"`
+	SupportsAuthenticatedExtendedCard types.Bool                `tfsdk:"supports_authenticated_extended_card"`
+	Signatures                        []AgentCardSignatureModel `tfsdk:"signatures"`
 }
 
 type AgentResourceModel struct {
-	ID               types.String                `tfsdk:"id"`
-	AgentName        types.String                `tfsdk:"agent_name"`
-	AgentCard        *AgentCardModel             `tfsdk:"agent_card"`
-	LiteLLMParams    types.Map                   `tfsdk:"litellm_params"`
-	ObjectPermission *AgentObjectPermissionModel `tfsdk:"object_permission"`
-	TPMLimit         types.Int64                 `tfsdk:"tpm_limit"`
-	RPMLimit         types.Int64                 `tfsdk:"rpm_limit"`
-	SessionTPMLimit  types.Int64                 `tfsdk:"session_tpm_limit"`
-	SessionRPMLimit  types.Int64                 `tfsdk:"session_rpm_limit"`
-	StaticHeaders    types.Map                   `tfsdk:"static_headers"`
-	ExtraHeaders     types.List                  `tfsdk:"extra_headers"`
+	ID                types.String                `tfsdk:"id"`
+	AgentName         types.String                `tfsdk:"agent_name"`
+	AgentCard         *AgentCardModel             `tfsdk:"agent_card"`
+	LiteLLMParams     types.Map                   `tfsdk:"litellm_params"`
+	LiteLLMParamsJSON types.String                `tfsdk:"litellm_params_json"`
+	ObjectPermission  *AgentObjectPermissionModel `tfsdk:"object_permission"`
+	TPMLimit          types.Int64                 `tfsdk:"tpm_limit"`
+	RPMLimit          types.Int64                 `tfsdk:"rpm_limit"`
+	SessionTPMLimit   types.Int64                 `tfsdk:"session_tpm_limit"`
+	SessionRPMLimit   types.Int64                 `tfsdk:"session_rpm_limit"`
+	StaticHeaders     types.Map                   `tfsdk:"static_headers"`
+	ExtraHeaders      types.List                  `tfsdk:"extra_headers"`
 	// Computed
 	CreatedAt types.String `tfsdk:"created_at"`
 	UpdatedAt types.String `tfsdk:"updated_at"`
@@ -117,11 +128,21 @@ func (r *AgentResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 				Required:    true,
 			},
 			"litellm_params": schema.MapAttribute{
-				Description: "LiteLLM-specific parameters for the agent (e.g. model, api_key). Marked sensitive because it can contain JWTs or AWS credentials.",
+				Description: "Legacy literal string-only LiteLLM parameters. Values are never parsed or coerced. Use litellm_params_json for heterogeneous values.",
 				Optional:    true,
 				Computed:    true,
 				Sensitive:   true,
 				ElementType: types.StringType,
+			},
+			"litellm_params_json": schema.StringAttribute{
+				Description: "Lossless JSON-object bridge for arbitrary LiteLLM parameters. It merges with non-overlapping legacy map keys; overlapping values must be the identical JSON string value. Explicit configuration owns only its exact keys.",
+				Optional:    true,
+				Computed:    true,
+				Sensitive:   true,
+				Validators:  []validator.String{agentJSONObjectValidator{}},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"tpm_limit": schema.Int64Attribute{
 				Description: "Tokens per minute limit for the agent.",
@@ -190,7 +211,7 @@ func (r *AgentResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 						Optional:    true,
 					},
 					"protocol_version": schema.StringAttribute{
-						Description: "A2A protocol version (e.g. '0.2.6').",
+						Description: "A2A protocol version string. LiteLLM serves the 0.3 and 1.0 protocol families; the registry field itself is not narrowed to a provider-defined enum.",
 						Optional:    true,
 					},
 					"default_input_modes": schema.ListAttribute{
@@ -253,6 +274,15 @@ func (r *AgentResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 							},
 						},
 					},
+					"signatures": schema.ListNestedBlock{
+						Description: "Ordered JWS signatures. Duplicate entries are preserved. An empty list explicitly clears signatures.",
+						NestedObject: schema.NestedBlockObject{Attributes: map[string]schema.Attribute{
+							"protected":   schema.StringAttribute{Description: "JWS protected header.", Required: true, Sensitive: true},
+							"signature":   schema.StringAttribute{Description: "JWS signature.", Required: true, Sensitive: true},
+							"header":      schema.StringAttribute{Description: "Optional arbitrary non-null JWS header as a JSON object. Conflicts with header_json.", Optional: true, Sensitive: true, Validators: []validator.String{agentJSONObjectValidator{}}},
+							"header_json": schema.StringAttribute{Description: "Strict JSON bridge for an arbitrary JWS header, including explicit JSON null. Conflicts with header.", Optional: true, Sensitive: true, Validators: []validator.String{agentJSONNullOrObjectValidator{}}},
+						}},
+					},
 					"skills": schema.ListNestedBlock{
 						Description: "Skills the agent can perform.",
 						NestedObject: schema.NestedBlockObject{
@@ -288,6 +318,17 @@ func (r *AgentResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 									Description: "Supported output MIME types.",
 									Optional:    true,
 									ElementType: types.StringType,
+								},
+								"security": schema.ListAttribute{
+									Description: "Ordered non-null A2A security requirements. Each map value is an ordered list of scopes; duplicates are preserved. Conflicts with security_json.",
+									Optional:    true,
+									ElementType: types.MapType{ElemType: types.ListType{ElemType: types.StringType}},
+								},
+								"security_json": schema.StringAttribute{
+									Description: "Strict JSON bridge for ordered A2A security requirements, including explicit JSON null. Conflicts with security.",
+									Optional:    true,
+									Sensitive:   true,
+									Validators:  []validator.String{agentJSONNullOrSecurityValidator{}},
 								},
 							},
 						},
@@ -351,6 +392,12 @@ func (r *AgentResource) Create(ctx context.Context, req resource.CreateRequest, 
 		return
 	}
 
+	// Optional+Computed JSON is unknown in a legacy-only create plan. Request
+	// construction uses the explicit configuration surface and never treats
+	// that unknown as a structured value.
+	if planned.LiteLLMParamsJSON.IsUnknown() {
+		planned.LiteLLMParamsJSON = config.LiteLLMParamsJSON
+	}
 	agentReq, err := r.buildAgentRequest(&planned)
 	if err != nil {
 		resp.Diagnostics.AddError("Invalid Agent Request", "The agent request could not be converted to the LiteLLM v1.98 wire shape.")
@@ -418,7 +465,8 @@ func (r *AgentResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	}
 	imported := string(importedMarker) == "true"
 
-	if err := r.readAgentWithOwnership(ctx, &data, imported, apiOwned); err != nil {
+	var rawResult map[string]interface{}
+	if err := r.readAgentWithOwnershipTransportCapture(ctx, &data, imported, apiOwned, false, &rawResult); err != nil {
 		if IsAPIErrorStatus(err, 404) {
 			resp.State.RemoveResource(ctx)
 			return
@@ -432,7 +480,7 @@ func (r *AgentResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 	if !resp.Diagnostics.HasError() && resp.Private != nil {
 		if imported {
-			apiOwned = agentImportedFieldsFromState(data)
+			apiOwned = agentImportedFieldsFromWire(data, rawResult)
 		}
 		resp.Diagnostics.Append(resp.Private.SetKey(ctx, agentImportedFieldsPrivateKey, encodeAgentFieldSet(apiOwned))...)
 		resp.Diagnostics.Append(resp.Private.SetKey(ctx, agentOwnershipInitializedPrivateKey, []byte("true"))...)
@@ -478,26 +526,57 @@ func (r *AgentResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		return
 	}
 	cardTouched := agentCardUpdateTouched(planned, state, config, importedFields)
-	if cardTouched {
-		// This GET intentionally occurs after secret hydration and immediately
-		// before request construction. The replacement card is based only on this
-		// authoritative response, never stale Terraform state.
-		fresh, err := r.sampleFreshAgentCard(ctx, state, importedFields, 8)
+	paramsTouched := agentParamsUpdateTouched(planned, state, config, importedFields)
+	var preservation agentPatchPreservation
+	if paramsTouched || cardTouched {
+		// Every complete-object PATCH starts from two matching fresh-connection
+		// samples. Terraform overlays only its exact owned keys/paths onto that
+		// wire object; typed state is never authority for unowned values.
+		paramsBase, cardBase, err := r.sampleFreshAgentUpdateBase(ctx, state, paramsTouched, cardTouched, 8)
 		if err != nil {
 			resp.Private = req.Private
 			resp.State = req.State
-			resp.Diagnostics.AddError("Agent Update Preflight Failed", "The provider could not authoritatively preserve the complete current agent card through bounded fresh-worker sampling before mutation. The agent was not changed.")
+			resp.Diagnostics.AddError("Agent Update Preflight Failed", "The provider could not obtain a stable fresh authoritative complete-object base. The agent was not changed.")
 			return
 		}
-		wirePlanned.AgentCard = overlayAgentCardWire(fresh, planned, state, config, importedFields)
+		if paramsTouched {
+			preservation.paramsBase = paramsBase
+			preservation.paramsPatch, err = overlayAgentParamsWire(paramsBase, state, config, importedFields)
+			if err != nil {
+				resp.Private = req.Private
+				resp.State = req.State
+				resp.Diagnostics.AddError("Invalid Agent Request", "The configured LiteLLM parameter overlay is not safe. The agent was not changed.")
+				return
+			}
+		}
+		if cardTouched {
+			preservation.cardBase = cardBase
+			preservation.cardPatch, err = overlayAgentCardRaw(cardBase, planned, state, config, importedFields)
+			if err != nil {
+				resp.Private = req.Private
+				resp.State = req.State
+				resp.Diagnostics.AddError("Invalid Agent Request", "The configured agent-card overlay is not safe. The agent was not changed.")
+				return
+			}
+		}
 	}
 
-	agentReq, err := r.buildAgentUpdateRequest(&wirePlanned, &state, &config, importedFields, cardTouched)
+	agentReq, err := r.buildAgentUpdateRequest(&wirePlanned, &state, &config, importedFields, false)
 	if err != nil {
 		resp.Private = req.Private
 		resp.State = req.State
 		resp.Diagnostics.AddError("Invalid Agent Request", "The agent update could not be converted to the LiteLLM v1.98 wire shape. The agent was not changed.")
 		return
+	}
+	if paramsTouched {
+		agentReq["litellm_params"] = preservation.paramsPatch
+	} else {
+		delete(agentReq, "litellm_params")
+	}
+	if cardTouched {
+		agentReq["agent_card_params"] = preservation.cardPatch
+	} else {
+		delete(agentReq, "agent_card_params")
 	}
 	endpoint := fmt.Sprintf("/v1/agents/%s", url.PathEscape(planned.ID.ValueString()))
 	if err := r.client.DoRequestWithResponse(ctx, "PATCH", endpoint, agentReq, nil); err != nil {
@@ -507,7 +586,7 @@ func (r *AgentResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		return
 	}
 
-	confirmed, err := r.confirmAgentMutation(ctx, planned, state, config, importedFields, 8)
+	confirmed, err := r.confirmAgentMutationWithPreservation(ctx, planned, state, config, importedFields, &preservation, 8)
 	if err != nil {
 		resp.Private = req.Private
 		resp.State = req.State
@@ -523,7 +602,8 @@ func (r *AgentResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &confirmed)...)
 	if !resp.Diagnostics.HasError() && resp.Private != nil {
-		for field := range agentConfiguredFields(config) {
+		configuredFields := agentConfiguredFields(config)
+		for field := range configuredFields {
 			delete(importedFields, field)
 		}
 		resp.Diagnostics.Append(resp.Private.SetKey(ctx, agentImportedFieldsPrivateKey, encodeAgentFieldSet(importedFields))...)
@@ -638,7 +718,7 @@ func (r *AgentResource) hydrateAgentUpdateFieldsWithOwnership(ctx context.Contex
 	if imported == nil {
 		imported = agentFieldSet{}
 	}
-	needsParams := data.LiteLLMParams.IsNull() || data.LiteLLMParams.IsUnknown() || agentMapContainsMaskedValues(data.LiteLLMParams) || (!config.LiteLLMParams.IsNull() && agentFieldSetHasPrefix(imported, agentFieldParams+"["))
+	needsParams := data.LiteLLMParams.IsNull() || data.LiteLLMParams.IsUnknown() || agentMapContainsMaskedValues(data.LiteLLMParams) || (!config.LiteLLMParams.IsNull() && agentFieldSetHasPrefix(imported, agentFieldParams+"[")) || (imported[agentFieldParamsJSON] && config.LiteLLMParamsJSON.IsNull())
 	needsHeaders := data.StaticHeaders.IsNull() || data.StaticHeaders.IsUnknown() || agentMapContainsMaskedValues(data.StaticHeaders) || (!config.StaticHeaders.IsNull() && agentFieldSetHasPrefix(imported, agentFieldStaticHeaders+"["))
 	needsExtraHeaders := data.ExtraHeaders.IsNull() || data.ExtraHeaders.IsUnknown()
 	if !needsParams && !needsHeaders && !needsExtraHeaders {
@@ -654,7 +734,25 @@ func (r *AgentResource) hydrateAgentUpdateFieldsWithOwnership(ctx context.Contex
 		return err
 	}
 	if needsParams {
-		params, _ := result["litellm_params"].(map[string]interface{})
+		rawParams, present := result["litellm_params"]
+		params := map[string]interface{}{}
+		if present && rawParams != nil {
+			var ok bool
+			params, ok = rawParams.(map[string]interface{})
+			if !ok {
+				return fmt.Errorf("LiteLLM returned malformed agent parameters during update preflight")
+			}
+		}
+		if imported[agentFieldParamsJSON] && config.LiteLLMParamsJSON.IsNull() {
+			if !present || rawParams == nil {
+				return fmt.Errorf("LiteLLM omitted API-owned structured agent parameters during update preflight")
+			}
+			var err error
+			data.LiteLLMParamsJSON, err = reconcileAgentJSONObject(data.LiteLLMParamsJSON, params)
+			if err != nil {
+				return err
+			}
+		}
 		value, err := hydrateAgentUpdateMap(data.LiteLLMParams, params, true)
 		if err != nil {
 			return err
@@ -766,6 +864,34 @@ func (r *AgentResource) buildAgentRequest(data *AgentResourceModel) (map[string]
 			}
 		}
 
+		// Signatures are an ordered complete-list replacement. Header is an
+		// arbitrary JSON object and is decoded with UseNumber.
+		if data.AgentCard.Signatures != nil {
+			signatures := make([]map[string]interface{}, 0, len(data.AgentCard.Signatures))
+			for _, configured := range data.AgentCard.Signatures {
+				signature := map[string]interface{}{
+					"protected": configured.Protected.ValueString(),
+					"signature": configured.Signature.ValueString(),
+				}
+				if !configured.Header.IsNull() && !configured.Header.IsUnknown() {
+					header, err := decodeAgentJSONObject(configured.Header.ValueString())
+					if err != nil {
+						return nil, err
+					}
+					signature["header"] = header
+				}
+				if !configured.HeaderJSON.IsNull() && !configured.HeaderJSON.IsUnknown() {
+					header, err := decodeAgentNullOrObject(configured.HeaderJSON.ValueString())
+					if err != nil {
+						return nil, err
+					}
+					signature["header"] = header
+				}
+				signatures = append(signatures, signature)
+			}
+			card["signatures"] = signatures
+		}
+
 		// Skills. A non-nil empty list is an explicit complete-list replacement;
 		// omission leaves the remote list untouched.
 		if data.AgentCard.Skills != nil {
@@ -790,6 +916,20 @@ func (r *AgentResource) buildAgentRequest(data *AgentResourceModel) (map[string]
 				if !s.OutputModes.IsNull() && !s.OutputModes.IsUnknown() {
 					skill["outputModes"] = listToStringSlice(s.OutputModes)
 				}
+				if !s.Security.IsNull() && !s.Security.IsUnknown() {
+					security, err := decodeAgentSecurity(s.Security)
+					if err != nil {
+						return nil, err
+					}
+					skill["security"] = security
+				}
+				if !s.SecurityJSON.IsNull() && !s.SecurityJSON.IsUnknown() {
+					security, err := decodeAgentSecurityJSON(s.SecurityJSON.ValueString())
+					if err != nil {
+						return nil, err
+					}
+					skill["security"] = security
+				}
 				skills = append(skills, skill)
 			}
 			card["skills"] = skills
@@ -798,17 +938,17 @@ func (r *AgentResource) buildAgentRequest(data *AgentResourceModel) (map[string]
 		req["agent_card_params"] = card
 	}
 
-	// LiteLLM params
-	if !data.LiteLLMParams.IsNull() && !data.LiteLLMParams.IsUnknown() {
-		params := map[string]interface{}{}
-		for k, v := range data.LiteLLMParams.Elements() {
-			if sv, ok := v.(types.String); ok {
-				params[k] = sv.ValueString()
-			}
-		}
-		if len(params) > 0 {
-			req["litellm_params"] = params
-		}
+	// LiteLLM params. The legacy map is literal; only the additive JSON
+	// attribute can introduce heterogeneous values.
+	params, paramsConfigured, err := configuredAgentParams(data.LiteLLMParams, data.LiteLLMParamsJSON)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateAgentCorePair(params); err != nil {
+		return nil, err
+	}
+	if paramsConfigured && len(params) > 0 {
+		req["litellm_params"] = params
 	}
 
 	// Object permission
@@ -965,6 +1105,11 @@ func reconcileAgentStringMapWithOwnership(current types.Map, raw map[string]inte
 			scope = agentScopeStaticHeaders
 		}
 		ownedByAPI := importAll || apiOwned[marker]
+		if !importAll && !priorPresent && apiOwned[marker] {
+			// Already-adopted API leaf omitted from plan-consistent public state.
+			// Keep its private/raw ownership without recreating perpetual drift.
+			continue
+		}
 		if !priorPresent && !ownedByAPI && apiOwned[scope] {
 			apiOwned[marker] = true
 			ownedByAPI = true
@@ -982,7 +1127,19 @@ func reconcileAgentStringMapWithOwnership(current types.Map, raw map[string]inte
 			observed[key] = types.StringValue(prior)
 			continue
 		}
-		value := metadataValueToString(rawValue)
+		// Preserve the historical import/state projection. Private JSON
+		// provenance prevents these compatibility strings from becoming wire
+		// authority on a later unrelated update.
+		remoteString, isString := rawValue.(string)
+		if !isString {
+			value := metadataValueToString(rawValue)
+			if priorPresent {
+				value = metadataValueToStringPreservingMasked(rawValue, prior)
+			}
+			observed[key] = types.StringValue(value)
+			continue
+		}
+		value := remoteString
 		if priorPresent && !ownedByAPI && (prior == value || jsonSemanticallyEqual(prior, value)) {
 			value = prior
 		}
@@ -1025,6 +1182,10 @@ func (r *AgentResource) readAgentFreshWithOwnership(ctx context.Context, data *A
 }
 
 func (r *AgentResource) readAgentWithOwnershipTransport(ctx context.Context, data *AgentResourceModel, imported bool, apiOwned agentFieldSet, freshConnection bool) error {
+	return r.readAgentWithOwnershipTransportCapture(ctx, data, imported, apiOwned, freshConnection, nil)
+}
+
+func (r *AgentResource) readAgentWithOwnershipTransportCapture(ctx context.Context, data *AgentResourceModel, imported bool, apiOwned agentFieldSet, freshConnection bool, capture *map[string]interface{}) error {
 	if apiOwned == nil {
 		apiOwned = agentFieldSet{}
 	}
@@ -1052,6 +1213,9 @@ func (r *AgentResource) readAgentWithOwnershipTransport(ctx context.Context, dat
 	}
 	if err := requireImportedStringField(true, "agent", result, "agent_name"); err != nil {
 		return err
+	}
+	if capture != nil {
+		*capture = cloneAgentWireObject(result)
 	}
 
 	// Identity is authoritative on every read, not only import. A successful
@@ -1092,7 +1256,10 @@ func (r *AgentResource) readAgentWithOwnershipTransport(ctx context.Context, dat
 		}
 	}
 
-	// LiteLLM params
+	// LiteLLM params. Present malformed values fail closed. Omission may be
+	// role sanitization, so prior resource state is retained. Imports and an
+	// existing/configured JSON bridge adopt the complete heterogeneous object;
+	// legacy-only resources remain legacy-only and are never silently migrated.
 	if rawParams, present := result["litellm_params"]; present && rawParams != nil {
 		params, ok := rawParams.(map[string]interface{})
 		if !ok {
@@ -1103,8 +1270,33 @@ func (r *AgentResource) readAgentWithOwnershipTransport(ctx context.Context, dat
 			return err
 		}
 		data.LiteLLMParams = value
-	} else if data.LiteLLMParams.IsUnknown() || (!data.LiteLLMParams.IsNull() && len(data.LiteLLMParams.Elements()) > 0) {
-		data.LiteLLMParams = types.MapNull(types.StringType)
+		adoptJSON := imported || apiOwned[agentFieldParamsJSON] || (!data.LiteLLMParamsJSON.IsNull() && !data.LiteLLMParamsJSON.IsUnknown())
+		if adoptJSON {
+			structuredParams := params
+			if !imported && !apiOwned[agentFieldParamsJSON] && !data.LiteLLMParamsJSON.IsNull() && !data.LiteLLMParamsJSON.IsUnknown() {
+				priorObject, decodeErr := decodeAgentJSONObject(data.LiteLLMParamsJSON.ValueString())
+				if decodeErr != nil {
+					return decodeErr
+				}
+				structuredParams = make(map[string]interface{}, len(priorObject))
+				for key := range priorObject {
+					if value, present := params[key]; present {
+						structuredParams[key] = value
+					}
+				}
+			}
+			data.LiteLLMParamsJSON, err = reconcileAgentJSONObject(data.LiteLLMParamsJSON, structuredParams)
+			if err != nil {
+				return fmt.Errorf("agent read response contains unrecoverable structured LiteLLM parameters")
+			}
+		}
+	} else {
+		if data.LiteLLMParams.IsUnknown() {
+			data.LiteLLMParams = types.MapNull(types.StringType)
+		}
+		if data.LiteLLMParamsJSON.IsUnknown() {
+			data.LiteLLMParamsJSON = types.StringNull()
+		}
 	}
 
 	// Static headers
@@ -1112,6 +1304,11 @@ func (r *AgentResource) readAgentWithOwnershipTransport(ctx context.Context, dat
 		headers, ok := rawHeaders.(map[string]interface{})
 		if !ok {
 			return fmt.Errorf("agent read response contains malformed static headers")
+		}
+		for _, raw := range headers {
+			if _, ok := raw.(string); !ok {
+				return fmt.Errorf("agent read response contains malformed static headers")
+			}
 		}
 		value, err := reconcileAgentStringMapWithOwnership(data.StaticHeaders, headers, false, agentFieldStaticHeaders, imported, apiOwned)
 		if err != nil {
@@ -1127,6 +1324,11 @@ func (r *AgentResource) readAgentWithOwnershipTransport(ctx context.Context, dat
 		headers, ok := rawHeaders.([]interface{})
 		if !ok {
 			return fmt.Errorf("agent read response contains malformed extra headers")
+		}
+		for _, raw := range headers {
+			if _, ok := raw.(string); !ok {
+				return fmt.Errorf("agent read response contains malformed extra headers")
+			}
 		}
 		data.ExtraHeaders = interfaceSliceToStringList(headers)
 	} else if data.ExtraHeaders.IsUnknown() || (!data.ExtraHeaders.IsNull() && len(data.ExtraHeaders.Elements()) > 0) {
@@ -1312,6 +1514,32 @@ func (r *AgentResource) readAgentCard(cardRaw map[string]interface{}, data *Agen
 		card.Provider = nil
 	}
 
+	// Signatures preserve wire order and duplicates.
+	if signaturesRaw, ok := cardRaw["signatures"].([]interface{}); ok && (populateAll || card.Signatures != nil) {
+		signatures := make([]AgentCardSignatureModel, 0, len(signaturesRaw))
+		for _, raw := range signaturesRaw {
+			object := raw.(map[string]interface{}) // validated by validateAgentCardResponse
+			signature := AgentCardSignatureModel{
+				Protected:  types.StringValue(object["protected"].(string)),
+				Signature:  types.StringValue(object["signature"].(string)),
+				Header:     types.StringNull(),
+				HeaderJSON: types.StringNull(),
+			}
+			if header, present := object["header"]; present {
+				if header == nil {
+					signature.HeaderJSON = types.StringValue("null")
+				} else if objectHeader, ok := header.(map[string]interface{}); ok {
+					encoded, _ := canonicalAgentJSON(objectHeader)
+					signature.Header = types.StringValue(encoded)
+				}
+			}
+			signatures = append(signatures, signature)
+		}
+		card.Signatures = signatures
+	} else if !populateAll && card.Signatures != nil {
+		card.Signatures = []AgentCardSignatureModel{}
+	}
+
 	// Skills
 	if skillsRaw, ok := cardRaw["skills"].([]interface{}); ok && (populateAll || card.Skills != nil) {
 		skills := make([]AgentSkillModel, 0, len(skillsRaw))
@@ -1346,6 +1574,15 @@ func (r *AgentResource) readAgentCard(cardRaw map[string]interface{}, data *Agen
 					skill.OutputModes = interfaceSliceToStringList(v)
 				} else {
 					skill.OutputModes = types.ListNull(types.StringType)
+				}
+				skill.Security = types.ListNull(types.MapType{ElemType: types.ListType{ElemType: types.StringType}})
+				skill.SecurityJSON = types.StringNull()
+				if v, present := s["security"]; present {
+					if v == nil {
+						skill.SecurityJSON = types.StringValue("null")
+					} else {
+						skill.Security, _ = readAgentSecurity(v)
+					}
 				}
 				skills = append(skills, skill)
 			}
@@ -1430,6 +1667,41 @@ func (r *AgentResource) reconcileAgentCardWithOwnership(cardRaw map[string]inter
 	reconcileString(agentFieldCardIcon, &out.IconURL, observed.IconURL)
 	reconcileString(agentFieldCardDocumentation, &out.DocumentationURL, observed.DocumentationURL)
 	reconcileBool(agentFieldCardAuthenticated, &out.SupportsAuthenticatedExtendedCard, observed.SupportsAuthenticatedExtendedCard)
+	rawSignatures, signaturesWirePresent := cardRaw["signatures"]
+	signatureMarkers := agentFieldSetHasPrefix(apiOwned, agentFieldCardSignatures+"[")
+	if prior.Signatures != nil || (apiOwned[agentScopeCardSignatures] && signaturesWirePresent && !signatureMarkers) {
+		out.Signatures = append([]AgentCardSignatureModel(nil), observed.Signatures...)
+		if apiOwned[agentScopeCardSignatures] && signaturesWirePresent {
+			for index, signature := range agentWireObjectList(rawSignatures) {
+				for _, field := range []string{"protected", "signature", "header"} {
+					_, present := signature[field]
+					adopt := index >= len(prior.Signatures)
+					if field == "header" && index < len(prior.Signatures) {
+						adopt = prior.Signatures[index].Header.IsNull() && prior.Signatures[index].HeaderJSON.IsNull()
+					}
+					if present && adopt {
+						apiOwned[agentSignatureLeaf(index, field)] = true
+					}
+				}
+			}
+		}
+		if !apiOwned[agentFieldCardSignatures] && len(prior.Signatures) == len(out.Signatures) {
+			for index := range out.Signatures {
+				oldHeader, newHeader := prior.Signatures[index].Header, out.Signatures[index].Header
+				if prior.Signatures[index].Protected.Equal(out.Signatures[index].Protected) && prior.Signatures[index].Signature.Equal(out.Signatures[index].Signature) &&
+					!oldHeader.IsNull() && !oldHeader.IsUnknown() && !newHeader.IsNull() && !newHeader.IsUnknown() && jsonSemanticallyEqual(oldHeader.ValueString(), newHeader.ValueString()) {
+					out.Signatures[index].Header = oldHeader
+				}
+			}
+		}
+		if observed.Signatures == nil {
+			for field := range apiOwned {
+				if strings.HasPrefix(field, agentFieldCardSignatures+"[") {
+					delete(apiOwned, field)
+				}
+			}
+		}
+	}
 
 	capsRaw, _ := cardRaw["capabilities"].(map[string]interface{})
 	if prior.Capabilities == nil && observed.Capabilities != nil && apiOwned[agentScopeCardCapabilities] {
@@ -1507,6 +1779,7 @@ func (r *AgentResource) reconcileAgentCardWithOwnership(cardRaw map[string]inter
 		}
 	}
 
+	rawSkillsByID := agentSkillRawByID(cardRaw)
 	remoteByID := map[string]AgentSkillModel{}
 	for _, skill := range observed.Skills {
 		remoteByID[skill.ID.ValueString()] = skill
@@ -1517,7 +1790,7 @@ func (r *AgentResource) reconcileAgentCardWithOwnership(cardRaw map[string]inter
 		id := old.ID.ValueString()
 		remote, present := remoteByID[id]
 		if !present {
-			for _, leaf := range []string{"id", "name", "description", "tags", "examples", "input_modes", "output_modes"} {
+			for _, leaf := range []string{"id", "name", "description", "tags", "examples", "input_modes", "output_modes", "security"} {
 				delete(apiOwned, agentSkillLeaf(id, leaf))
 			}
 			continue
@@ -1529,6 +1802,17 @@ func (r *AgentResource) reconcileAgentCardWithOwnership(cardRaw map[string]inter
 		reconcileList(agentSkillLeaf(id, "examples"), &current.Examples, remote.Examples, false)
 		reconcileList(agentSkillLeaf(id, "input_modes"), &current.InputModes, remote.InputModes, false)
 		reconcileList(agentSkillLeaf(id, "output_modes"), &current.OutputModes, remote.OutputModes, false)
+		securityField := agentSkillLeaf(id, "security")
+		if _, present := rawSkillsByID[id]["security"]; present && apiOwned[agentScopeCardSkills] && current.Security.IsNull() && current.SecurityJSON.IsNull() {
+			apiOwned[securityField] = true
+		}
+		if apiOwned[securityField] || (!current.Security.IsNull() || !current.SecurityJSON.IsNull()) {
+			current.Security = remote.Security
+			current.SecurityJSON = remote.SecurityJSON
+			if remote.Security.IsNull() && remote.SecurityJSON.IsNull() {
+				delete(apiOwned, securityField)
+			}
+		}
 		skills = append(skills, current)
 		seen[id] = true
 	}
@@ -1540,13 +1824,13 @@ func (r *AgentResource) reconcileAgentCardWithOwnership(cardRaw map[string]inter
 	}
 	slices.Sort(newIDs)
 	for _, id := range newIDs {
-		if !apiOwned[agentScopeCardSkills] {
+		if !apiOwned[agentScopeCardSkills] || agentFieldSetHasPrefix(apiOwned, agentLeaf(agentFieldCardSkills, id)+".") {
+			// Previously adopted API skills may be hidden after a configured-list
+			// apply. Preserve them privately/on wire without perpetual plan drift.
 			continue
 		}
 		skills = append(skills, remoteByID[id])
-		for _, leaf := range []string{"id", "name", "description", "tags", "examples", "input_modes", "output_modes"} {
-			apiOwned[agentSkillLeaf(id, leaf)] = true
-		}
+		markAgentSkillWireLeaves(apiOwned, id, rawSkillsByID[id])
 	}
 	if prior.Skills == nil && len(skills) == 0 {
 		out.Skills = nil
@@ -1705,6 +1989,7 @@ func cloneAgentResourceModel(source AgentResourceModel) AgentResourceModel {
 			cloned.AgentCard.Provider = &provider
 		}
 		cloned.AgentCard.Skills = append([]AgentSkillModel(nil), source.AgentCard.Skills...)
+		cloned.AgentCard.Signatures = append([]AgentCardSignatureModel(nil), source.AgentCard.Signatures...)
 	}
 	if source.ObjectPermission != nil {
 		permission := *source.ObjectPermission
@@ -1811,6 +2096,11 @@ func (r *AgentResource) readObjectPermission(permRaw map[string]interface{}, dat
 			items, ok := raw.([]interface{})
 			if !ok {
 				return fmt.Errorf("agent read response contains a malformed object permission collection")
+			}
+			for _, item := range items {
+				if _, ok := item.(string); !ok {
+					return fmt.Errorf("agent read response contains a malformed object permission collection")
+				}
 			}
 			*target = interfaceSliceToStringList(items)
 			return nil

--- a/internal/provider/resource_agent.go
+++ b/internal/provider/resource_agent.go
@@ -467,7 +467,10 @@ func (r *AgentResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		resp.Private = req.Private
 		return
 	}
-	apiOwned := bundle.committed
+	// Reads may use a working ownership copy to reconcile the public projection,
+	// but an ordinary refresh has no configuration or planned transition to
+	// confirm. It must therefore leave committed and pending provenance intact.
+	apiOwned := cloneAgentFieldSet(bundle.committed)
 	imported := string(importedMarker) == "true"
 
 	var rawResult map[string]interface{}
@@ -483,19 +486,25 @@ func (r *AgentResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	}
 
 	resolveAgentUnknowns(&data)
+	if !imported {
+		resp.Private = req.Private
+	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
-	if !resp.Diagnostics.HasError() && resp.Private != nil {
-		if imported {
-			apiOwned = agentImportedFieldsFromWire(data, rawResult)
-		} else if bundle.pending != nil {
-			apiOwned = bundle.pending
-		}
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if !imported {
+		// Only a successfully confirmed Create or Update may promote pending
+		// ownership. Preserve ordinary-read private state byte-for-byte, including
+		// a canonical pending transition whose API-owned field is omitted or null.
+		return
+	}
+	if resp.Private != nil {
+		apiOwned = agentImportedFieldsFromWire(data, rawResult)
 		resp.Diagnostics.Append(resp.Private.SetKey(ctx, agentImportedFieldsPrivateKey, encodeAgentFieldSet(apiOwned))...)
 		resp.Diagnostics.Append(resp.Private.SetKey(ctx, agentOwnershipInitializedPrivateKey, []byte("true"))...)
 		resp.Diagnostics.Append(resp.Private.SetKey(ctx, agentOwnershipPendingPrivateKey, nil)...)
-		if imported {
-			resp.Diagnostics.Append(resp.Private.SetKey(ctx, numericImportedPrivateKey, nil)...)
-		}
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, numericImportedPrivateKey, nil)...)
 	}
 }
 

--- a/internal/provider/resource_agent.go
+++ b/internal/provider/resource_agent.go
@@ -438,8 +438,9 @@ func (r *AgentResource) Create(ctx context.Context, req resource.CreateRequest, 
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &confirmed)...)
 	if !resp.Diagnostics.HasError() && resp.Private != nil {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, agentImportedFieldsPrivateKey, nil)...)
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, agentImportedFieldsPrivateKey, encodeAgentFieldSet(agentFieldSet{}))...)
 		resp.Diagnostics.Append(resp.Private.SetKey(ctx, agentOwnershipInitializedPrivateKey, []byte("true"))...)
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, agentOwnershipPendingPrivateKey, nil)...)
 	}
 }
 
@@ -448,8 +449,9 @@ func setAgentIdentityOnlyCreateState(ctx context.Context, resp *resource.CreateR
 	partial.ID = confirmedAgentID
 	resp.Diagnostics.Append(resp.State.Set(ctx, &partial)...)
 	if resp.Private != nil {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, agentImportedFieldsPrivateKey, nil)...)
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, agentImportedFieldsPrivateKey, encodeAgentFieldSet(agentFieldSet{}))...)
 		resp.Diagnostics.Append(resp.Private.SetKey(ctx, agentOwnershipInitializedPrivateKey, []byte("true"))...)
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, agentOwnershipPendingPrivateKey, nil)...)
 	}
 }
 
@@ -458,11 +460,14 @@ func (r *AgentResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
 	importedMarker, privateDiags := req.Private.GetKey(ctx, numericImportedPrivateKey)
 	resp.Diagnostics.Append(privateDiags...)
-	apiOwned, ownershipDiags := readAgentImportedFields(ctx, req.Private)
+	bundle, ownershipDiags := readAgentOwnershipBundle(ctx, req.Private)
 	resp.Diagnostics.Append(ownershipDiags...)
 	if resp.Diagnostics.HasError() {
+		resp.State = req.State
+		resp.Private = req.Private
 		return
 	}
+	apiOwned := bundle.committed
 	imported := string(importedMarker) == "true"
 
 	var rawResult map[string]interface{}
@@ -472,6 +477,7 @@ func (r *AgentResource) Read(ctx context.Context, req resource.ReadRequest, resp
 			return
 		}
 		resp.State = req.State
+		resp.Private = req.Private
 		resp.Diagnostics.AddError("Agent Read Failed", "LiteLLM did not return an authoritative agent response. Prior Terraform state was retained.")
 		return
 	}
@@ -481,9 +487,12 @@ func (r *AgentResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	if !resp.Diagnostics.HasError() && resp.Private != nil {
 		if imported {
 			apiOwned = agentImportedFieldsFromWire(data, rawResult)
+		} else if bundle.pending != nil {
+			apiOwned = bundle.pending
 		}
 		resp.Diagnostics.Append(resp.Private.SetKey(ctx, agentImportedFieldsPrivateKey, encodeAgentFieldSet(apiOwned))...)
 		resp.Diagnostics.Append(resp.Private.SetKey(ctx, agentOwnershipInitializedPrivateKey, []byte("true"))...)
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, agentOwnershipPendingPrivateKey, nil)...)
 		if imported {
 			resp.Diagnostics.Append(resp.Private.SetKey(ctx, numericImportedPrivateKey, nil)...)
 		}
@@ -495,9 +504,22 @@ func (r *AgentResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &planned)...)
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
-	importedFields, ownershipDiags := readAgentImportedFields(ctx, req.Private)
+	bundle, ownershipDiags := readAgentOwnershipBundle(ctx, req.Private)
 	resp.Diagnostics.Append(ownershipDiags...)
 	if resp.Diagnostics.HasError() {
+		resp.Private = req.Private
+		resp.State = req.State
+		return
+	}
+	importedFields := bundle.committed
+	expectedOwnership := cloneAgentFieldSet(importedFields)
+	for field := range agentConfiguredFields(config) {
+		delete(expectedOwnership, field)
+	}
+	if (bundle.pending == nil && !agentFieldSetsEqual(expectedOwnership, importedFields)) || (bundle.pending != nil && !agentFieldSetsEqual(bundle.pending, expectedOwnership)) {
+		resp.Private = req.Private
+		resp.State = req.State
+		resp.Diagnostics.AddError("Invalid Agent Ownership State", "Provider-private pending agent ownership does not match the planned ownership transition. Prior public and private state was retained; no remote operation was attempted.")
 		return
 	}
 	planned.ID = state.ID
@@ -552,6 +574,9 @@ func (r *AgentResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		if cardTouched {
 			preservation.cardBase = cardBase
 			preservation.cardPatch, err = overlayAgentCardRaw(cardBase, planned, state, config, importedFields)
+			if err == nil {
+				err = validateAgentCardV198RoundTrip(preservation.cardPatch)
+			}
 			if err != nil {
 				resp.Private = req.Private
 				resp.State = req.State
@@ -579,6 +604,7 @@ func (r *AgentResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		delete(agentReq, "agent_card_params")
 	}
 	endpoint := fmt.Sprintf("/v1/agents/%s", url.PathEscape(planned.ID.ValueString()))
+//line internal/provider/resource_agent.go:582
 	if err := r.client.DoRequestWithResponse(ctx, "PATCH", endpoint, agentReq, nil); err != nil {
 		resp.Private = req.Private
 		resp.State = req.State
@@ -602,23 +628,41 @@ func (r *AgentResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &confirmed)...)
 	if !resp.Diagnostics.HasError() && resp.Private != nil {
-		configuredFields := agentConfiguredFields(config)
-		for field := range configuredFields {
-			delete(importedFields, field)
+		committed := bundle.pending
+		if committed == nil {
+			committed = cloneAgentFieldSet(importedFields)
 		}
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, agentImportedFieldsPrivateKey, encodeAgentFieldSet(importedFields))...)
+		if preservation.cardBase != nil && state.AgentCard != nil {
+			priorIDs := map[string]bool{}
+			for _, skill := range state.AgentCard.Skills {
+				if !skill.ID.IsNull() && !skill.ID.IsUnknown() {
+					priorIDs[skill.ID.ValueString()] = true
+				}
+			}
+			for id, rawSkill := range agentSkillRawByID(preservation.cardBase) {
+				if !priorIDs[id] && importedFields[agentScopeCardSkills] {
+					markAgentSkillWireLeaves(committed, id, rawSkill)
+				}
+			}
+		}
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, agentImportedFieldsPrivateKey, encodeAgentFieldSet(committed))...)
 		resp.Diagnostics.Append(resp.Private.SetKey(ctx, agentOwnershipPendingPrivateKey, nil)...)
 	}
 }
 
 func (r *AgentResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	var data AgentResourceModel
+	_, ownershipDiags := readAgentOwnershipBundle(ctx, req.Private)
+	resp.Diagnostics.Append(ownershipDiags...)
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
+		resp.Private = req.Private
+		resp.State = req.State
 		return
 	}
 
 	endpoint := fmt.Sprintf("/v1/agents/%s", url.PathEscape(data.ID.ValueString()))
+//line internal/provider/resource_agent.go:622
 	if err := r.client.DoRequestWithResponse(ctx, "DELETE", endpoint, nil, nil); err != nil {
 		if IsAPIErrorStatus(err, 404) {
 			return
@@ -633,7 +677,8 @@ func (r *AgentResource) ImportState(ctx context.Context, req resource.ImportStat
 	if resp.Private != nil {
 		resp.Diagnostics.Append(resp.Private.SetKey(ctx, numericImportedPrivateKey, []byte("true"))...)
 		resp.Diagnostics.Append(resp.Private.SetKey(ctx, agentImportedFieldsPrivateKey, nil)...)
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, agentOwnershipInitializedPrivateKey, []byte("true"))...)
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, agentOwnershipInitializedPrivateKey, nil)...)
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, agentOwnershipPendingPrivateKey, nil)...)
 	}
 }
 
@@ -727,6 +772,7 @@ func (r *AgentResource) hydrateAgentUpdateFieldsWithOwnership(ctx context.Contex
 
 	endpoint := fmt.Sprintf("/v1/agents/%s", url.PathEscape(data.ID.ValueString()))
 	var result map[string]interface{}
+//line internal/provider/resource_agent.go:730
 	if err := r.client.doFreshRequestWithResponse(ctx, "GET", endpoint, nil, &result); err != nil {
 		return err
 	}
@@ -1201,8 +1247,10 @@ func (r *AgentResource) readAgentWithOwnershipTransportCapture(ctx context.Conte
 	var result map[string]interface{}
 	var err error
 	if freshConnection {
+//line internal/provider/resource_agent.go:1204
 		err = r.client.doFreshRequestWithResponse(ctx, "GET", endpoint, nil, &result)
 	} else {
+//line internal/provider/resource_agent.go:1206
 		err = r.client.DoRequestWithResponse(ctx, "GET", endpoint, nil, &result)
 	}
 	if err != nil {
@@ -1518,12 +1566,19 @@ func (r *AgentResource) readAgentCard(cardRaw map[string]interface{}, data *Agen
 	if signaturesRaw, ok := cardRaw["signatures"].([]interface{}); ok && (populateAll || card.Signatures != nil) {
 		signatures := make([]AgentCardSignatureModel, 0, len(signaturesRaw))
 		for _, raw := range signaturesRaw {
-			object := raw.(map[string]interface{}) // validated by validateAgentCardResponse
+			object, ok := raw.(map[string]interface{})
+			if !ok {
+				continue
+			}
 			signature := AgentCardSignatureModel{
-				Protected:  types.StringValue(object["protected"].(string)),
-				Signature:  types.StringValue(object["signature"].(string)),
-				Header:     types.StringNull(),
-				HeaderJSON: types.StringNull(),
+				Protected: types.StringNull(), Signature: types.StringNull(),
+				Header: types.StringNull(), HeaderJSON: types.StringNull(),
+			}
+			if value, ok := object["protected"].(string); ok {
+				signature.Protected = types.StringValue(value)
+			}
+			if value, ok := object["signature"].(string); ok {
+				signature.Signature = types.StringValue(value)
 			}
 			if header, present := object["header"]; present {
 				if header == nil {

--- a/internal/provider/resource_agent_lifecycle.go
+++ b/internal/provider/resource_agent_lifecycle.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -41,40 +42,150 @@ func encodeAgentFieldSet(fields agentFieldSet) []byte {
 	return encoded
 }
 
+func agentOwnershipMarkerKnown(name string) bool {
+	fixed := map[string]bool{
+		agentFieldParamsJSON: true, agentFieldTPM: true, agentFieldRPM: true, agentFieldSessionTPM: true, agentFieldSessionRPM: true,
+		agentFieldExtraHeaders: true, agentFieldCardName: true, agentFieldCardURL: true,
+		agentFieldCardDescription: true, agentFieldCardVersion: true, agentFieldCardProtocol: true,
+		agentFieldCardInputModes: true, agentFieldCardOutputModes: true, agentFieldCardCapStreaming: true,
+		agentFieldCardCapPush: true, agentFieldCardCapHistory: true, agentFieldCardProviderOrg: true,
+		agentFieldCardProviderURL: true, agentFieldCardTransport: true, agentFieldCardIcon: true,
+		agentFieldCardDocumentation: true, agentFieldCardAuthenticated: true,
+		agentFieldPermissionServers: true, agentFieldPermissionGroups: true, agentFieldPermissionTools: true,
+		agentFieldPermissionModels: true, agentFieldPermissionAgents: true,
+		agentScopeParams: true, agentScopeStaticHeaders: true, agentScopeCardCapabilities: true,
+		agentScopeCardProvider: true, agentScopeCardSkills: true, agentScopeCardSignatures: true,
+		agentScopePermission: true,
+	}
+	if fixed[name] {
+		return true
+	}
+	decodeLeaf := func(prefix, suffix string) bool {
+		if !strings.HasPrefix(name, prefix+"[") || !strings.HasSuffix(name, suffix) {
+			return false
+		}
+		encoded := strings.TrimSuffix(strings.TrimPrefix(name, prefix+"["), suffix)
+		decoded, err := base64.RawURLEncoding.DecodeString(encoded)
+		return err == nil && len(decoded) > 0 && base64.RawURLEncoding.EncodeToString(decoded) == encoded
+	}
+	if decodeLeaf(agentFieldParams, "]") || decodeLeaf(agentFieldStaticHeaders, "]") {
+		return true
+	}
+	for _, field := range []string{"id", "name", "description", "tags", "examples", "input_modes", "output_modes", "security"} {
+		if decodeLeaf(agentFieldCardSkills, "]."+field) {
+			return true
+		}
+	}
+	if strings.HasPrefix(name, agentFieldCardSignatures+"[") {
+		close := strings.Index(name[len(agentFieldCardSignatures)+1:], "]")
+		if close >= 0 {
+			indexText := name[len(agentFieldCardSignatures)+1 : len(agentFieldCardSignatures)+1+close]
+			var index int
+			if _, err := fmt.Sscanf(indexText, "%d", &index); err == nil && index >= 0 && fmt.Sprintf("%d", index) == indexText {
+				suffix := name[len(agentFieldCardSignatures)+2+close:]
+				return suffix == ".protected" || suffix == ".signature" || suffix == ".header"
+			}
+		}
+	}
+	return false
+}
+
 func decodeAgentFieldSet(raw []byte) (agentFieldSet, error) {
-	fields := agentFieldSet{}
-	if len(raw) == 0 {
-		return fields, nil
+	if raw == nil {
+		return nil, fmt.Errorf("provider-private agent ownership data is missing")
 	}
 	var names []string
-	if err := json.Unmarshal(raw, &names); err != nil {
-		return nil, fmt.Errorf("The provider-private agent ownership marker is malformed.")
+	if err := json.Unmarshal(raw, &names); err != nil || names == nil {
+		return nil, fmt.Errorf("provider-private agent ownership data is malformed")
 	}
+	fields := agentFieldSet{}
 	for _, name := range names {
-		if name == "" {
-			return nil, fmt.Errorf("The provider-private agent ownership marker is malformed.")
+		if !agentOwnershipMarkerKnown(name) || fields[name] {
+			return nil, fmt.Errorf("provider-private agent ownership data is malformed")
 		}
 		fields[name] = true
+	}
+	if !bytes.Equal(raw, encodeAgentFieldSet(fields)) {
+		return nil, fmt.Errorf("provider-private agent ownership data is not canonical")
 	}
 	return fields, nil
 }
 
-func readAgentImportedFields(ctx context.Context, private agentPrivateReader) (agentFieldSet, diag.Diagnostics) {
+type agentOwnershipBundle struct {
+	committed agentFieldSet
+	pending   agentFieldSet
+	versioned bool
+}
+
+func readAgentOwnershipBundle(ctx context.Context, private agentPrivateReader) (agentOwnershipBundle, diag.Diagnostics) {
+	result := agentOwnershipBundle{committed: agentFieldSet{}}
 	var diagnostics diag.Diagnostics
 	if private == nil {
-		return agentFieldSet{}, diagnostics
+		return result, diagnostics
 	}
-	raw, privateDiags := private.GetKey(ctx, agentImportedFieldsPrivateKey)
-	diagnostics.Append(privateDiags...)
+	committedRaw, committedDiags := private.GetKey(ctx, agentImportedFieldsPrivateKey)
+	initializedRaw, initializedDiags := private.GetKey(ctx, agentOwnershipInitializedPrivateKey)
+	pendingRaw, pendingDiags := private.GetKey(ctx, agentOwnershipPendingPrivateKey)
+	diagnostics.Append(committedDiags...)
+	diagnostics.Append(initializedDiags...)
+	diagnostics.Append(pendingDiags...)
 	if diagnostics.HasError() {
-		return nil, diagnostics
+		return result, diagnostics
 	}
-	fields, err := decodeAgentFieldSet(raw)
+	any := committedRaw != nil || initializedRaw != nil || pendingRaw != nil
+	if !any {
+		return result, diagnostics
+	}
+	invalid := func() (agentOwnershipBundle, diag.Diagnostics) {
+		diagnostics.AddError("Invalid Agent Ownership State", "Provider-private agent ownership data is invalid. Prior public and private state was retained; no remote operation was attempted. This diagnostic contains no public values or identifiers.")
+		return result, diagnostics
+	}
+	if committedRaw == nil || string(initializedRaw) != "true" {
+		return invalid()
+	}
+	committed, err := decodeAgentFieldSet(committedRaw)
 	if err != nil {
-		diagnostics.AddError("Invalid Agent Ownership State", err.Error())
-		return nil, diagnostics
+		return invalid()
 	}
-	return fields, diagnostics
+	result.committed, result.versioned = committed, true
+	if pendingRaw != nil {
+		pending, err := decodeAgentFieldSet(pendingRaw)
+		if err != nil {
+			return invalid()
+		}
+		for field := range pending {
+			if !committed[field] {
+				return invalid()
+			}
+		}
+		result.pending = pending
+	}
+	return result, diagnostics
+}
+
+func readAgentImportedFields(ctx context.Context, private agentPrivateReader) (agentFieldSet, diag.Diagnostics) {
+	bundle, diagnostics := readAgentOwnershipBundle(ctx, private)
+	return bundle.committed, diagnostics
+}
+
+func cloneAgentFieldSet(source agentFieldSet) agentFieldSet {
+	result := agentFieldSet{}
+	for field := range source {
+		result[field] = true
+	}
+	return result
+}
+
+func agentFieldSetsEqual(left, right agentFieldSet) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for field := range left {
+		if !right[field] {
+			return false
+		}
+	}
+	return true
 }
 
 const (
@@ -370,18 +481,15 @@ func (r *AgentResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanR
 		resp.Diagnostics.AddError("Agent Parameter Conflict", err.Error())
 		return
 	}
-	imported, diagnostics := readAgentImportedFields(ctx, req.Private)
+	bundle, diagnostics := readAgentOwnershipBundle(ctx, req.Private)
 	resp.Diagnostics.Append(diagnostics...)
 	if resp.Diagnostics.HasError() {
+		resp.Private = req.Private
+		resp.Plan.Raw = req.State.Raw
 		return
 	}
-	initialized := false
-	if req.Private != nil {
-		raw, privateDiags := req.Private.GetKey(ctx, agentOwnershipInitializedPrivateKey)
-		resp.Diagnostics.Append(privateDiags...)
-		initialized = string(raw) == "true"
-	}
-	if !initialized {
+	imported := bundle.committed
+	if !bundle.versioned {
 		// Older state has no ownership provenance. Conservatively classify every
 		// known optional value as API-owned until explicit HCL transfers ownership
 		// through a verified apply.
@@ -419,11 +527,9 @@ func (r *AgentResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanR
 		headersMerged = mergeAPIMapLeavesIntoPlan(&plan.StaticHeaders, state.StaticHeaders, agentFieldStaticHeaders)
 	}
 	configured := agentConfiguredFields(config)
-	pending := agentFieldSet{}
-	for field := range imported {
-		if configured[field] {
-			pending[field] = true
-		}
+	pending := cloneAgentFieldSet(imported)
+	for field := range configured {
+		delete(pending, field)
 		// Do not copy imported Optional-only values into Plan when HCL omits
 		// them: Terraform rejects provider-planned values for non-computed
 		// attributes. Update builds a separate wire model from prior state so
@@ -448,10 +554,15 @@ func (r *AgentResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanR
 		// unknown so authoritative exact-type read-back is plan-consistent.
 		resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root(agentFieldParamsJSON), types.StringUnknown())...)
 	}
+	pendingChanged := !agentFieldSetsEqual(imported, pending)
 	if resp.Private != nil {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, agentOwnershipPendingPrivateKey, encodeAgentFieldSet(pending))...)
+		if pendingChanged {
+			resp.Diagnostics.Append(resp.Private.SetKey(ctx, agentOwnershipPendingPrivateKey, encodeAgentFieldSet(pending))...)
+		} else {
+			resp.Diagnostics.Append(resp.Private.SetKey(ctx, agentOwnershipPendingPrivateKey, nil)...)
+		}
 	}
-	if len(pending) > 0 {
+	if pendingChanged {
 		// Equal-value ownership transfers require Apply so provenance is consumed
 		// only after authoritative read-back succeeds.
 		resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, pathRootID, types.StringUnknown())...)
@@ -584,7 +695,226 @@ func copyAgentField(target *AgentResourceModel, source AgentResourceModel, field
 	}
 }
 
+func validateAgentCardSourceShape(card map[string]interface{}) error {
+	malformed := func() error { return fmt.Errorf("agent read response contains a malformed agent card") }
+	stringValue := func(object map[string]interface{}, field string, nullable bool) bool {
+		value, present := object[field]
+		return !present || (value == nil && nullable) || func() bool { _, ok := value.(string); return ok }()
+	}
+	boolValue := func(object map[string]interface{}, field string, nullable bool) bool {
+		value, present := object[field]
+		return !present || (value == nil && nullable) || func() bool { _, ok := value.(bool); return ok }()
+	}
+	stringList := func(value interface{}, nullable bool) bool {
+		if value == nil {
+			return nullable
+		}
+		items, ok := value.([]interface{})
+		if !ok {
+			return false
+		}
+		for _, item := range items {
+			if _, ok := item.(string); !ok {
+				return false
+			}
+		}
+		return true
+	}
+	for _, field := range []string{"protocolVersion", "name", "description", "url", "version"} {
+		if !stringValue(card, field, false) {
+			return malformed()
+		}
+	}
+	for _, field := range []string{"preferredTransport", "iconUrl", "documentationUrl"} {
+		if !stringValue(card, field, true) {
+			return malformed()
+		}
+	}
+	if !boolValue(card, "supportsAuthenticatedExtendedCard", true) {
+		return malformed()
+	}
+	for _, field := range []string{"defaultInputModes", "defaultOutputModes"} {
+		if value, present := card[field]; present && !stringList(value, false) {
+			return malformed()
+		}
+	}
+	if raw, present := card["capabilities"]; present {
+		capabilities, ok := raw.(map[string]interface{})
+		if !ok {
+			return malformed()
+		}
+		for _, field := range []string{"streaming", "pushNotifications", "stateTransitionHistory"} {
+			if !boolValue(capabilities, field, true) {
+				return malformed()
+			}
+		}
+		if rawExtensions, present := capabilities["extensions"]; present && rawExtensions != nil {
+			extensions, ok := rawExtensions.([]interface{})
+			if !ok {
+				return malformed()
+			}
+			for _, rawExtension := range extensions {
+				extension, ok := rawExtension.(map[string]interface{})
+				if !ok {
+					return malformed()
+				}
+				if !stringValue(extension, "uri", false) || !stringValue(extension, "description", true) || !boolValue(extension, "required", true) {
+					return malformed()
+				}
+				if params, present := extension["params"]; present && params != nil {
+					if _, ok := params.(map[string]interface{}); !ok {
+						return malformed()
+					}
+				}
+			}
+		}
+	}
+	if raw, present := card["provider"]; present && raw != nil {
+		provider, ok := raw.(map[string]interface{})
+		if !ok {
+			return malformed()
+		}
+		if !stringValue(provider, "organization", false) || !stringValue(provider, "url", false) {
+			return malformed()
+		}
+	}
+	for _, field := range []string{"additionalInterfaces", "supportedInterfaces"} {
+		if raw, present := card[field]; present && raw != nil {
+			interfaces, ok := raw.([]interface{})
+			if !ok {
+				return malformed()
+			}
+			for _, rawInterface := range interfaces {
+				item, ok := rawInterface.(map[string]interface{})
+				if !ok {
+					return malformed()
+				}
+				if !stringValue(item, "url", false) || !stringValue(item, "transport", false) || !stringValue(item, "protocolBinding", false) || !stringValue(item, "protocolVersion", false) {
+					return malformed()
+				}
+			}
+		}
+	}
+	validateSecurity := func(raw interface{}) bool {
+		if raw == nil {
+			return true
+		}
+		_, err := readAgentSecurity(raw)
+		return err == nil
+	}
+	if raw, present := card["security"]; present && !validateSecurity(raw) {
+		return malformed()
+	}
+	if raw, present := card["securitySchemes"]; present && raw != nil {
+		schemes, ok := raw.(map[string]interface{})
+		if !ok {
+			return malformed()
+		}
+		for _, rawScheme := range schemes {
+			scheme, ok := rawScheme.(map[string]interface{})
+			if !ok {
+				return malformed()
+			}
+			if !stringValue(scheme, "description", true) {
+				return malformed()
+			}
+			typeValue, ok := scheme["type"].(string)
+			if !ok {
+				return malformed()
+			}
+			switch typeValue {
+			case "apiKey":
+				location, locationOK := scheme["in_"].(string)
+				if !locationOK {
+					location, locationOK = scheme["in"].(string)
+				}
+				if !locationOK || (location != "query" && location != "header" && location != "cookie") || !stringValue(scheme, "name", false) || scheme["name"] == nil {
+					return malformed()
+				}
+			case "http":
+				if value, present := scheme["scheme"]; !present || value == nil || !stringValue(scheme, "scheme", false) || !stringValue(scheme, "bearerFormat", true) {
+					return malformed()
+				}
+			case "oauth2":
+				flows, ok := scheme["flows"].(map[string]interface{})
+				if !ok {
+					return malformed()
+				}
+				for _, flow := range []string{"authorizationCode", "clientCredentials", "implicit", "password"} {
+					if value, present := flows[flow]; present && value != nil {
+						if _, ok := value.(map[string]interface{}); !ok {
+							return malformed()
+						}
+					}
+				}
+				if !stringValue(scheme, "oauth2MetadataUrl", true) {
+					return malformed()
+				}
+			case "openIdConnect":
+				if value, present := scheme["openIdConnectUrl"]; !present || value == nil || !stringValue(scheme, "openIdConnectUrl", false) {
+					return malformed()
+				}
+			case "mutualTLS":
+			default:
+				return malformed()
+			}
+		}
+	}
+	if raw, present := card["signatures"]; present && raw != nil {
+		signatures, ok := raw.([]interface{})
+		if !ok {
+			return malformed()
+		}
+		for _, rawSignature := range signatures {
+			signature, ok := rawSignature.(map[string]interface{})
+			if !ok {
+				return malformed()
+			}
+			if !stringValue(signature, "protected", false) || !stringValue(signature, "signature", false) {
+				return malformed()
+			}
+			if header, present := signature["header"]; present && header != nil {
+				if _, ok := header.(map[string]interface{}); !ok {
+					return malformed()
+				}
+			}
+		}
+	}
+	if raw, present := card["skills"]; present {
+		skills, ok := raw.([]interface{})
+		if !ok {
+			return malformed()
+		}
+		for _, rawSkill := range skills {
+			skill, ok := rawSkill.(map[string]interface{})
+			if !ok {
+				return malformed()
+			}
+			for _, field := range []string{"id", "name", "description"} {
+				if !stringValue(skill, field, false) {
+					return malformed()
+				}
+			}
+			if value, present := skill["tags"]; present && !stringList(value, false) {
+				return malformed()
+			}
+			for _, field := range []string{"examples", "inputModes", "outputModes"} {
+				if value, present := skill[field]; present && !stringList(value, true) {
+					return malformed()
+				}
+			}
+			if value, present := skill["security"]; present && !validateSecurity(value) {
+				return malformed()
+			}
+		}
+	}
+	return nil
+}
+
 func validateAgentCardResponse(card map[string]interface{}, requiredIdentity bool) error {
+	if err := validateAgentCardSourceShape(card); err != nil {
+		return err
+	}
 	if requiredIdentity {
 		name, nameOK := card["name"].(string)
 		_, urlOK := card["url"].(string)
@@ -660,9 +990,6 @@ func validateAgentCardResponse(card map[string]interface{}, requiredIdentity boo
 			}
 			for _, field := range []string{"protected", "signature"} {
 				value, present := signature[field]
-				if requiredIdentity && !present {
-					return fmt.Errorf("agent read response contains a malformed agent card")
-				}
 				if present && value != nil {
 					if _, ok := value.(string); !ok {
 						return fmt.Errorf("agent read response contains a malformed agent card")
@@ -744,6 +1071,7 @@ func waitAgentFreshSample(ctx context.Context, delay time.Duration) error {
 
 func fetchFreshAgentListObjects(ctx context.Context, client *Client) ([]map[string]interface{}, error) {
 	var raw json.RawMessage
+//line internal/provider/resource_agent_lifecycle.go:747
 	if err := client.doFreshRequestWithResponse(ctx, "GET", "/v1/agents", nil, &raw); err != nil {
 		return nil, err
 	}
@@ -1512,7 +1840,7 @@ func compareAgentCard(mismatches *[]string, planned, prior, config AgentResource
 	}
 	providerCheck(agentFieldCardProviderOrg, plannedProvider.Organization, observedProvider.Organization)
 	providerCheck(agentFieldCardProviderURL, plannedProvider.URL, observedProvider.URL)
-	if config.AgentCard.Skills != nil && !agentSkillsMutationMatch(planned.AgentCard.Skills, prior.AgentCard, config.AgentCard.Skills, observed.AgentCard.Skills, imported) {
+	if (config.AgentCard.Skills != nil || (prior.AgentCard != nil && prior.AgentCard.Skills != nil)) && !agentSkillsMutationMatch(planned.AgentCard.Skills, prior.AgentCard, config.AgentCard.Skills, observed.AgentCard.Skills, imported) {
 		*mismatches = append(*mismatches, agentFieldCardSkills)
 	}
 }
@@ -1734,12 +2062,39 @@ func reconcileConfirmedAgentState(planned, observed, config, prior AgentResource
 	} else {
 		result.StaticHeaders = config.StaticHeaders
 	}
-	// Optional+Computed maps may retain API-owned keys in the planned value.
-	// Optional-only nested leaves cannot be added after apply without violating
-	// Terraform's planned-value contract; ordinary Read re-adopts those leaves
-	// authoritatively and keeps their provenance for subsequent planning.
+	// Keep preserved API-owned and concurrently API-added skill siblings in the
+	// confirmed state. Terraform-owned removals were already required absent by
+	// agentSkillsMutationMatch; publishing only the planned list here would forget
+	// the remote siblings that made the full-card mutation safe.
+	if result.AgentCard != nil && observed.AgentCard != nil {
+		plannedIDs, priorIDs := map[string]bool{}, map[string]bool{}
+		for _, skill := range result.AgentCard.Skills {
+			if !skill.ID.IsNull() && !skill.ID.IsUnknown() {
+				plannedIDs[skill.ID.ValueString()] = true
+			}
+		}
+		if prior.AgentCard != nil {
+			for _, skill := range prior.AgentCard.Skills {
+				if !skill.ID.IsNull() && !skill.ID.IsUnknown() {
+					priorIDs[skill.ID.ValueString()] = true
+				}
+			}
+		}
+		for _, skill := range observed.AgentCard.Skills {
+			if skill.ID.IsNull() || skill.ID.IsUnknown() {
+				continue
+			}
+			id := skill.ID.ValueString()
+			if plannedIDs[id] {
+				continue
+			}
+			if agentFieldSetHasPrefix(imported, agentLeaf(agentFieldCardSkills, id)+".") || (imported[agentScopeCardSkills] && !priorIDs[id]) {
+				result.AgentCard.Skills = append(result.AgentCard.Skills, skill)
+				plannedIDs[id] = true
+			}
+		}
+	}
 	_ = config
-	_ = prior
 	resolveAgentUnknowns(&result)
 	return result
 }

--- a/internal/provider/resource_agent_lifecycle.go
+++ b/internal/provider/resource_agent_lifecycle.go
@@ -79,6 +79,7 @@ func readAgentImportedFields(ctx context.Context, private agentPrivateReader) (a
 
 const (
 	agentFieldParams            = "litellm_params"
+	agentFieldParamsJSON        = "litellm_params_json"
 	agentFieldTPM               = "tpm_limit"
 	agentFieldRPM               = "rpm_limit"
 	agentFieldSessionTPM        = "session_tpm_limit"
@@ -105,6 +106,7 @@ const (
 	agentFieldCardIcon          = "agent_card.icon_url"
 	agentFieldCardDocumentation = "agent_card.documentation_url"
 	agentFieldCardAuthenticated = "agent_card.supports_authenticated_extended_card"
+	agentFieldCardSignatures    = "agent_card.signatures"
 	agentFieldPermission        = "object_permission"
 	agentFieldPermissionServers = "object_permission.mcp_servers"
 	agentFieldPermissionGroups  = "object_permission.mcp_access_groups"
@@ -120,6 +122,7 @@ const (
 	agentScopeCardCapabilities = "__api_scope.agent_card.capabilities"
 	agentScopeCardProvider     = "__api_scope.agent_card.provider"
 	agentScopeCardSkills       = "__api_scope.agent_card.skills"
+	agentScopeCardSignatures   = "__api_scope.agent_card.signatures"
 	agentScopePermission       = "__api_scope.object_permission"
 )
 
@@ -129,6 +132,10 @@ func agentLeaf(prefix, value string) string {
 
 func agentSkillLeaf(id, field string) string {
 	return agentLeaf(agentFieldCardSkills, id) + "." + field
+}
+
+func agentSignatureLeaf(index int, field string) string {
+	return fmt.Sprintf("%s[%d].%s", agentFieldCardSignatures, index, field)
 }
 
 func agentFieldSetHasPrefix(fields agentFieldSet, prefix string) bool {
@@ -168,6 +175,14 @@ func agentConfiguredFields(data AgentResourceModel) agentFieldSet {
 		}
 	}
 	knownMap(agentFieldParams, data.LiteLLMParams)
+	knownString(agentFieldParamsJSON, data.LiteLLMParamsJSON)
+	if !data.LiteLLMParamsJSON.IsNull() && !data.LiteLLMParamsJSON.IsUnknown() {
+		if object, err := decodeAgentJSONObject(data.LiteLLMParamsJSON.ValueString()); err == nil {
+			for key := range object {
+				fields[agentLeaf(agentFieldParams, key)] = true
+			}
+		}
+	}
 	if !data.LiteLLMParams.IsNull() && !data.LiteLLMParams.IsUnknown() {
 		for key := range data.LiteLLMParams.Elements() {
 			fields[agentLeaf(agentFieldParams, key)] = true
@@ -197,6 +212,20 @@ func agentConfiguredFields(data AgentResourceModel) agentFieldSet {
 		knownString(agentFieldCardIcon, data.AgentCard.IconURL)
 		knownString(agentFieldCardDocumentation, data.AgentCard.DocumentationURL)
 		knownBool(agentFieldCardAuthenticated, data.AgentCard.SupportsAuthenticatedExtendedCard)
+		if data.AgentCard.Signatures != nil {
+			fields[agentFieldCardSignatures] = true
+			for index, signature := range data.AgentCard.Signatures {
+				if !signature.Protected.IsNull() && !signature.Protected.IsUnknown() {
+					fields[agentSignatureLeaf(index, "protected")] = true
+				}
+				if !signature.Signature.IsNull() && !signature.Signature.IsUnknown() {
+					fields[agentSignatureLeaf(index, "signature")] = true
+				}
+				if (!signature.Header.IsNull() && !signature.Header.IsUnknown()) || (!signature.HeaderJSON.IsNull() && !signature.HeaderJSON.IsUnknown()) {
+					fields[agentSignatureLeaf(index, "header")] = true
+				}
+			}
+		}
 		if data.AgentCard.Capabilities != nil {
 			fields[agentFieldCardCapabilities] = true
 			knownBool(agentFieldCardCapStreaming, data.AgentCard.Capabilities.Streaming)
@@ -234,6 +263,9 @@ func agentConfiguredFields(data AgentResourceModel) agentFieldSet {
 				if !skill.OutputModes.IsNull() && !skill.OutputModes.IsUnknown() {
 					fields[agentSkillLeaf(id, "output_modes")] = true
 				}
+				if (!skill.Security.IsNull() && !skill.Security.IsUnknown()) || (!skill.SecurityJSON.IsNull() && !skill.SecurityJSON.IsUnknown()) {
+					fields[agentSkillLeaf(id, "security")] = true
+				}
 			}
 		}
 	}
@@ -252,7 +284,7 @@ func agentImportedFieldsFromState(data AgentResourceModel) agentFieldSet {
 	all := agentConfiguredFields(data)
 	// Ownership is leaf-scoped. The distinct structural markers allow later API
 	// additions to imported collections without transferring sibling ownership.
-	for _, parent := range []string{agentFieldParams, agentFieldStaticHeaders, agentFieldCard, agentFieldCardCapabilities, agentFieldCardProvider, agentFieldCardSkills, agentFieldPermission} {
+	for _, parent := range []string{agentFieldParams, agentFieldStaticHeaders, agentFieldCard, agentFieldCardCapabilities, agentFieldCardProvider, agentFieldCardSkills, agentFieldCardSignatures, agentFieldPermission} {
 		delete(all, parent)
 	}
 	all[agentScopeParams] = true
@@ -262,6 +294,7 @@ func agentImportedFieldsFromState(data AgentResourceModel) agentFieldSet {
 		all[agentScopeCardCapabilities] = true
 		all[agentScopeCardProvider] = true
 		all[agentScopeCardSkills] = true
+		all[agentScopeCardSignatures] = true
 	}
 	return all
 }
@@ -286,9 +319,32 @@ func validateAgentSkillModels(skills []AgentSkillModel) error {
 
 func validateAgentModelSkillIdentities(models ...AgentResourceModel) error {
 	for _, model := range models {
-		if model.AgentCard != nil && model.AgentCard.Skills != nil {
+		if model.AgentCard == nil {
+			continue
+		}
+		if model.AgentCard.Skills != nil {
 			if err := validateAgentSkillModels(model.AgentCard.Skills); err != nil {
 				return err
+			}
+			for _, skill := range model.AgentCard.Skills {
+				if !skill.Security.IsNull() && !skill.Security.IsUnknown() && !skill.SecurityJSON.IsNull() && !skill.SecurityJSON.IsUnknown() {
+					return fmt.Errorf("agent card skill security conflicts with security_json")
+				}
+				if !skill.SecurityJSON.IsNull() && !skill.SecurityJSON.IsUnknown() {
+					if _, err := decodeAgentSecurityJSON(skill.SecurityJSON.ValueString()); err != nil {
+						return fmt.Errorf("agent card skill security_json is malformed")
+					}
+				}
+			}
+		}
+		for _, signature := range model.AgentCard.Signatures {
+			if !signature.Header.IsNull() && !signature.Header.IsUnknown() && !signature.HeaderJSON.IsNull() && !signature.HeaderJSON.IsUnknown() {
+				return fmt.Errorf("agent card signature header conflicts with header_json")
+			}
+			if !signature.HeaderJSON.IsNull() && !signature.HeaderJSON.IsUnknown() {
+				if _, err := decodeAgentNullOrObject(signature.HeaderJSON.ValueString()); err != nil {
+					return fmt.Errorf("agent card signature header_json is malformed")
+				}
 			}
 		}
 	}
@@ -308,6 +364,10 @@ func (r *AgentResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanR
 	}
 	if err := validateAgentModelSkillIdentities(state, plan, config); err != nil {
 		resp.Diagnostics.AddError("Invalid Agent Skill Identity", err.Error())
+		return
+	}
+	if _, _, err := configuredAgentParams(config.LiteLLMParams, config.LiteLLMParamsJSON); err != nil {
+		resp.Diagnostics.AddError("Agent Parameter Conflict", err.Error())
 		return
 	}
 	imported, diagnostics := readAgentImportedFields(ctx, req.Private)
@@ -350,8 +410,14 @@ func (r *AgentResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanR
 		*target = types.MapValueMust(types.StringType, values)
 		return !original.Equal(*target)
 	}
-	paramsMerged := mergeAPIMapLeavesIntoPlan(&plan.LiteLLMParams, state.LiteLLMParams, agentFieldParams)
-	headersMerged := mergeAPIMapLeavesIntoPlan(&plan.StaticHeaders, state.StaticHeaders, agentFieldStaticHeaders)
+	paramsMerged := false
+	if config.LiteLLMParams.IsNull() || config.LiteLLMParams.IsUnknown() {
+		paramsMerged = mergeAPIMapLeavesIntoPlan(&plan.LiteLLMParams, state.LiteLLMParams, agentFieldParams)
+	}
+	headersMerged := false
+	if config.StaticHeaders.IsNull() || config.StaticHeaders.IsUnknown() {
+		headersMerged = mergeAPIMapLeavesIntoPlan(&plan.StaticHeaders, state.StaticHeaders, agentFieldStaticHeaders)
+	}
 	configured := agentConfiguredFields(config)
 	pending := agentFieldSet{}
 	for field := range imported {
@@ -375,6 +441,12 @@ func (r *AgentResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanR
 	}
 	if headersMerged {
 		resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root(agentFieldStaticHeaders), plan.StaticHeaders)...)
+	}
+	if agentParamsUpdateTouched(plan, state, config, imported) && config.LiteLLMParamsJSON.IsNull() && !state.LiteLLMParamsJSON.IsNull() {
+		// An imported/API-owned JSON projection changes as a consequence of an
+		// explicitly planned legacy-key update. Mark only that computed bridge
+		// unknown so authoritative exact-type read-back is plan-consistent.
+		resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root(agentFieldParamsJSON), types.StringUnknown())...)
 	}
 	if resp.Private != nil {
 		resp.Diagnostics.Append(resp.Private.SetKey(ctx, agentOwnershipPendingPrivateKey, encodeAgentFieldSet(pending))...)
@@ -410,6 +482,8 @@ func copyAgentField(target *AgentResourceModel, source AgentResourceModel, field
 	switch field {
 	case agentFieldParams:
 		target.LiteLLMParams = source.LiteLLMParams
+	case agentFieldParamsJSON:
+		target.LiteLLMParamsJSON = source.LiteLLMParamsJSON
 	case agentFieldTPM:
 		target.TPMLimit = source.TPMLimit
 	case agentFieldRPM:
@@ -427,7 +501,7 @@ func copyAgentField(target *AgentResourceModel, source AgentResourceModel, field
 	case agentFieldCardDescription, agentFieldCardVersion, agentFieldCardProtocol, agentFieldCardInputModes, agentFieldCardOutputModes,
 		agentFieldCardCapabilities, agentFieldCardCapStreaming, agentFieldCardCapPush, agentFieldCardCapHistory,
 		agentFieldCardProvider, agentFieldCardProviderOrg, agentFieldCardProviderURL, agentFieldCardSkills, agentFieldCardTransport, agentFieldCardIcon,
-		agentFieldCardDocumentation, agentFieldCardAuthenticated:
+		agentFieldCardDocumentation, agentFieldCardAuthenticated, agentFieldCardSignatures:
 		if target.AgentCard == nil || source.AgentCard == nil {
 			return
 		}
@@ -483,6 +557,8 @@ func copyAgentField(target *AgentResourceModel, source AgentResourceModel, field
 			target.AgentCard.DocumentationURL = source.AgentCard.DocumentationURL
 		case agentFieldCardAuthenticated:
 			target.AgentCard.SupportsAuthenticatedExtendedCard = source.AgentCard.SupportsAuthenticatedExtendedCard
+		case agentFieldCardSignatures:
+			target.AgentCard.Signatures = append([]AgentCardSignatureModel(nil), source.AgentCard.Signatures...)
 		}
 	case agentFieldPermission:
 		target.ObjectPermission = cloneAgentResourceModel(source).ObjectPermission
@@ -572,6 +648,34 @@ func validateAgentCardResponse(card map[string]interface{}, requiredIdentity boo
 			}
 		}
 	}
+	if raw, present := card["signatures"]; present && raw != nil {
+		signatures, ok := raw.([]interface{})
+		if !ok {
+			return fmt.Errorf("agent read response contains a malformed agent card")
+		}
+		for _, rawSignature := range signatures {
+			signature, ok := rawSignature.(map[string]interface{})
+			if !ok {
+				return fmt.Errorf("agent read response contains a malformed agent card")
+			}
+			for _, field := range []string{"protected", "signature"} {
+				value, present := signature[field]
+				if requiredIdentity && !present {
+					return fmt.Errorf("agent read response contains a malformed agent card")
+				}
+				if present && value != nil {
+					if _, ok := value.(string); !ok {
+						return fmt.Errorf("agent read response contains a malformed agent card")
+					}
+				}
+			}
+			if header, present := signature["header"]; present && header != nil {
+				if _, ok := header.(map[string]interface{}); !ok {
+					return fmt.Errorf("agent read response contains a malformed agent card")
+				}
+			}
+		}
+	}
 	if raw, present := card["skills"]; present && raw != nil {
 		skills, ok := raw.([]interface{})
 		if !ok {
@@ -585,13 +689,18 @@ func validateAgentCardResponse(card map[string]interface{}, requiredIdentity boo
 			}
 			skillID, idOK := skill["id"].(string)
 			skillName, skillNameOK := skill["name"].(string)
-			if !idOK || strings.TrimSpace(skillID) == "" || skillID != strings.TrimSpace(skillID) || !skillNameOK || strings.TrimSpace(skillName) == "" {
+			if requiredIdentity && (!idOK || strings.TrimSpace(skillID) == "" || skillID != strings.TrimSpace(skillID) || !skillNameOK || strings.TrimSpace(skillName) == "") {
 				return fmt.Errorf("agent read response contains a malformed agent card")
 			}
-			if _, duplicate := seenSkillIDs[skillID]; duplicate {
-				return fmt.Errorf("agent read response contains duplicate agent skill identities")
+			if idOK {
+				if strings.TrimSpace(skillID) == "" || skillID != strings.TrimSpace(skillID) {
+					return fmt.Errorf("agent read response contains a malformed agent card")
+				}
+				if _, duplicate := seenSkillIDs[skillID]; duplicate {
+					return fmt.Errorf("agent read response contains duplicate agent skill identities")
+				}
+				seenSkillIDs[skillID] = struct{}{}
 			}
-			seenSkillIDs[skillID] = struct{}{}
 			for _, field := range []string{"id", "name", "description"} {
 				if value, present := skill[field]; present && value != nil {
 					if _, ok := value.(string); !ok {
@@ -601,6 +710,11 @@ func validateAgentCardResponse(card map[string]interface{}, requiredIdentity boo
 			}
 			for _, field := range []string{"tags", "examples", "inputModes", "outputModes"} {
 				if value, present := skill[field]; present && value != nil && !validateStringArray(value) {
+					return fmt.Errorf("agent read response contains a malformed agent card")
+				}
+			}
+			if value, present := skill["security"]; present && value != nil {
+				if _, err := readAgentSecurity(value); err != nil {
 					return fmt.Errorf("agent read response contains a malformed agent card")
 				}
 			}
@@ -751,7 +865,24 @@ func validateAgentUpdateClears(plan, state, config AgentResourceModel, imported 
 		return !prior.IsNull() && !prior.IsUnknown() && knownNullString(planned) && !configured[field] && !imported[field]
 	}
 
-	if (!state.LiteLLMParams.IsNull() && !state.LiteLLMParams.IsUnknown() && knownNullMap(plan.LiteLLMParams) && !agentFieldSetHasPrefix(imported, agentFieldParams+"[")) ||
+	structuredEmptyClear := false
+	if !config.LiteLLMParamsJSON.IsNull() && !config.LiteLLMParamsJSON.IsUnknown() {
+		configuredObject, err := decodeAgentJSONObject(config.LiteLLMParamsJSON.ValueString())
+		if err != nil {
+			return err
+		}
+		priorJSONNonempty := false
+		if !state.LiteLLMParamsJSON.IsNull() && !state.LiteLLMParamsJSON.IsUnknown() {
+			priorObject, priorErr := decodeAgentJSONObject(state.LiteLLMParamsJSON.ValueString())
+			if priorErr != nil {
+				return priorErr
+			}
+			priorJSONNonempty = len(priorObject) > 0
+		}
+		priorNonempty := priorJSONNonempty || (!state.LiteLLMParams.IsNull() && !state.LiteLLMParams.IsUnknown() && len(state.LiteLLMParams.Elements()) > 0)
+		structuredEmptyClear = len(configuredObject) == 0 && config.LiteLLMParams.IsNull() && priorNonempty
+	}
+	if structuredEmptyClear || (!state.LiteLLMParams.IsNull() && !state.LiteLLMParams.IsUnknown() && knownNullMap(plan.LiteLLMParams) && !agentFieldSetHasPrefix(imported, agentFieldParams+"[")) ||
 		(!config.LiteLLMParams.IsNull() && !config.LiteLLMParams.IsUnknown() && len(config.LiteLLMParams.Elements()) == 0 && !plan.LiteLLMParams.IsNull() && !plan.LiteLLMParams.IsUnknown() && len(plan.LiteLLMParams.Elements()) == 0 && !state.LiteLLMParams.IsNull() && len(state.LiteLLMParams.Elements()) > 0) {
 		return fmt.Errorf("LiteLLM v1.98 ignores an empty litellm_params object. Keep at least one parameter, or retain the existing map; complete map clearing is not API-safe.")
 	}
@@ -790,7 +921,10 @@ func validateAgentUpdateClears(plan, state, config AgentResourceModel, imported 
 				continue
 			}
 			if agentFieldSetHasPrefix(imported, agentLeaf(agentFieldCardSkills, id)+".") {
-				return fmt.Errorf("an agent skill cannot be removed while it contains API-owned leaves; configure or transfer every leaf first")
+				// Omission of an API-owned skill is preservation, not removal. The
+				// raw-card overlay retains it. Once HCL has transferred all present
+				// leaves, the markers disappear and a later omission removes it.
+				continue
 			}
 		}
 	}
@@ -838,6 +972,9 @@ func agentCardUpdateTouched(plan, state, config AgentResourceModel, imported age
 		changed(agentFieldCardIcon, plan.AgentCard.IconURL.Equal(state.AgentCard.IconURL), plan.AgentCard.IconURL.IsNull()) ||
 		changed(agentFieldCardDocumentation, plan.AgentCard.DocumentationURL.Equal(state.AgentCard.DocumentationURL), plan.AgentCard.DocumentationURL.IsNull()) ||
 		changed(agentFieldCardAuthenticated, plan.AgentCard.SupportsAuthenticatedExtendedCard.Equal(state.AgentCard.SupportsAuthenticatedExtendedCard), plan.AgentCard.SupportsAuthenticatedExtendedCard.IsNull()) {
+		return true
+	}
+	if !reflect.DeepEqual(plan.AgentCard.Signatures, state.AgentCard.Signatures) && (config.AgentCard != nil && config.AgentCard.Signatures != nil || prior[agentFieldCardSignatures]) {
 		return true
 	}
 	if !agentSkillsEqual(plan.AgentCard.Skills, state.AgentCard.Skills) && (config.AgentCard != nil && config.AgentCard.Skills != nil || prior[agentFieldCardSkills]) {
@@ -956,6 +1093,9 @@ func overlayAgentCardWire(fresh, plan, state, config AgentResourceModel, importe
 	copyString(agentFieldCardIcon, &wire.IconURL, plan.AgentCard.IconURL)
 	copyString(agentFieldCardDocumentation, &wire.DocumentationURL, plan.AgentCard.DocumentationURL)
 	copyBool(agentFieldCardAuthenticated, &wire.SupportsAuthenticatedExtendedCard, plan.AgentCard.SupportsAuthenticatedExtendedCard)
+	if configured[agentFieldCardSignatures] || (prior[agentFieldCardSignatures] && !imported[agentFieldCardSignatures] && plan.AgentCard.Signatures == nil) {
+		wire.Signatures = append([]AgentCardSignatureModel(nil), plan.AgentCard.Signatures...)
+	}
 	if wire.Capabilities == nil {
 		wire.Capabilities = &AgentCapabilitiesModel{Streaming: types.BoolNull(), PushNotifications: types.BoolNull(), StateTransitionHistory: types.BoolNull()}
 	}
@@ -1014,6 +1154,11 @@ func overlayAgentCardWire(fresh, plan, state, config AgentResourceModel, importe
 					*item.target = item.value
 				}
 			}
+			securityField := agentSkillLeaf(id, "security")
+			if configured[securityField] || (!imported[securityField] && desired.Security.IsNull() && desired.SecurityJSON.IsNull()) {
+				current.Security = desired.Security
+				current.SecurityJSON = desired.SecurityJSON
+			}
 			merged = append(merged, current)
 			seen[id] = true
 		}
@@ -1048,6 +1193,38 @@ func (r *AgentResource) buildAgentUpdateRequest(plan, state, config *AgentResour
 			copyAgentField(&wirePlan, *state, field)
 		}
 	}
+	// An explicitly configured structured object is a complete ownership
+	// transfer for that surface. Build it only with explicit legacy siblings,
+	// not API-owned legacy projections retained in the Terraform plan.
+	if configured[agentFieldParamsJSON] {
+		wirePlan.LiteLLMParams = config.LiteLLMParams
+		wirePlan.LiteLLMParamsJSON = config.LiteLLMParamsJSON
+	} else if imported[agentFieldParamsJSON] && !wirePlan.LiteLLMParamsJSON.IsNull() && !wirePlan.LiteLLMParamsJSON.IsUnknown() {
+		// The legacy import projection intentionally keeps its historic
+		// map(string) rendering, but the private JSON marker proves the JSON
+		// document is the wire authority. Overlay only explicitly configured
+		// legacy strings so numeric/bool/null/container values never round-trip
+		// as ambiguous strings.
+		remoteObject, decodeErr := decodeAgentJSONObject(wirePlan.LiteLLMParamsJSON.ValueString())
+		if decodeErr != nil {
+			return nil, decodeErr
+		}
+		if !config.LiteLLMParams.IsNull() && !config.LiteLLMParams.IsUnknown() {
+			for key, raw := range config.LiteLLMParams.Elements() {
+				value, ok := raw.(types.String)
+				if !ok || value.IsNull() || value.IsUnknown() {
+					return nil, fmt.Errorf("invalid configured legacy agent parameter")
+				}
+				remoteObject[key] = value.ValueString()
+			}
+		}
+		encoded, encodeErr := canonicalAgentJSON(remoteObject)
+		if encodeErr != nil {
+			return nil, encodeErr
+		}
+		wirePlan.LiteLLMParams = types.MapNull(types.StringType)
+		wirePlan.LiteLLMParamsJSON = types.StringValue(encoded)
+	}
 	full, err := r.buildAgentRequest(&wirePlan)
 	if err != nil {
 		return nil, err
@@ -1061,12 +1238,19 @@ func (r *AgentResource) buildAgentUpdateRequest(plan, state, config *AgentResour
 			req["agent_card_params"] = card
 		}
 	}
-	if configured[agentFieldParams] {
-		params := map[string]interface{}{}
-		for key, value := range plan.LiteLLMParams.Elements() {
-			if stringValue, ok := value.(types.String); ok {
-				params[key] = stringValue.ValueString()
-			}
+	if configured[agentFieldParams] || configured[agentFieldParamsJSON] {
+		paramsSource, jsonSource := plan.LiteLLMParams, plan.LiteLLMParamsJSON
+		if configured[agentFieldParamsJSON] {
+			paramsSource, jsonSource = config.LiteLLMParams, config.LiteLLMParamsJSON
+		} else if imported[agentFieldParamsJSON] {
+			paramsSource, jsonSource = wirePlan.LiteLLMParams, wirePlan.LiteLLMParamsJSON
+		}
+		params, _, err := configuredAgentParams(paramsSource, jsonSource)
+		if err != nil {
+			return nil, err
+		}
+		if err := validateAgentCorePair(params); err != nil {
+			return nil, err
 		}
 		req["litellm_params"] = params
 	}
@@ -1085,7 +1269,7 @@ func (r *AgentResource) buildAgentUpdateRequest(plan, state, config *AgentResour
 	}
 	if configured[agentFieldStaticHeaders] {
 		headers := map[string]interface{}{}
-		for key, value := range plan.StaticHeaders.Elements() {
+		for key, value := range wirePlan.StaticHeaders.Elements() {
 			if stringValue, ok := value.(types.String); ok {
 				headers[key] = stringValue.ValueString()
 			}
@@ -1132,6 +1316,10 @@ func (r *AgentResource) buildAgentUpdateRequest(plan, state, config *AgentResour
 }
 
 func (r *AgentResource) confirmAgentMutation(ctx context.Context, planned, prior, config AgentResourceModel, imported agentFieldSet, maxAttempts int) (AgentResourceModel, error) {
+	return r.confirmAgentMutationWithPreservation(ctx, planned, prior, config, imported, nil, maxAttempts)
+}
+
+func (r *AgentResource) confirmAgentMutationWithPreservation(ctx context.Context, planned, prior, config AgentResourceModel, imported agentFieldSet, preservation *agentPatchPreservation, maxAttempts int) (AgentResourceModel, error) {
 	if err := validateAgentModelSkillIdentities(planned, prior, config); err != nil {
 		return AgentResourceModel{}, err
 	}
@@ -1145,10 +1333,11 @@ func (r *AgentResource) confirmAgentMutation(ctx context.Context, planned, prior
 	for attempt := 0; attempt < maxAttempts; attempt++ {
 		observed := emptyKnownAgentResourceModel()
 		observed.ID = planned.ID
-		err := r.readAgentFreshWithOwnership(ctx, &observed, true, nil)
+		var raw map[string]interface{}
+		err := r.readAgentWithOwnershipTransportCapture(ctx, &observed, true, nil, true, &raw)
 		if err == nil {
 			resolveAgentUnknowns(&observed)
-			if validateAgentModelSkillIdentities(observed) == nil && len(agentMutationMismatches(planned, prior, config, imported, observed)) == 0 && !agentResourceHasUnknowns(observed) {
+			if validateAgentModelSkillIdentities(observed) == nil && preservation.matches(raw) && len(agentMutationMismatches(planned, prior, config, imported, observed)) == 0 && !agentResourceHasUnknowns(observed) {
 				consecutive++
 				lastConfirmed = reconcileConfirmedAgentState(planned, observed, config, prior, imported)
 				if consecutive >= 2 {
@@ -1219,6 +1408,26 @@ func agentMutationMismatches(planned, prior, config AgentResourceModel, imported
 	if !agentMapMutationMatches(planned.LiteLLMParams, prior.LiteLLMParams, config.LiteLLMParams, observed.LiteLLMParams, imported, agentFieldParams) {
 		mismatches = append(mismatches, agentFieldParams)
 	}
+	if configured[agentFieldParamsJSON] {
+		expected, _, err := configuredAgentParams(config.LiteLLMParams, config.LiteLLMParamsJSON)
+		var actual map[string]interface{}
+		if err == nil && !observed.LiteLLMParamsJSON.IsNull() && !observed.LiteLLMParamsJSON.IsUnknown() {
+			actual, err = decodeAgentJSONObject(observed.LiteLLMParamsJSON.ValueString())
+		}
+		matches := err == nil
+		if matches {
+			for key, value := range expected {
+				observedValue, present := actual[key]
+				if !present || !exactJSONValuesEqual(value, observedValue) {
+					matches = false
+					break
+				}
+			}
+		}
+		if !matches {
+			mismatches = append(mismatches, agentFieldParamsJSON)
+		}
+	}
 	check(agentFieldTPM, planned.TPMLimit.Equal(observed.TPMLimit), observed.TPMLimit.IsNull())
 	check(agentFieldRPM, planned.RPMLimit.Equal(observed.RPMLimit), observed.RPMLimit.IsNull())
 	check(agentFieldSessionTPM, planned.SessionTPMLimit.Equal(observed.SessionTPMLimit), observed.SessionTPMLimit.IsNull())
@@ -1265,6 +1474,9 @@ func compareAgentCard(mismatches *[]string, planned, prior, config AgentResource
 	authEqual := planned.AgentCard.SupportsAuthenticatedExtendedCard.Equal(observed.AgentCard.SupportsAuthenticatedExtendedCard) ||
 		(!planned.AgentCard.SupportsAuthenticatedExtendedCard.IsNull() && !planned.AgentCard.SupportsAuthenticatedExtendedCard.IsUnknown() && !planned.AgentCard.SupportsAuthenticatedExtendedCard.ValueBool() && observed.AgentCard.SupportsAuthenticatedExtendedCard.IsNull())
 	check(agentFieldCardAuthenticated, authEqual, observed.AgentCard.SupportsAuthenticatedExtendedCard.IsNull() || !observed.AgentCard.SupportsAuthenticatedExtendedCard.ValueBool())
+	if !agentSignaturesMutationMatch(planned.AgentCard.Signatures, prior.AgentCard, config.AgentCard.Signatures, observed.AgentCard.Signatures, imported) {
+		*mismatches = append(*mismatches, agentFieldCardSignatures)
+	}
 	plannedCapabilities, observedCapabilities := planned.AgentCard.Capabilities, observed.AgentCard.Capabilities
 	capabilityCheck := func(field string, plannedValue, observedValue types.Bool) {
 		configuredValue := configured[field]
@@ -1305,6 +1517,37 @@ func compareAgentCard(mismatches *[]string, planned, prior, config AgentResource
 	}
 }
 
+func agentSignaturesMutationMatch(planned []AgentCardSignatureModel, priorCard *AgentCardModel, config, observed []AgentCardSignatureModel, imported agentFieldSet) bool {
+	prior := []AgentCardSignatureModel(nil)
+	if priorCard != nil {
+		prior = priorCard.Signatures
+	}
+	if config != nil {
+		for index, configured := range config {
+			if index >= len(planned) || index >= len(observed) {
+				return false
+			}
+			if !planned[index].Protected.Equal(observed[index].Protected) || !planned[index].Signature.Equal(observed[index].Signature) {
+				return false
+			}
+			if (!configured.Header.IsNull() && !configured.Header.IsUnknown()) || (!configured.HeaderJSON.IsNull() && !configured.HeaderJSON.IsUnknown()) {
+				if !agentOptionalJSONEqual(planned[index].Header, observed[index].Header) || !agentOptionalJSONEqual(planned[index].HeaderJSON, observed[index].HeaderJSON) {
+					return false
+				}
+			}
+		}
+	}
+	for index := len(config); index < len(prior); index++ {
+		if agentFieldSetHasPrefix(imported, fmt.Sprintf("%s[%d].", agentFieldCardSignatures, index)) {
+			continue
+		}
+		if index < len(observed) {
+			return false
+		}
+	}
+	return true
+}
+
 func agentSkillsMutationMatch(planned []AgentSkillModel, priorCard *AgentCardModel, config, observed []AgentSkillModel, imported agentFieldSet) bool {
 	byID := func(skills []AgentSkillModel) map[string]AgentSkillModel {
 		result := map[string]AgentSkillModel{}
@@ -1314,6 +1557,10 @@ func agentSkillsMutationMatch(planned []AgentSkillModel, priorCard *AgentCardMod
 		return result
 	}
 	p, c, o := byID(planned), byID(config), byID(observed)
+	priorByID := map[string]AgentSkillModel{}
+	if priorCard != nil {
+		priorByID = byID(priorCard.Skills)
+	}
 	configured := agentConfiguredFields(AgentResourceModel{AgentCard: &AgentCardModel{Skills: config}})
 	for id := range c {
 		pv, pok := p[id]
@@ -1337,6 +1584,12 @@ func agentSkillsMutationMatch(planned []AgentSkillModel, priorCard *AgentCardMod
 			return false
 		}
 		if configured[agentSkillLeaf(id, "output_modes")] && !pv.OutputModes.Equal(ov.OutputModes) {
+			return false
+		}
+		if configured[agentSkillLeaf(id, "security")] && (!pv.Security.Equal(ov.Security) || !pv.SecurityJSON.Equal(ov.SecurityJSON)) {
+			return false
+		}
+		if priorSkill, hadPrior := priorByID[id]; hadPrior && !priorSkill.Security.IsNull() && !configured[agentSkillLeaf(id, "security")] && !imported[agentSkillLeaf(id, "security")] && !ov.Security.IsNull() {
 			return false
 		}
 	}
@@ -1385,6 +1638,28 @@ func compareAgentPermissions(mismatches *[]string, planned, prior, config AgentR
 	}
 }
 
+func agentOptionalJSONEqual(left, right types.String) bool {
+	if left.Equal(right) {
+		return true
+	}
+	return !left.IsNull() && !left.IsUnknown() && !right.IsNull() && !right.IsUnknown() && jsonSemanticallyEqual(left.ValueString(), right.ValueString())
+}
+
+func agentSignaturesEqual(left, right []AgentCardSignatureModel) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if !left[index].Protected.Equal(right[index].Protected) || !left[index].Signature.Equal(right[index].Signature) {
+			return false
+		}
+		if !agentOptionalJSONEqual(left[index].Header, right[index].Header) || !agentOptionalJSONEqual(left[index].HeaderJSON, right[index].HeaderJSON) {
+			return false
+		}
+	}
+	return true
+}
+
 func agentSkillsEqual(left, right []AgentSkillModel) bool {
 	if len(left) != len(right) {
 		return false
@@ -1410,7 +1685,7 @@ func agentSkillsEqual(left, right []AgentSkillModel) bool {
 		seenLeft[l.ID.ValueString()] = struct{}{}
 		r, ok := rightByID[l.ID.ValueString()]
 		if !ok || !l.Name.Equal(r.Name) || !l.Description.Equal(r.Description) ||
-			!agentStringListSetEqual(l.Tags, r.Tags) || !l.Examples.Equal(r.Examples) || !l.InputModes.Equal(r.InputModes) || !l.OutputModes.Equal(r.OutputModes) {
+			!agentStringListSetEqual(l.Tags, r.Tags) || !l.Examples.Equal(r.Examples) || !l.InputModes.Equal(r.InputModes) || !l.OutputModes.Equal(r.OutputModes) || !l.Security.Equal(r.Security) || !agentOptionalJSONEqual(l.SecurityJSON, r.SecurityJSON) {
 			return false
 		}
 	}
@@ -1443,8 +1718,22 @@ func reconcileConfirmedAgentState(planned, observed, config, prior AgentResource
 		}
 		*target = types.MapValueMust(types.StringType, values)
 	}
-	mergeMap(&result.LiteLLMParams, observed.LiteLLMParams, agentFieldParams)
-	mergeMap(&result.StaticHeaders, observed.StaticHeaders, agentFieldStaticHeaders)
+	if config.LiteLLMParams.IsNull() || config.LiteLLMParams.IsUnknown() {
+		mergeMap(&result.LiteLLMParams, observed.LiteLLMParams, agentFieldParams)
+	} else {
+		result.LiteLLMParams = config.LiteLLMParams
+	}
+	if !config.LiteLLMParamsJSON.IsNull() && !config.LiteLLMParamsJSON.IsUnknown() {
+		result.LiteLLMParams = config.LiteLLMParams
+	}
+	if imported[agentFieldParamsJSON] && config.LiteLLMParamsJSON.IsNull() {
+		result.LiteLLMParamsJSON = observed.LiteLLMParamsJSON
+	}
+	if config.StaticHeaders.IsNull() || config.StaticHeaders.IsUnknown() {
+		mergeMap(&result.StaticHeaders, observed.StaticHeaders, agentFieldStaticHeaders)
+	} else {
+		result.StaticHeaders = config.StaticHeaders
+	}
 	// Optional+Computed maps may retain API-owned keys in the planned value.
 	// Optional-only nested leaves cannot be added after apply without violating
 	// Terraform's planned-value contract; ordinary Read re-adopts those leaves
@@ -1457,21 +1746,22 @@ func reconcileConfirmedAgentState(planned, observed, config, prior AgentResource
 
 func emptyKnownAgentResourceModel() AgentResourceModel {
 	return AgentResourceModel{
-		ID:               types.StringNull(),
-		AgentName:        types.StringNull(),
-		AgentCard:        nil,
-		LiteLLMParams:    types.MapNull(types.StringType),
-		ObjectPermission: nil,
-		TPMLimit:         types.Int64Null(),
-		RPMLimit:         types.Int64Null(),
-		SessionTPMLimit:  types.Int64Null(),
-		SessionRPMLimit:  types.Int64Null(),
-		StaticHeaders:    types.MapNull(types.StringType),
-		ExtraHeaders:     types.ListNull(types.StringType),
-		CreatedAt:        types.StringNull(),
-		UpdatedAt:        types.StringNull(),
-		CreatedBy:        types.StringNull(),
-		UpdatedBy:        types.StringNull(),
+		ID:                types.StringNull(),
+		AgentName:         types.StringNull(),
+		AgentCard:         nil,
+		LiteLLMParams:     types.MapNull(types.StringType),
+		LiteLLMParamsJSON: types.StringNull(),
+		ObjectPermission:  nil,
+		TPMLimit:          types.Int64Null(),
+		RPMLimit:          types.Int64Null(),
+		SessionTPMLimit:   types.Int64Null(),
+		SessionRPMLimit:   types.Int64Null(),
+		StaticHeaders:     types.MapNull(types.StringType),
+		ExtraHeaders:      types.ListNull(types.StringType),
+		CreatedAt:         types.StringNull(),
+		UpdatedAt:         types.StringNull(),
+		CreatedBy:         types.StringNull(),
+		UpdatedBy:         types.StringNull(),
 	}
 }
 
@@ -1484,6 +1774,9 @@ func resolveAgentUnknowns(data *AgentResourceModel) {
 	}
 	if data.LiteLLMParams.IsUnknown() {
 		data.LiteLLMParams = types.MapNull(types.StringType)
+	}
+	if data.LiteLLMParamsJSON.IsUnknown() {
+		data.LiteLLMParamsJSON = types.StringNull()
 	}
 	if data.TPMLimit.IsUnknown() {
 		data.TPMLimit = types.Int64Null()
@@ -1569,6 +1862,21 @@ func resolveAgentUnknowns(data *AgentResourceModel) {
 				card.Provider.URL = types.StringNull()
 			}
 		}
+		for index := range card.Signatures {
+			signature := &card.Signatures[index]
+			if signature.Protected.IsUnknown() {
+				signature.Protected = types.StringNull()
+			}
+			if signature.Signature.IsUnknown() {
+				signature.Signature = types.StringNull()
+			}
+			if signature.Header.IsUnknown() {
+				signature.Header = types.StringNull()
+			}
+			if signature.HeaderJSON.IsUnknown() {
+				signature.HeaderJSON = types.StringNull()
+			}
+		}
 		for index := range card.Skills {
 			skill := &card.Skills[index]
 			if skill.ID.IsUnknown() {
@@ -1591,6 +1899,12 @@ func resolveAgentUnknowns(data *AgentResourceModel) {
 			}
 			if skill.OutputModes.IsUnknown() {
 				skill.OutputModes = types.ListNull(types.StringType)
+			}
+			if skill.Security.IsUnknown() {
+				skill.Security = types.ListNull(types.MapType{ElemType: types.ListType{ElemType: types.StringType}})
+			}
+			if skill.SecurityJSON.IsUnknown() {
+				skill.SecurityJSON = types.StringNull()
 			}
 		}
 	}
@@ -1615,7 +1929,7 @@ func resolveAgentUnknowns(data *AgentResourceModel) {
 }
 
 func agentResourceHasUnknowns(data AgentResourceModel) bool {
-	if data.ID.IsUnknown() || data.AgentName.IsUnknown() || data.LiteLLMParams.IsUnknown() || data.TPMLimit.IsUnknown() || data.RPMLimit.IsUnknown() ||
+	if data.ID.IsUnknown() || data.AgentName.IsUnknown() || data.LiteLLMParams.IsUnknown() || data.LiteLLMParamsJSON.IsUnknown() || data.TPMLimit.IsUnknown() || data.RPMLimit.IsUnknown() ||
 		data.SessionTPMLimit.IsUnknown() || data.SessionRPMLimit.IsUnknown() || data.StaticHeaders.IsUnknown() || data.ExtraHeaders.IsUnknown() ||
 		data.CreatedAt.IsUnknown() || data.UpdatedAt.IsUnknown() || data.CreatedBy.IsUnknown() || data.UpdatedBy.IsUnknown() {
 		return true
@@ -1633,8 +1947,13 @@ func agentResourceHasUnknowns(data AgentResourceModel) bool {
 		if card.Provider != nil && (card.Provider.Organization.IsUnknown() || card.Provider.URL.IsUnknown()) {
 			return true
 		}
+		for _, signature := range card.Signatures {
+			if signature.Protected.IsUnknown() || signature.Signature.IsUnknown() || signature.Header.IsUnknown() || signature.HeaderJSON.IsUnknown() {
+				return true
+			}
+		}
 		for _, skill := range card.Skills {
-			if skill.ID.IsUnknown() || skill.Name.IsUnknown() || skill.Description.IsUnknown() || skill.Tags.IsUnknown() || skill.Examples.IsUnknown() || skill.InputModes.IsUnknown() || skill.OutputModes.IsUnknown() {
+			if skill.ID.IsUnknown() || skill.Name.IsUnknown() || skill.Description.IsUnknown() || skill.Tags.IsUnknown() || skill.Examples.IsUnknown() || skill.InputModes.IsUnknown() || skill.OutputModes.IsUnknown() || skill.Security.IsUnknown() || skill.SecurityJSON.IsUnknown() {
 				return true
 			}
 		}

--- a/internal/provider/resource_agent_lifecycle_test.go
+++ b/internal/provider/resource_agent_lifecycle_test.go
@@ -643,8 +643,8 @@ func TestAgentSkillRemovalOwnershipAndPayload(t *testing.T) {
 	plan := cloneAgentResourceModel(state)
 	plan.AgentCard.Skills = []AgentSkillModel{skill("keep")}
 	config := cloneAgentResourceModel(plan)
-	if err := validateAgentUpdateClears(plan, state, config, agentFieldSet{agentSkillLeaf("remove", "name"): true}); err == nil {
-		t.Fatal("API-owned skill removal was accepted")
+	if err := validateAgentUpdateClears(plan, state, config, agentFieldSet{agentSkillLeaf("remove", "name"): true}); err != nil {
+		t.Fatalf("API-owned skill preservation was rejected: %v", err)
 	}
 	structuralScope := agentFieldSet{agentScopeCardSkills: true}
 	if err := validateAgentUpdateClears(plan, state, config, structuralScope); err != nil {

--- a/internal/provider/resource_agent_test.go
+++ b/internal/provider/resource_agent_test.go
@@ -326,7 +326,7 @@ func TestBuildAgentRequest_Full(t *testing.T) {
 			Description:                       types.StringValue("A fully configured agent"),
 			URL:                               types.StringValue("https://agent.example.com/a2a"),
 			Version:                           types.StringValue("1.0.0"),
-			ProtocolVersion:                   types.StringValue("0.2.6"),
+			ProtocolVersion:                   types.StringValue("0.3"),
 			DefaultInputModes:                 stringListValue("application/json"),
 			DefaultOutputModes:                stringListValue("application/json", "text/plain"),
 			PreferredTransport:                types.StringValue("httpsse"),
@@ -383,8 +383,8 @@ func TestBuildAgentRequest_Full(t *testing.T) {
 	if !ok {
 		t.Fatal("expected agent_card_params map")
 	}
-	if card["protocolVersion"] != "0.2.6" {
-		t.Errorf("expected protocolVersion '0.2.6', got %v", card["protocolVersion"])
+	if card["protocolVersion"] != "0.3" {
+		t.Errorf("expected protocolVersion '0.3', got %v", card["protocolVersion"])
 	}
 	if card["preferredTransport"] != "httpsse" {
 		t.Errorf("expected preferredTransport 'httpsse', got %v", card["preferredTransport"])
@@ -451,7 +451,7 @@ func TestReadAgent_PopulatesState(t *testing.T) {
 				"description":                       "A helpful agent",
 				"url":                               "https://agent.example.com",
 				"version":                           "1.0.0",
-				"protocolVersion":                   "0.2.6",
+				"protocolVersion":                   "1.0",
 				"supportsAuthenticatedExtendedCard": true,
 				"capabilities": map[string]interface{}{
 					"streaming":         true,
@@ -553,8 +553,8 @@ func TestReadAgent_PopulatesState(t *testing.T) {
 	if data.AgentCard.Description.ValueString() != "A helpful agent" {
 		t.Errorf("expected card description 'A helpful agent', got %q", data.AgentCard.Description.ValueString())
 	}
-	if data.AgentCard.ProtocolVersion.ValueString() != "0.2.6" {
-		t.Errorf("expected protocolVersion '0.2.6', got %q", data.AgentCard.ProtocolVersion.ValueString())
+	if data.AgentCard.ProtocolVersion.ValueString() != "1.0" {
+		t.Errorf("expected protocolVersion '1.0', got %q", data.AgentCard.ProtocolVersion.ValueString())
 	}
 	if !data.AgentCard.SupportsAuthenticatedExtendedCard.ValueBool() {
 		t.Error("expected supportsAuthenticatedExtendedCard true")

--- a/internal_testing/acceptance.sh
+++ b/internal_testing/acceptance.sh
@@ -76,7 +76,7 @@ run_agent_lifecycle_case() {
 # Explicit coverage table. litellm_project is enterprise-only and intentionally
 # excluded; every other registered resource has a lifecycle case here.
 run_case access_group resources model_access_group.tf,access_group_minimal.tf
-run_case agent resources mcp_server_minimal.tf,agent_minimal.tf,agent_bedrock_agentcore.tf,agent_mcp_tool_permissions.tf datasources agent.tf,agents_list.tf
+run_case agent resources mcp_server_minimal.tf,agent_minimal.tf,agent_bedrock_agentcore.tf,agent_mcp_tool_permissions.tf,agent_structured_advanced.tf datasources agent.tf,agents_list.tf,agent_structured_parity.tf
 run_agent_lifecycle_case
 run_case budget resources budget_minimal.tf datasources budget.tf,budgets_list.tf
 run_case credential_values resources credential_minimal.tf,credential_full.tf datasources credential_minimal.tf,credential_full.tf

--- a/internal_testing/datasources/agent_structured_parity.tf
+++ b/internal_testing/datasources/agent_structured_parity.tf
@@ -1,0 +1,39 @@
+data "litellm_agent" "structured_advanced" {
+  id = litellm_agent.structured_advanced.id
+}
+
+output "ds_agent_structured_projection" {
+  value = {
+    card        = data.litellm_agent.structured_advanced.agent_card_params_json
+    params      = data.litellm_agent.structured_advanced.litellm_params_json
+    permissions = data.litellm_agent.structured_advanced.object_permission_json
+  }
+  sensitive = true
+}
+
+locals {
+  agent_structured_list_projection = one([
+    for agent in data.litellm_agents.all.agents : {
+      card        = agent.agent_card_params_json
+      params      = agent.litellm_params_json
+      permissions = agent.object_permission_json
+    } if agent.agent_id == litellm_agent.structured_advanced.id
+  ])
+  agent_structured_single_projection = {
+    card        = data.litellm_agent.structured_advanced.agent_card_params_json
+    params      = data.litellm_agent.structured_advanced.litellm_params_json
+    permissions = data.litellm_agent.structured_advanced.object_permission_json
+  }
+}
+
+check "agent_structured_single_list_parity" {
+  assert {
+    condition     = nonsensitive(local.agent_structured_single_projection == local.agent_structured_list_projection)
+    error_message = "Single-agent and list-agent structured projections must be identical for the target agent."
+  }
+}
+
+output "ds_agents_structured_parity" {
+  value     = local.agent_structured_list_projection
+  sensitive = true
+}

--- a/internal_testing/datasources/agents_list.tf
+++ b/internal_testing/datasources/agents_list.tf
@@ -1,9 +1,15 @@
 # data.litellm_agents - Lists all agents
 
 data "litellm_agents" "all" {
-  depends_on = [litellm_agent.minimal]
+  depends_on = [
+    litellm_agent.minimal,
+    litellm_agent.bedrock_agentcore,
+    litellm_agent.mcp_tool_permissions,
+    litellm_agent.structured_advanced,
+  ]
 }
 
 output "ds_agents_list" {
-  value = data.litellm_agents.all
+  value     = data.litellm_agents.all
+  sensitive = true
 }

--- a/internal_testing/resources/agent_lifecycle_clear.tf
+++ b/internal_testing/resources/agent_lifecycle_clear.tf
@@ -4,13 +4,14 @@ variable "agent_lifecycle_phase" {
   default     = "set"
 
   validation {
-    condition     = contains(["set", "cleared"], var.agent_lifecycle_phase)
-    error_message = "agent_lifecycle_phase must be set or cleared."
+    condition     = contains(["set", "cleared", "adversarial"], var.agent_lifecycle_phase)
+    error_message = "agent_lifecycle_phase must be set, cleared, or adversarial."
   }
 }
 
 locals {
-  agent_lifecycle_cleared = var.agent_lifecycle_phase == "cleared"
+  agent_lifecycle_cleared     = var.agent_lifecycle_phase != "set"
+  agent_lifecycle_adversarial = var.agent_lifecycle_phase == "adversarial"
 }
 
 resource "litellm_agent" "lifecycle" {
@@ -23,7 +24,7 @@ resource "litellm_agent" "lifecycle" {
   # v1.98 cannot clear the complete parameter object, but it can replace a
   # nonempty object and thereby remove individual keys.
   litellm_params = local.agent_lifecycle_cleared ? {
-    model = "openai/gpt-4o-mini"
+    model = local.agent_lifecycle_adversarial ? "openai/gpt-4o-mini-adversarial" : "openai/gpt-4o-mini"
     } : {
     model     = "openai/gpt-4o-mini"
     qualifier = "acceptance"
@@ -36,7 +37,7 @@ resource "litellm_agent" "lifecycle" {
 
   agent_card {
     name                 = "Smoke Agent Lifecycle"
-    description          = local.agent_lifecycle_cleared ? null : "set then clear"
+    description          = local.agent_lifecycle_adversarial ? "adversarial unrelated card update" : (local.agent_lifecycle_cleared ? null : "set then clear")
     url                  = "https://agent.example.com/lifecycle"
     version              = "1.0.0"
     protocol_version     = "1.0"
@@ -69,6 +70,18 @@ resource "litellm_agent" "lifecycle" {
       examples     = local.agent_lifecycle_cleared ? [] : ["test"]
       input_modes  = local.agent_lifecycle_cleared ? [] : ["text"]
       output_modes = local.agent_lifecycle_cleared ? [] : ["text"]
+      security = local.agent_lifecycle_cleared ? [] : [
+        { oauth2 = ["read", "read"] },
+      ]
+    }
+
+    dynamic "signatures" {
+      for_each = local.agent_lifecycle_cleared ? [] : [1, 1]
+      content {
+        protected = "acceptance-protected"
+        signature = "acceptance-signature"
+        header    = jsonencode({ duplicate = signatures.key, exact = 9007199254740993 })
+      }
     }
   }
 

--- a/internal_testing/resources/agent_structured_advanced.tf
+++ b/internal_testing/resources/agent_structured_advanced.tf
@@ -1,0 +1,94 @@
+# Pinned-v1.98 disposable structured Agent lifecycle fixture. All names and
+# targets are acceptance-only placeholders; this never imports or mutates a
+# pre-existing development object.
+resource "litellm_agent" "structured_advanced" {
+  agent_name = "smoke-agent-structured-advanced"
+
+  litellm_params = {
+    model               = "bedrock/agentcore/arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/smoke-structured"
+    custom_llm_provider = "bedrock"
+    scalar_text         = "false"
+    leading_text        = "001"
+    json_looking_text   = "{\"still\":\"text\"}"
+  }
+  litellm_params_json = jsonencode({
+    enabled      = false
+    exact_large  = 9007199254740993
+    explicit_nil = null
+    empty_list   = []
+    empty_object = {}
+    nested = {
+      routing = [
+        { region = "us-east-1", weight = 1 },
+        { region = "us-west-2", weight = 0.25 },
+      ]
+    }
+  })
+
+  agent_card {
+    name             = "Smoke Structured Advanced"
+    url              = ""
+    version          = "1.0.0"
+    protocol_version = "1.0"
+
+    capabilities { streaming = true }
+
+    provider {
+      organization = "Acceptance"
+      url          = "https://agent.example.invalid"
+    }
+
+    skills {
+      id          = "structured"
+      name        = "Structured"
+      description = "Exercises ordered security requirements"
+      tags        = ["acceptance", "structured"]
+      security = [
+        { oauth2 = ["read", "write", "write"] },
+        { api_key = [] },
+        { oauth2 = ["read", "write", "write"] },
+      ]
+    }
+
+    skills {
+      id            = "structured-null-security"
+      name          = "Structured Null Security"
+      security_json = jsonencode(null)
+    }
+
+    skills {
+      id   = "structured-omitted-security"
+      name = "Structured Omitted Security"
+    }
+
+    signatures {
+      protected = "acceptance-protected"
+      signature = "acceptance-signature"
+      header = jsonencode({
+        kid    = "acceptance-key"
+        exact  = 9007199254740993
+        nested = { empty = [] }
+      })
+    }
+    signatures {
+      protected   = "acceptance-protected-null"
+      signature   = "acceptance-signature"
+      header_json = jsonencode(null)
+    }
+    signatures {
+      protected = "acceptance-protected-omitted"
+      signature = "acceptance-signature"
+    }
+  }
+
+  object_permission {
+    mcp_servers = []
+    mcp_tool_permissions = {
+      "acceptance-server" = jsonencode(["tool-a", "tool-a"])
+    }
+  }
+}
+
+output "agent_structured_advanced_id" {
+  value = litellm_agent.structured_advanced.id
+}

--- a/internal_testing/smoke.sh
+++ b/internal_testing/smoke.sh
@@ -207,18 +207,24 @@ elif [ "${SMOKE_MCP_IMPORT:-}" = "1" ]; then
   STEADY_ARGS='-var=mcp_import_phase=imported'
   CLEANUP_ARGS=$STEADY_ARGS
   for refresh_number in 1 2; do
-    echo "=== MCP IMPORT REFRESH-ONLY $refresh_number ==="
+    echo "=== MCP IMPORT REFRESH-ONLY APPLY $refresh_number ==="
     set +e
+    # Persist provider-private provenance from each authoritative refresh; a
+    # plan-only refresh discards the updated private state before stability is
+    # checked by the next process.
     # shellcheck disable=SC2086 # STEADY_ARGS is one complete optional argument.
-    terraform plan -refresh-only -detailed-exitcode $STEADY_ARGS >"mcp-import-refresh-$refresh_number.log" 2>&1
+    terraform apply -refresh-only -auto-approve $STEADY_ARGS >"mcp-import-refresh-$refresh_number.log" 2>&1
     refresh_status=$?
     set -e
     cat "mcp-import-refresh-$refresh_number.log"
     if [ "$refresh_status" -ne 0 ]; then
-      echo "MCP import refresh-only $refresh_number was not immediately stable (exit $refresh_status)." >&3
+      echo "MCP import refresh-only apply $refresh_number was not immediately stable (exit $refresh_status)." >&3
       exit 1
     fi
   done
+  echo '=== MCP IMPORT CONFIG OWNERSHIP CONVERGENCE APPLY ==='
+  # shellcheck disable=SC2086 # STEADY_ARGS is one complete optional argument.
+  terraform apply -auto-approve $STEADY_ARGS
   rm -f "$IMPORT_BACKUP"
   IMPORT_BACKUP=
 elif [ "${SMOKE_CREDENTIAL_UPDATE:-}" = "1" ]; then
@@ -254,23 +260,68 @@ skill = skills["acceptance"]
 for field in ("tags", "examples", "inputModes", "outputModes"):
     assert skill.get(field) in ([], None), (field, skill.get(field))
 PY
-  echo '=== AGENT DIRECT API-OWNED SIBLING SEED ==='
+  echo '=== AGENT DIRECT API-OWNED NULL/OMISSION/EXACT-NUMBER SEED ==='
+  curl --fail --silent --show-error -H 'Authorization: Bearer sk-testing-key' "http://localhost:4000/v1/agents/$agent_lifecycle_id" >agent-before-adversarial.json
+  python3 - agent-before-adversarial.json agent-adversarial-patch.json <<'PY'
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as stream:
+    value = json.load(stream)
+card = value["agent_card_params"]
+card["signatures"] = [
+    {"protected": "api-null", "signature": "api", "header": None},
+    {"protected": "api-omitted", "signature": "api"},
+]
+skills = [skill for skill in card.get("skills", []) if skill.get("id") not in {"api-null", "api-omitted"}]
+skills.extend([
+    {"id": "api-null", "name": "API Null", "security": None},
+    {"id": "api-omitted", "name": "API Omitted"},
+])
+card["skills"] = skills
+patch = {
+    "litellm_params": {
+        "model": "openai/gpt-4o-mini",
+        "api_owned_large": 9007199254740993,
+        "api_owned_null": None,
+        "api_owned_nested": {"present": None, "exact": 9007199254740993},
+    },
+    "static_headers": {"X-API-Owned": "preserve"},
+    "agent_card_params": card,
+}
+with open(sys.argv[2], "w", encoding="utf-8") as stream:
+    json.dump(patch, stream, separators=(",", ":"))
+PY
   curl --fail --silent --show-error -X PATCH \
     -H 'Authorization: Bearer sk-testing-key' -H 'Content-Type: application/json' \
-    --data '{"litellm_params":{"model":"openai/gpt-4o-mini","api_owned":"preserve"},"static_headers":{"X-API-Owned":"preserve"}}' \
+    --data-binary @agent-adversarial-patch.json \
     "http://localhost:4000/v1/agents/$agent_lifecycle_id" >/dev/null
   echo '=== AGENT CLEARED IMPORT/OWNERSHIP APPLY ==='
   terraform state rm litellm_agent.lifecycle
   terraform import -var=agent_lifecycle_phase=cleared litellm_agent.lifecycle "$agent_lifecycle_id"
   terraform apply -auto-approve -var=agent_lifecycle_phase=cleared
+  echo '=== AGENT UNRELATED LEGACY/CARD UPDATE OVER AUTHORITATIVE BASE ==='
+  terraform apply -auto-approve -var=agent_lifecycle_phase=adversarial
   curl --fail --silent --show-error -H 'Authorization: Bearer sk-testing-key' "http://localhost:4000/v1/agents/$agent_lifecycle_id" >agent-imported.json
   python3 - agent-imported.json <<'PY'
 import json, sys
-value = json.load(open(sys.argv[1], encoding="utf-8"))
-assert value.get("litellm_params", {}).get("api_owned") == "preserve"
+value = json.load(open(sys.argv[1], encoding="utf-8"), parse_int=int)
+params = value.get("litellm_params", {})
+assert params.get("model") == "openai/gpt-4o-mini-adversarial"
+assert params.get("api_owned_large") == 9007199254740993
+assert "api_owned_null" in params and params["api_owned_null"] is None
+assert params.get("api_owned_nested") == {"present": None, "exact": 9007199254740993}
 assert value.get("static_headers", {}).get("X-API-Owned") == "preserve"
+card = value.get("agent_card_params", {})
+assert card.get("description") == "adversarial unrelated card update"
+signatures = card.get("signatures", [])
+assert signatures == [
+    {"protected": "api-null", "signature": "api", "header": None},
+    {"protected": "api-omitted", "signature": "api"},
+]
+skills = {skill["id"]: skill for skill in card.get("skills", [])}
+assert "security" in skills["api-null"] and skills["api-null"]["security"] is None
+assert "security" not in skills["api-omitted"]
 PY
-  STEADY_ARGS='-var=agent_lifecycle_phase=cleared'
+  STEADY_ARGS='-var=agent_lifecycle_phase=adversarial'
   CLEANUP_ARGS=$STEADY_ARGS
 fi
 


### PR DESCRIPTION
### Summary

Related to #199. Agent resources now preserve LiteLLM v1.98 structured parameters, card signatures, skill security, and unknown API-owned structured values without changing the legacy `litellm_params` type.

The additive sensitive JSON bridge and exact leaf ownership model keep imports and existing HCL compatible, make single/list data sources consistent, and ensure failed or unconfirmed mutations cannot transfer ownership during refresh. AgentCore pairing and existing permission behavior remain unchanged.

### Validation

Validated with focused protocol coverage for import, masking, structured updates, clears, failed confirmation, repeated refresh, retry, and malformed provenance; the full and race suites, contract gates, and disposable LiteLLM v1.98 Agent lifecycles also passed.

### Checklist

- [x] Tests cover the changed behavior.
- [x] Documentation reflects the additive Agent fields and compatibility contract.
- [x] Existing schemas, IDs, imports, and legacy HCL remain compatible.
- [x] No credentials or live environment data are included.

### Diff size

**Docs** — 3 files · `+48 / -9`

Documents the structured JSON bridge, card security fields, and data-source parity.

**Implementation** — 9 files · `+2364 / -478`

Implements lossless wire overlays, exact leaf ownership/provenance, strict structured projection, lifecycle recovery, and regenerated API-contract metadata. The size is driven by preserving arbitrary nested v1.98 documents without weakening existing compatibility boundaries.

**Tests** — 10 files · `+1095 / -24`

Adds protocol and unit regressions plus disposable acceptance fixtures for structured parity, clears, imports, failure recovery, and pending-ownership retention.
