### PR TITLE
fix(agent): preserve safe hidden block collections

### DIFF
--- a/internal/contract/manifest.json
+++ b/internal/contract/manifest.json
@@ -16,7 +16,7 @@
   "provider_golden": {
     "operation_count": 108,
     "path": "internal/contractapi/testdata/provider-operations.golden.json",
-    "sha256": "da2a2c5dc5bbf20450280c9abcd8dab407a767b405ee6856ab0dd23f2856eade"
+    "sha256": "32f2b0f6f5b8a0b3575ddbd5780d54040c71e25e43d798178ad216ef557dc960"
   },
   "provider_operations": [
     {
@@ -1537,7 +1537,7 @@
       "evidence": [
         {
           "file": "internal/provider/resource_agent.go",
-          "line": 408
+          "line": 407
         }
       ],
       "method": "POST",

--- a/internal/contract/reviewed-pins.json
+++ b/internal/contract/reviewed-pins.json
@@ -9,7 +9,7 @@
     },
     "manifest": {
       "path": "internal/contract/manifest.json",
-      "sha256": "f44de55ad30de67674682b5ed4cf65b91262ec36892574fed3d41e91c467b7a7"
+      "sha256": "4754f30c0e618e754cc99135c2563610b9c2d38cef6179a10f76c5a243327d61"
     },
     "openapi": {
       "operation_count": 800,
@@ -20,7 +20,7 @@
     "provider_golden": {
       "operation_count": 108,
       "path": "internal/contractapi/testdata/provider-operations.golden.json",
-      "sha256": "da2a2c5dc5bbf20450280c9abcd8dab407a767b405ee6856ab0dd23f2856eade"
+      "sha256": "32f2b0f6f5b8a0b3575ddbd5780d54040c71e25e43d798178ad216ef557dc960"
     },
     "supplemental": {
       "operation_count": 1,

--- a/internal/contractapi/testdata/provider-operations.golden.json
+++ b/internal/contractapi/testdata/provider-operations.golden.json
@@ -1521,7 +1521,7 @@
     "evidence": [
       {
         "file": "internal/provider/resource_agent.go",
-        "line": 408
+        "line": 407
       }
     ]
   },

--- a/internal/provider/agent_block_schema_compatibility_test.go
+++ b/internal/provider/agent_block_schema_compatibility_test.go
@@ -1,0 +1,100 @@
+package provider
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+)
+
+type agentSchemaCompatibilityGolden struct {
+	Version              int64    `json:"version"`
+	AgentCardNesting     string   `json:"agent_card_nesting"`
+	SkillsNesting        string   `json:"skills_nesting"`
+	SignaturesNesting    string   `json:"signatures_nesting"`
+	SkillsAttributes     []string `json:"skills_attributes"`
+	SignaturesAttributes []string `json:"signatures_attributes"`
+}
+
+func findAgentNestedBlock(t *testing.T, block *tfprotov6.SchemaBlock, name string) *tfprotov6.SchemaNestedBlock {
+	t.Helper()
+	for _, nested := range block.BlockTypes {
+		if nested.TypeName == name {
+			return nested
+		}
+	}
+	t.Fatalf("nested block %q missing", name)
+	return nil
+}
+
+func TestAgentSchemaMatchesOriginIssuesBlockGolden(t *testing.T) {
+	server := providerserver.NewProtocol6(New("test")())()
+	response, err := server.GetProviderSchema(context.Background(), &tfprotov6.GetProviderSchemaRequest{})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(response.Diagnostics) {
+		t.Fatalf("schema: err=%v diagnostics=%v", err, response.Diagnostics)
+	}
+	resourceSchema := response.ResourceSchemas["litellm_agent"]
+	agentCard := findAgentNestedBlock(t, resourceSchema.Block, "agent_card")
+	skills := findAgentNestedBlock(t, agentCard.Block, "skills")
+	signatures := findAgentNestedBlock(t, agentCard.Block, "signatures")
+	for _, attribute := range agentCard.Block.Attributes {
+		if attribute.Name == "skills" || attribute.Name == "signatures" {
+			t.Fatalf("%s was converted from block_types to assignment attribute", attribute.Name)
+		}
+	}
+	attributeNames := func(block *tfprotov6.SchemaBlock) []string {
+		result := make([]string, 0, len(block.Attributes))
+		for _, attribute := range block.Attributes {
+			result = append(result, attribute.Name)
+		}
+		sort.Strings(result)
+		return result
+	}
+	actual := agentSchemaCompatibilityGolden{
+		Version: resourceSchema.Version, AgentCardNesting: agentCard.Nesting.String(),
+		SkillsNesting: skills.Nesting.String(), SignaturesNesting: signatures.Nesting.String(),
+		SkillsAttributes: attributeNames(skills.Block), SignaturesAttributes: attributeNames(signatures.Block),
+	}
+	actualJSON, err := json.MarshalIndent(actual, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	actualJSON = append(actualJSON, '\n')
+	golden, err := os.ReadFile(filepath.Join("testdata", "agent-schema-origin-issues.golden.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(actualJSON, golden) {
+		t.Fatalf("agent protocol schema differs from origin/issues golden:\n%s", actualJSON)
+	}
+}
+
+func TestExistingAgentFixturesUseValidBlockGrammar(t *testing.T) {
+	fixtures := []string{
+		filepath.Join("..", "..", "internal_testing", "resources", "agent_lifecycle_clear.tf"),
+		filepath.Join("..", "..", "internal_testing", "resources", "agent_structured_advanced.tf"),
+	}
+	assignment := regexp.MustCompile(`(?m)^\s*(skills|signatures)\s*=`)
+	for _, fixture := range fixtures {
+		source, err := os.ReadFile(fixture)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if assignment.Match(source) {
+			t.Fatalf("%s uses incompatible collection assignment syntax", fixture)
+		}
+		_, diagnostics := hclsyntax.ParseConfig(source, fixture, hcl.Pos{Line: 1, Column: 1})
+		if diagnostics.HasErrors() {
+			t.Fatalf("%s does not parse as existing block HCL: %s", fixture, diagnostics.Error())
+		}
+	}
+}

--- a/internal/provider/agent_clear_overlay_protocol_test.go
+++ b/internal/provider/agent_clear_overlay_protocol_test.go
@@ -1,0 +1,642 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+const agentClearProtocolID = "agent-clear"
+
+type agentClearOverlayProtocolAPI struct {
+	mu          sync.Mutex
+	serverURL   string
+	created     bool
+	cleared     bool
+	adversarial string
+	requests    atomic.Int64
+	posts       atomic.Int64
+	patches     atomic.Int64
+	badMutation atomic.Bool
+}
+
+func agentClearProtocolSecuritySchemes() map[string]interface{} {
+	return map[string]interface{}{
+		"LiteLLMKey": map[string]interface{}{
+			"type": "http", "scheme": "bearer", "description": "LiteLLM virtual key",
+		},
+	}
+}
+
+func agentClearProtocolSupportedInterfaces(serverURL string) []interface{} {
+	return []interface{}{map[string]interface{}{
+		"url": serverURL + "/a2a/" + agentClearProtocolID, "protocolBinding": "JSONRPC", "protocolVersion": "1.0",
+	}}
+}
+
+func agentClearProtocolSetCard(serverURL string) map[string]interface{} {
+	return map[string]interface{}{
+		"name": "Smoke Agent Lifecycle", "description": "set then clear", "url": "https://agent.example.com/lifecycle",
+		"version": "1.0.0", "protocolVersion": "1.0",
+		"defaultInputModes": []interface{}{"text"}, "defaultOutputModes": []interface{}{"text"},
+		"preferredTransport": "JSONRPC", "iconUrl": "https://agent.example.com/icon.png", "documentationUrl": "https://agent.example.com/docs",
+		"supportsAuthenticatedExtendedCard": true,
+		"capabilities":                      map[string]interface{}{"streaming": true},
+		"provider":                          map[string]interface{}{"organization": "Acceptance", "url": "https://agent.example.com"},
+		"skills": []interface{}{map[string]interface{}{
+			"id": "acceptance", "name": "Acceptance", "description": "set then clear",
+			"tags": []interface{}{"lifecycle"}, "examples": []interface{}{"test"}, "inputModes": []interface{}{"text"}, "outputModes": []interface{}{"text"},
+			"security": []interface{}{map[string]interface{}{"oauth2": []interface{}{"read", "read"}}},
+		}},
+		"signatures": []interface{}{
+			map[string]interface{}{"protected": "acceptance-protected", "signature": "acceptance-signature", "header": map[string]interface{}{"duplicate": json.Number("0"), "exact": json.Number("9007199254740993")}},
+			map[string]interface{}{"protected": "acceptance-protected", "signature": "acceptance-signature", "header": map[string]interface{}{"duplicate": json.Number("1"), "exact": json.Number("9007199254740993")}},
+		},
+		"security":            []interface{}{map[string]interface{}{"LiteLLMKey": []interface{}{}}},
+		"securitySchemes":     agentClearProtocolSecuritySchemes(),
+		"supportedInterfaces": agentClearProtocolSupportedInterfaces(serverURL),
+	}
+}
+
+func agentClearProtocolClearedCard(serverURL string) map[string]interface{} {
+	return map[string]interface{}{
+		"name": "Smoke Agent Lifecycle", "url": "https://agent.example.com/lifecycle", "version": "1.0.0", "protocolVersion": "1.0",
+		"defaultInputModes": []interface{}{"text"}, "defaultOutputModes": []interface{}{"text"},
+		"supportsAuthenticatedExtendedCard": false,
+		// v1.98's merge always materializes the capabilities parent while filtering
+		// every configured false leaf from it.
+		"capabilities": map[string]interface{}{},
+		"provider":     map[string]interface{}{"url": "https://agent.example.com"},
+		"skills": []interface{}{map[string]interface{}{
+			"id": "acceptance", "name": "Acceptance", "tags": []interface{}{}, "examples": []interface{}{},
+			"inputModes": []interface{}{}, "outputModes": []interface{}{}, "security": []interface{}{},
+		}},
+		// The fixture's empty dynamic signatures block is represented by omission
+		// on the complete-card PATCH; v1.98 preserves that omission on read-back.
+		"security":            []interface{}{map[string]interface{}{"LiteLLMKey": []interface{}{}}},
+		"securitySchemes":     agentClearProtocolSecuritySchemes(),
+		"supportedInterfaces": agentClearProtocolSupportedInterfaces(serverURL),
+	}
+}
+
+func agentClearProtocolObjectPermission(cleared bool) map[string]interface{} {
+	permission := map[string]interface{}{
+		"object_permission_id": "permission-clear", "vector_stores": []interface{}{}, "agent_access_groups": []interface{}{},
+		"blocked_tools": []interface{}{}, "mcp_toolsets": []interface{}{}, "search_tools": []interface{}{}, "mcp_tool_search_enabled": nil,
+		"teams": nil, "projects": nil, "verification_tokens": nil, "organizations": nil, "users": nil, "end_users": nil, "agents_table": nil,
+	}
+	if cleared {
+		permission["mcp_servers"] = []interface{}{}
+		permission["mcp_access_groups"] = []interface{}{}
+		permission["mcp_tool_permissions"] = map[string]interface{}{}
+		permission["models"] = []interface{}{}
+		permission["agents"] = []interface{}{}
+	} else {
+		permission["mcp_servers"] = []interface{}{"acceptance-server"}
+		permission["mcp_access_groups"] = []interface{}{"acceptance-group"}
+		permission["mcp_tool_permissions"] = map[string]interface{}{"acceptance-server": []interface{}{"acceptance-tool"}}
+		permission["models"] = []interface{}{"openai/gpt-4o-mini"}
+		permission["agents"] = []interface{}{"acceptance-agent"}
+	}
+	return permission
+}
+
+func agentClearProtocolResponse(serverURL string, cleared bool, adversarial string) map[string]interface{} {
+	card := agentClearProtocolSetCard(serverURL)
+	params := map[string]interface{}{"model": "openai/gpt-4o-mini", "qualifier": "acceptance"}
+	staticHeaders := map[string]interface{}{"X-Agent-Acceptance": "set"}
+	extraHeaders := []interface{}{"X-Agent-Acceptance"}
+	if cleared {
+		card = agentClearProtocolClearedCard(serverURL)
+		params = map[string]interface{}{"model": "openai/gpt-4o-mini"}
+		staticHeaders = map[string]interface{}{}
+		extraHeaders = []interface{}{}
+	}
+	switch adversarial {
+	case "top-level":
+		card["x-adversarial"] = map[string]interface{}{"must": "not mutate"}
+	case "nested-capability":
+		card["capabilities"].(map[string]interface{})["x-adversarial"] = map[string]interface{}{"must": "not mutate"}
+	}
+	response := map[string]interface{}{
+		"agent_id": agentClearProtocolID, "agent_name": "smoke-agent-lifecycle",
+		"litellm_params": params, "agent_card_params": card, "object_permission": agentClearProtocolObjectPermission(cleared),
+		"static_headers": staticHeaders, "extra_headers": extraHeaders,
+		"spend": json.Number("0.0"), "keys": nil,
+		"created_at": "2026-08-26T10:08:47.128000Z", "updated_at": "2026-08-26T10:08:47.128000Z",
+		"created_by": "default_user_id", "updated_by": "default_user_id",
+	}
+	for _, field := range []string{"tpm_limit", "rpm_limit", "session_tpm_limit", "session_rpm_limit"} {
+		response[field] = nil
+	}
+	if !cleared {
+		response["tpm_limit"] = json.Number("1200")
+		response["rpm_limit"] = json.Number("120")
+		response["session_tpm_limit"] = json.Number("600")
+		response["session_rpm_limit"] = json.Number("60")
+	}
+	return response
+}
+
+func agentClearProtocolCreateRequest() map[string]interface{} {
+	return map[string]interface{}{
+		"agent_name": "smoke-agent-lifecycle", "tpm_limit": json.Number("1200"), "rpm_limit": json.Number("120"),
+		"session_tpm_limit": json.Number("600"), "session_rpm_limit": json.Number("60"),
+		"litellm_params": map[string]interface{}{"model": "openai/gpt-4o-mini", "qualifier": "acceptance"},
+		"static_headers": map[string]interface{}{"X-Agent-Acceptance": "set"}, "extra_headers": []interface{}{"X-Agent-Acceptance"},
+		"agent_card_params": map[string]interface{}{
+			"name": "Smoke Agent Lifecycle", "description": "set then clear", "url": "https://agent.example.com/lifecycle",
+			"version": "1.0.0", "protocolVersion": "1.0", "defaultInputModes": []interface{}{"text"}, "defaultOutputModes": []interface{}{"text"},
+			"preferredTransport": "JSONRPC", "iconUrl": "https://agent.example.com/icon.png", "documentationUrl": "https://agent.example.com/docs",
+			"supportsAuthenticatedExtendedCard": true,
+			"capabilities":                      map[string]interface{}{"streaming": true, "pushNotifications": false, "stateTransitionHistory": false},
+			"provider":                          map[string]interface{}{"organization": "Acceptance", "url": "https://agent.example.com"},
+			"skills": []interface{}{map[string]interface{}{
+				"id": "acceptance", "name": "Acceptance", "description": "set then clear", "tags": []interface{}{"lifecycle"}, "examples": []interface{}{"test"},
+				"inputModes": []interface{}{"text"}, "outputModes": []interface{}{"text"}, "security": []interface{}{map[string]interface{}{"oauth2": []interface{}{"read", "read"}}},
+			}},
+			"signatures": []interface{}{
+				map[string]interface{}{"protected": "acceptance-protected", "signature": "acceptance-signature", "header": map[string]interface{}{"duplicate": json.Number("0"), "exact": json.Number("9007199254740993")}},
+				map[string]interface{}{"protected": "acceptance-protected", "signature": "acceptance-signature", "header": map[string]interface{}{"duplicate": json.Number("1"), "exact": json.Number("9007199254740993")}},
+			},
+		},
+		"object_permission": map[string]interface{}{
+			"mcp_servers": []interface{}{"acceptance-server"}, "mcp_access_groups": []interface{}{"acceptance-group"},
+			"mcp_tool_permissions": map[string]interface{}{"acceptance-server": []interface{}{"acceptance-tool"}},
+			"models":               []interface{}{"openai/gpt-4o-mini"}, "agents": []interface{}{"acceptance-agent"},
+		},
+	}
+}
+
+func agentClearProtocolPatchRequest(serverURL string) map[string]interface{} {
+	card := agentClearProtocolClearedCard(serverURL)
+	// False capability leaves are clear intent in Terraform but v1.98 filters
+	// them. The complete-card PATCH must omit the parent rather than sending an
+	// empty or false-bearing object; GET canonicalization rematerializes {}.
+	delete(card, "capabilities")
+	return map[string]interface{}{
+		"agent_name": "smoke-agent-lifecycle",
+		"tpm_limit":  nil, "rpm_limit": nil, "session_tpm_limit": nil, "session_rpm_limit": nil,
+		"litellm_params": map[string]interface{}{"model": "openai/gpt-4o-mini"},
+		"static_headers": map[string]interface{}{}, "extra_headers": []interface{}{},
+		"agent_card_params": card,
+		"object_permission": map[string]interface{}{
+			"mcp_servers": []interface{}{}, "mcp_access_groups": []interface{}{}, "mcp_tool_permissions": map[string]interface{}{},
+			"models": []interface{}{}, "agents": []interface{}{},
+		},
+	}
+}
+
+func agentClearProtocolExactShape(got, want map[string]interface{}) error {
+	if !reflect.DeepEqual(got, want) {
+		return fmt.Errorf("wire object did not match the exact v1.98 shape")
+	}
+	return nil
+}
+
+func agentClearProtocolCanonicalResponseShape(got, want map[string]interface{}) error {
+	if err := agentClearProtocolExactShape(got, want); err != nil {
+		return err
+	}
+	card := got["agent_card_params"].(map[string]interface{})
+	capabilities, present := card["capabilities"].(map[string]interface{})
+	if !present || len(capabilities) != 0 {
+		return fmt.Errorf("canonical response did not materialize an empty capabilities parent")
+	}
+	return nil
+}
+
+func (a *agentClearOverlayProtocolAPI) response() map[string]interface{} {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return agentClearProtocolResponse(a.serverURL, a.cleared, a.adversarial)
+}
+
+func (a *agentClearOverlayProtocolAPI) setAdversarial(value string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.adversarial = value
+}
+
+func (a *agentClearOverlayProtocolAPI) handler(w http.ResponseWriter, r *http.Request) {
+	a.requests.Add(1)
+	w.Header().Set("Content-Type", "application/json")
+	decode := func() (map[string]interface{}, bool) {
+		var request map[string]interface{}
+		decoder := json.NewDecoder(r.Body)
+		decoder.UseNumber()
+		if err := decoder.Decode(&request); err != nil {
+			a.badMutation.Store(true)
+			http.Error(w, `{}`, http.StatusBadRequest)
+			return nil, false
+		}
+		return request, true
+	}
+	switch {
+	case r.Method == http.MethodPost && r.URL.Path == "/v1/agents":
+		a.posts.Add(1)
+		request, ok := decode()
+		if !ok {
+			return
+		}
+		if err := agentClearProtocolExactShape(request, agentClearProtocolCreateRequest()); err != nil {
+			a.badMutation.Store(true)
+			http.Error(w, `{}`, http.StatusBadRequest)
+			return
+		}
+		a.mu.Lock()
+		a.created = true
+		a.mu.Unlock()
+		_ = json.NewEncoder(w).Encode(a.response())
+	case r.Method == http.MethodGet && r.URL.Path == "/v1/agents/"+agentClearProtocolID:
+		a.mu.Lock()
+		created := a.created
+		cleared := a.cleared
+		adversarial := a.adversarial
+		a.mu.Unlock()
+		if !created {
+			http.NotFound(w, r)
+			return
+		}
+		response := agentClearProtocolResponse(a.serverURL, cleared, adversarial)
+		if cleared && adversarial == "" {
+			if err := agentClearProtocolCanonicalResponseShape(response, agentClearProtocolResponse(a.serverURL, true, "")); err != nil {
+				a.badMutation.Store(true)
+				http.Error(w, `{}`, http.StatusInternalServerError)
+				return
+			}
+		}
+		_ = json.NewEncoder(w).Encode(response)
+	case r.Method == http.MethodPatch && r.URL.Path == "/v1/agents/"+agentClearProtocolID:
+		a.patches.Add(1)
+		request, ok := decode()
+		if !ok {
+			return
+		}
+		if err := agentClearProtocolExactShape(request, agentClearProtocolPatchRequest(a.serverURL)); err != nil {
+			a.badMutation.Store(true)
+			http.Error(w, `{}`, http.StatusBadRequest)
+			return
+		}
+		a.mu.Lock()
+		a.cleared = true
+		a.mu.Unlock()
+		_ = json.NewEncoder(w).Encode(a.response())
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func agentClearOverlaySetConfig() map[string]interface{} {
+	return map[string]interface{}{
+		"agent_name": "smoke-agent-lifecycle", "tpm_limit": int64(1200), "rpm_limit": int64(120),
+		"session_tpm_limit": int64(600), "session_rpm_limit": int64(60),
+		"litellm_params": map[string]interface{}{"model": "openai/gpt-4o-mini", "qualifier": "acceptance"},
+		"static_headers": map[string]interface{}{"X-Agent-Acceptance": "set"}, "extra_headers": []interface{}{"X-Agent-Acceptance"},
+		"agent_card": map[string]interface{}{
+			"name": "Smoke Agent Lifecycle", "description": "set then clear", "url": "https://agent.example.com/lifecycle",
+			"version": "1.0.0", "protocol_version": "1.0", "default_input_modes": []interface{}{"text"}, "default_output_modes": []interface{}{"text"},
+			"preferred_transport": "JSONRPC", "icon_url": "https://agent.example.com/icon.png", "documentation_url": "https://agent.example.com/docs",
+			"supports_authenticated_extended_card": true,
+			"capabilities":                         map[string]interface{}{"streaming": true, "push_notifications": false, "state_transition_history": false},
+			"provider":                             map[string]interface{}{"organization": "Acceptance", "url": "https://agent.example.com"},
+			"skills": []interface{}{map[string]interface{}{
+				"id": "acceptance", "name": "Acceptance", "description": "set then clear", "tags": []interface{}{"lifecycle"}, "examples": []interface{}{"test"},
+				"input_modes": []interface{}{"text"}, "output_modes": []interface{}{"text"},
+				"security": []interface{}{map[string]interface{}{"oauth2": []interface{}{"read", "read"}}},
+			}},
+			"signatures": []interface{}{
+				map[string]interface{}{"protected": "acceptance-protected", "signature": "acceptance-signature", "header": `{"duplicate":0,"exact":9007199254740993}`},
+				map[string]interface{}{"protected": "acceptance-protected", "signature": "acceptance-signature", "header": `{"duplicate":1,"exact":9007199254740993}`},
+			},
+		},
+		"object_permission": map[string]interface{}{
+			"mcp_servers": []interface{}{"acceptance-server"}, "mcp_access_groups": []interface{}{"acceptance-group"},
+			"mcp_tool_permissions": map[string]interface{}{"acceptance-server": ` [ "acceptance-tool" ] `},
+			"models":               []interface{}{"openai/gpt-4o-mini"}, "agents": []interface{}{"acceptance-agent"},
+		},
+	}
+}
+
+func agentClearOverlayClearedConfig() map[string]interface{} {
+	return map[string]interface{}{
+		"agent_name":     "smoke-agent-lifecycle",
+		"litellm_params": map[string]interface{}{"model": "openai/gpt-4o-mini"},
+		"static_headers": map[string]interface{}{}, "extra_headers": []interface{}{},
+		"agent_card": map[string]interface{}{
+			"name": "Smoke Agent Lifecycle", "url": "https://agent.example.com/lifecycle", "version": "1.0.0", "protocol_version": "1.0",
+			"default_input_modes": []interface{}{"text"}, "default_output_modes": []interface{}{"text"}, "supports_authenticated_extended_card": false,
+			"capabilities": map[string]interface{}{"streaming": false, "push_notifications": false, "state_transition_history": false},
+			"provider":     map[string]interface{}{"url": "https://agent.example.com"},
+			"skills": []interface{}{map[string]interface{}{
+				"id": "acceptance", "name": "Acceptance", "tags": []interface{}{}, "examples": []interface{}{},
+				"input_modes": []interface{}{}, "output_modes": []interface{}{}, "security": []interface{}{},
+			}},
+			"signatures": []interface{}{},
+		},
+		"object_permission": map[string]interface{}{
+			"mcp_servers": []interface{}{}, "mcp_access_groups": []interface{}{}, "mcp_tool_permissions": map[string]interface{}{},
+			"models": []interface{}{}, "agents": []interface{}{},
+		},
+	}
+}
+
+func agentProtocolReplaceMany(t *testing.T, schema *tfprotov6.Schema, current *tfprotov6.DynamicValue, replacements map[string]interface{}) *tfprotov6.DynamicValue {
+	t.Helper()
+	value, err := current.Unmarshal(schema.ValueType())
+	if err != nil {
+		t.Fatal(err)
+	}
+	attributes := map[string]tftypes.Value{}
+	if err := value.As(&attributes); err != nil {
+		t.Fatal(err)
+	}
+	attributeTypes := schema.ValueType().(tftypes.Object).AttributeTypes
+	for name, replacement := range replacements {
+		attributes[name] = agentProtocolValue(t, attributeTypes[name], replacement)
+	}
+	return accessGroupProtocolDynamicValue(t, schema, tftypes.NewValue(schema.ValueType(), attributes))
+}
+
+type agentClearProtocolFixture struct {
+	ctx            context.Context
+	api            *agentClearOverlayProtocolAPI
+	server         tfprotov6.ProviderServer
+	schema         *tfprotov6.Schema
+	createdState   *tfprotov6.DynamicValue
+	createdPrivate []byte
+}
+
+func newAgentClearProtocolFixture(t *testing.T) agentClearProtocolFixture {
+	t.Helper()
+	ctx := context.Background()
+	api := &agentClearOverlayProtocolAPI{}
+	httpServer := httptest.NewServer(http.HandlerFunc(api.handler))
+	t.Cleanup(httpServer.Close)
+	api.serverURL = httpServer.URL
+	protocolServer, schemas := configuredImportProtocolServer(t, ctx, httpServer.URL)
+	schema := schemas.ResourceSchemas["litellm_agent"]
+	setValues := agentClearOverlaySetConfig()
+	config := agentProtocolDynamicValue(t, schema, setValues)
+	proposedValues := make(map[string]interface{}, len(setValues)+6)
+	for key, value := range setValues {
+		proposedValues[key] = value
+	}
+	proposedValues["id"] = tftypes.UnknownValue
+	proposedValues["litellm_params_json"] = tftypes.UnknownValue
+	for _, field := range []string{"created_at", "updated_at", "created_by", "updated_by"} {
+		proposedValues[field] = tftypes.UnknownValue
+	}
+	proposed := agentProtocolDynamicValue(t, schema, proposedValues)
+	nullState := accessGroupProtocolDynamicValue(t, schema, tftypes.NewValue(schema.ValueType(), nil))
+	planned, err := protocolServer.PlanResourceChange(ctx, &tfprotov6.PlanResourceChangeRequest{
+		TypeName: "litellm_agent", Config: config, PriorState: nullState, ProposedNewState: proposed,
+	})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(planned.Diagnostics) || organizationProjectProtocolPlannedAction(t, schema, nullState, planned) != organizationProjectProtocolActionCreate {
+		t.Fatalf("set create plan: err=%v diagnostics=%s", err, agentProtocolDiagnosticsText(planned.Diagnostics))
+	}
+	created, err := protocolServer.ApplyResourceChange(ctx, &tfprotov6.ApplyResourceChangeRequest{
+		TypeName: "litellm_agent", Config: config, PriorState: nullState, PlannedState: planned.PlannedState, PlannedPrivate: planned.PlannedPrivate,
+	})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(created.Diagnostics) || api.posts.Load() != 1 || api.patches.Load() != 0 || api.badMutation.Load() {
+		t.Fatalf("set create: err=%v diagnostics=%s posts=%d patches=%d bad=%t", err, agentProtocolDiagnosticsText(created.Diagnostics), api.posts.Load(), api.patches.Load(), api.badMutation.Load())
+	}
+	committed, decodeErr := decodeAgentFieldSet(protocolPrivateValue(t, created.Private, agentImportedFieldsPrivateKey))
+	if decodeErr != nil || len(committed) != 0 || string(protocolPrivateValue(t, created.Private, agentOwnershipInitializedPrivateKey)) != "true" || protocolPrivateHasKey(t, created.Private, agentOwnershipPendingPrivateKey) {
+		t.Fatalf("configured create ownership was not authoritative: committed=%#v err=%v private=%s", committed, decodeErr, created.Private)
+	}
+	return agentClearProtocolFixture{ctx: ctx, api: api, server: protocolServer, schema: schema, createdState: created.NewState, createdPrivate: created.Private}
+}
+
+func planAgentClearProtocolFixture(t *testing.T, fixture agentClearProtocolFixture) (*tfprotov6.DynamicValue, *tfprotov6.PlanResourceChangeResponse) {
+	t.Helper()
+	clearValues := agentClearOverlayClearedConfig()
+	config := agentProtocolDynamicValue(t, fixture.schema, clearValues)
+	proposed := agentProtocolReplaceMany(t, fixture.schema, fixture.createdState, map[string]interface{}{
+		"tpm_limit": nil, "rpm_limit": nil, "session_tpm_limit": nil, "session_rpm_limit": nil,
+		"litellm_params": clearValues["litellm_params"], "static_headers": clearValues["static_headers"], "extra_headers": clearValues["extra_headers"],
+		"agent_card": clearValues["agent_card"], "object_permission": clearValues["object_permission"],
+	})
+	planned, err := fixture.server.PlanResourceChange(fixture.ctx, &tfprotov6.PlanResourceChangeRequest{
+		TypeName: "litellm_agent", Config: config, PriorState: fixture.createdState, ProposedNewState: proposed, PriorPrivate: fixture.createdPrivate,
+	})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(planned.Diagnostics) || organizationProjectProtocolPlannedAction(t, fixture.schema, fixture.createdState, planned) != organizationProjectProtocolActionUpdate {
+		t.Fatalf("set-to-cleared plan: err=%v diagnostics=%s action=%s", err, agentProtocolDiagnosticsText(planned.Diagnostics), organizationProjectProtocolPlannedAction(t, fixture.schema, fixture.createdState, planned))
+	}
+	return config, planned
+}
+
+func assertAgentClearProtocolClearedState(t *testing.T, schema *tfprotov6.Schema, state *tfprotov6.DynamicValue) {
+	t.Helper()
+	attributes := protocolAttributeMap(t, schema, state)
+	for _, field := range []string{"tpm_limit", "rpm_limit", "session_tpm_limit", "session_rpm_limit"} {
+		if !attributes[field].IsNull() {
+			t.Fatalf("%s did not clear", field)
+		}
+	}
+	assertEmpty := func(field string, value tftypes.Value) {
+		t.Helper()
+		if value.IsNull() || value.IsKnown() == false {
+			t.Fatalf("%s clear is not a known empty collection", field)
+		}
+		switch value.Type().(type) {
+		case tftypes.Map:
+			var items map[string]tftypes.Value
+			if err := value.As(&items); err != nil || len(items) != 0 {
+				t.Fatalf("%s clear = %#v, err=%v", field, items, err)
+			}
+		default:
+			var items []tftypes.Value
+			if err := value.As(&items); err != nil || len(items) != 0 {
+				t.Fatalf("%s clear = %#v, err=%v", field, items, err)
+			}
+		}
+	}
+	var params map[string]tftypes.Value
+	if err := attributes["litellm_params"].As(&params); err != nil || len(params) != 1 {
+		t.Fatalf("litellm_params replacement = %#v, err=%v", params, err)
+	}
+	var model string
+	if err := params["model"].As(&model); err != nil || model != "openai/gpt-4o-mini" {
+		t.Fatalf("litellm_params.model = %q, err=%v", model, err)
+	}
+	assertEmpty("static_headers", attributes["static_headers"])
+	assertEmpty("extra_headers", attributes["extra_headers"])
+
+	var card map[string]tftypes.Value
+	if err := attributes["agent_card"].As(&card); err != nil {
+		t.Fatal(err)
+	}
+	for _, field := range []string{"description", "preferred_transport", "icon_url", "documentation_url"} {
+		if !card[field].IsNull() {
+			t.Fatalf("agent_card.%s did not clear", field)
+		}
+	}
+	var authenticated bool
+	if err := card["supports_authenticated_extended_card"].As(&authenticated); err != nil || authenticated {
+		t.Fatalf("authenticated extended card clear = %t, err=%v", authenticated, err)
+	}
+	var capabilities map[string]tftypes.Value
+	if err := card["capabilities"].As(&capabilities); err != nil {
+		t.Fatal(err)
+	}
+	for _, field := range []string{"streaming", "push_notifications", "state_transition_history"} {
+		var enabled bool
+		if err := capabilities[field].As(&enabled); err != nil || enabled {
+			t.Fatalf("capability %s clear = %t, err=%v", field, enabled, err)
+		}
+	}
+	var provider map[string]tftypes.Value
+	if err := card["provider"].As(&provider); err != nil || !provider["organization"].IsNull() {
+		t.Fatalf("provider organization clear = %#v, err=%v", provider, err)
+	}
+	var providerURL string
+	if err := provider["url"].As(&providerURL); err != nil || providerURL != "https://agent.example.com" {
+		t.Fatalf("provider URL = %q, err=%v", providerURL, err)
+	}
+	var skills []tftypes.Value
+	if err := card["skills"].As(&skills); err != nil || len(skills) != 1 {
+		t.Fatalf("skills = %#v, err=%v", skills, err)
+	}
+	var skill map[string]tftypes.Value
+	if err := skills[0].As(&skill); err != nil || !skill["description"].IsNull() {
+		t.Fatalf("skill scalar clear = %#v, err=%v", skill, err)
+	}
+	for _, field := range []string{"tags", "examples", "input_modes", "output_modes", "security"} {
+		assertEmpty("agent_card.skills.acceptance."+field, skill[field])
+	}
+	assertEmpty("agent_card.signatures", card["signatures"])
+
+	var permission map[string]tftypes.Value
+	if err := attributes["object_permission"].As(&permission); err != nil {
+		t.Fatal(err)
+	}
+	for _, field := range []string{"mcp_servers", "mcp_access_groups", "mcp_tool_permissions", "models", "agents"} {
+		assertEmpty("object_permission."+field, permission[field])
+	}
+}
+
+func TestAgentProtocolMergedLifecycleSetToClearCanonicalNoDrift(t *testing.T) {
+	fixture := newAgentClearProtocolFixture(t)
+	config, planned := planAgentClearProtocolFixture(t, fixture)
+	cleared, err := fixture.server.ApplyResourceChange(fixture.ctx, &tfprotov6.ApplyResourceChangeRequest{
+		TypeName: "litellm_agent", Config: config, PriorState: fixture.createdState, PlannedState: planned.PlannedState, PlannedPrivate: planned.PlannedPrivate,
+	})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(cleared.Diagnostics) || fixture.api.patches.Load() != 1 || fixture.api.badMutation.Load() {
+		t.Fatalf("set-to-cleared apply: err=%v diagnostics=%s patches=%d bad=%t", err, agentProtocolDiagnosticsText(cleared.Diagnostics), fixture.api.patches.Load(), fixture.api.badMutation.Load())
+	}
+	committed, decodeErr := decodeAgentFieldSet(protocolPrivateValue(t, cleared.Private, agentImportedFieldsPrivateKey))
+	if decodeErr != nil || len(committed) != 0 || string(protocolPrivateValue(t, cleared.Private, agentOwnershipInitializedPrivateKey)) != "true" || protocolPrivateHasKey(t, cleared.Private, agentOwnershipPendingPrivateKey) {
+		t.Fatalf("clear ownership was not promoted: committed=%#v err=%v private=%s", committed, decodeErr, cleared.Private)
+	}
+	assertAgentClearProtocolClearedState(t, fixture.schema, cleared.NewState)
+
+	state, private := cleared.NewState, cleared.Private
+	for readNumber := 1; readNumber <= 2; readNumber++ {
+		refreshed, readErr := fixture.server.ReadResource(fixture.ctx, &tfprotov6.ReadResourceRequest{
+			TypeName: "litellm_agent", CurrentState: state, Private: private,
+		})
+		if readErr != nil || accessGroupProtocolDiagnosticsHaveError(refreshed.Diagnostics) {
+			t.Fatalf("stable read %d: err=%v diagnostics=%s", readNumber, readErr, agentProtocolDiagnosticsText(refreshed.Diagnostics))
+		}
+		assertAgentProtocolStateUnchanged(t, fixture.schema, state, refreshed.NewState)
+		assertAgentProtocolPrivateUnchanged(t, private, refreshed.Private)
+		state, private = refreshed.NewState, refreshed.Private
+	}
+	noOp, planErr := fixture.server.PlanResourceChange(fixture.ctx, &tfprotov6.PlanResourceChangeRequest{
+		TypeName: "litellm_agent", Config: config, PriorState: state, ProposedNewState: state, PriorPrivate: private,
+	})
+	if planErr != nil || accessGroupProtocolDiagnosticsHaveError(noOp.Diagnostics) || organizationProjectProtocolPlannedAction(t, fixture.schema, state, noOp) != organizationProjectProtocolActionNoOp || fixture.api.patches.Load() != 1 {
+		t.Fatalf("post-clear protocol plan: err=%v diagnostics=%s action=%s patches=%d", planErr, agentProtocolDiagnosticsText(noOp.Diagnostics), organizationProjectProtocolPlannedAction(t, fixture.schema, state, noOp), fixture.api.patches.Load())
+	}
+}
+
+func TestAgentProtocolMergedLifecycleAdversarialPreflightRetainsOwnedState(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		adversarial string
+	}{
+		{name: "unknown top-level card key", adversarial: "top-level"},
+		{name: "unknown nested capability key", adversarial: "nested-capability"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newAgentClearProtocolFixture(t)
+			fixture.api.setAdversarial(test.adversarial)
+			config, planned := planAgentClearProtocolFixture(t, fixture)
+			assertAgentProtocolPrivateUnchanged(t, fixture.createdPrivate, planned.PlannedPrivate)
+			beforeApply := fixture.api.requests.Load()
+			applied, err := fixture.server.ApplyResourceChange(fixture.ctx, &tfprotov6.ApplyResourceChangeRequest{
+				TypeName: "litellm_agent", Config: config, PriorState: fixture.createdState, PlannedState: planned.PlannedState, PlannedPrivate: planned.PlannedPrivate,
+			})
+			if err != nil || !accessGroupProtocolDiagnosticsHaveError(applied.Diagnostics) {
+				t.Fatalf("adversarial clear apply: err=%v diagnostics=%s", err, agentProtocolDiagnosticsText(applied.Diagnostics))
+			}
+			if fixture.api.requests.Load() <= beforeApply || fixture.api.patches.Load() != 0 || fixture.api.badMutation.Load() {
+				t.Fatalf("preflight requests=%d/%d patches=%d bad=%t", fixture.api.requests.Load(), beforeApply, fixture.api.patches.Load(), fixture.api.badMutation.Load())
+			}
+			diagnostic := agentProtocolDiagnosticsText(applied.Diagnostics)
+			for _, protected := range []string{"x-adversarial", "must", "not mutate", fixture.api.serverURL, "smoke-agent-lifecycle"} {
+				if strings.Contains(diagnostic, protected) {
+					t.Fatal("content-bearing preflight diagnostic")
+				}
+			}
+			assertAgentProtocolStateUnchanged(t, fixture.schema, fixture.createdState, applied.NewState)
+			assertAgentProtocolPrivateUnchanged(t, fixture.createdPrivate, applied.Private)
+		})
+	}
+}
+
+func TestAgentClearProtocolMockRejectsPermissiveEvidence(t *testing.T) {
+	serverURL := "http://127.0.0.1:41998"
+	expectedPatch := agentClearProtocolPatchRequest(serverURL)
+	setCard := agentClearProtocolSetCard(serverURL)
+	for _, test := range []struct {
+		name   string
+		mutate func(map[string]interface{})
+	}{
+		{name: "capability false sent", mutate: func(request map[string]interface{}) {
+			request["agent_card_params"].(map[string]interface{})["capabilities"] = map[string]interface{}{"streaming": false}
+		}},
+		{name: "required top-level clear omitted", mutate: func(request map[string]interface{}) { delete(request, "tpm_limit") }},
+		{name: "required nested clear omitted", mutate: func(request map[string]interface{}) {
+			delete(request["agent_card_params"].(map[string]interface{})["skills"].([]interface{})[0].(map[string]interface{}), "security")
+		}},
+		{name: "object permissions preserved", mutate: func(request map[string]interface{}) {
+			request["object_permission"].(map[string]interface{})["mcp_servers"] = []interface{}{"acceptance-server"}
+		}},
+		{name: "duplicate signatures preserved", mutate: func(request map[string]interface{}) {
+			request["agent_card_params"].(map[string]interface{})["signatures"] = cloneAgentWireValue(setCard["signatures"])
+		}},
+		{name: "skill security preserved", mutate: func(request map[string]interface{}) {
+			request["agent_card_params"].(map[string]interface{})["skills"].([]interface{})[0].(map[string]interface{})["security"] = []interface{}{map[string]interface{}{"oauth2": []interface{}{"read", "read"}}}
+		}},
+		{name: "unexpected field accepted", mutate: func(request map[string]interface{}) { request["unexpected"] = true }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			candidate := cloneAgentWireObject(expectedPatch)
+			test.mutate(candidate)
+			if err := agentClearProtocolExactShape(candidate, expectedPatch); err == nil {
+				t.Fatal("permissive mutation evidence passed the exact mock assertion")
+			}
+		})
+	}
+
+	// A request echo has neither v1.98's empty capabilities parent nor its
+	// canonical object-permission and response fields. It cannot be used as
+	// confirmation evidence by this mock.
+	echo := cloneAgentWireObject(expectedPatch)
+	echo["agent_id"] = agentClearProtocolID
+	if err := agentClearProtocolCanonicalResponseShape(echo, agentClearProtocolResponse(serverURL, true, "")); err == nil {
+		t.Fatal("request echo passed as canonical v1.98 confirmation evidence")
+	}
+}

--- a/internal/provider/agent_collection_block_projection_protocol_test.go
+++ b/internal/provider/agent_collection_block_projection_protocol_test.go
@@ -1,0 +1,295 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+type agentBlockProjectionAPI struct {
+	mu       sync.Mutex
+	response map[string]interface{}
+	patches  []map[string]interface{}
+	requests atomic.Int64
+}
+
+func agentBlockProjectionSeed(serverURL string) map[string]interface{} {
+	response := agentClearProtocolResponse(serverURL, true, "")
+	card := response["agent_card_params"].(map[string]interface{})
+	card["skills"] = []interface{}{
+		map[string]interface{}{"id": "acceptance", "name": "Acceptance", "description": "owned after convergence", "tags": []interface{}{}, "examples": []interface{}{}, "inputModes": []interface{}{}, "outputModes": []interface{}{}, "security": []interface{}{}},
+		map[string]interface{}{"id": "api-null", "name": "API Null", "security": nil},
+		map[string]interface{}{"id": "api-omitted", "name": "API Omitted"},
+	}
+	card["signatures"] = []interface{}{
+		map[string]interface{}{"protected": "duplicate", "signature": "secret", "header": nil},
+		map[string]interface{}{"protected": "duplicate", "signature": "secret", "header": nil},
+		map[string]interface{}{"protected": "duplicate", "signature": "secret"},
+		map[string]interface{}{"protected": "duplicate", "signature": "secret"},
+		map[string]interface{}{"protected": "number", "signature": "secret", "header": map[string]interface{}{"exact": json.Number("9007199254740993"), "spelling": json.Number("1e+09")}},
+	}
+	return response
+}
+
+func (a *agentBlockProjectionAPI) handler(w http.ResponseWriter, r *http.Request) {
+	a.requests.Add(1)
+	w.Header().Set("Content-Type", "application/json")
+	if r.URL.Path != "/v1/agents/"+agentClearProtocolID {
+		http.NotFound(w, r)
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	switch r.Method {
+	case http.MethodGet:
+		_ = json.NewEncoder(w).Encode(a.response)
+	case http.MethodPatch:
+		var request map[string]interface{}
+		decoder := json.NewDecoder(r.Body)
+		decoder.UseNumber()
+		if decoder.Decode(&request) != nil {
+			http.Error(w, `{}`, http.StatusBadRequest)
+			return
+		}
+		a.patches = append(a.patches, cloneAgentWireObject(request))
+		for _, field := range []string{"litellm_params", "static_headers", "agent_card_params"} {
+			if value, present := request[field].(map[string]interface{}); present {
+				a.response[field] = cloneAgentWireObject(value)
+			}
+		}
+		_, _ = io.WriteString(w, `{}`)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (a *agentBlockProjectionAPI) addConcurrent() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	card := a.response["agent_card_params"].(map[string]interface{})
+	card["skills"] = append(card["skills"].([]interface{}), map[string]interface{}{"id": "api-concurrent", "name": "API Concurrent", "security": nil})
+	card["signatures"] = append(card["signatures"].([]interface{}), map[string]interface{}{"protected": "concurrent", "signature": "secret"})
+}
+
+func (a *agentBlockProjectionAPI) patch(index int) map[string]interface{} {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return cloneAgentWireObject(a.patches[index])
+}
+
+func agentBlockProjectionValues(description string, includeSkill bool) map[string]interface{} {
+	values := agentClearOverlayClearedConfig()
+	card := values["agent_card"].(map[string]interface{})
+	card["signatures"] = []interface{}{}
+	if includeSkill {
+		card["skills"] = []interface{}{map[string]interface{}{
+			"id": "acceptance", "name": "Acceptance", "tags": []interface{}{}, "examples": []interface{}{},
+			"input_modes": []interface{}{}, "output_modes": []interface{}{}, "security": []interface{}{},
+		}}
+	} else {
+		card["skills"] = []interface{}{}
+	}
+	if description != "" {
+		card["description"] = description
+	}
+	return values
+}
+
+func assertAgentBlockCollectionCounts(t *testing.T, schema *tfprotov6.Schema, state *tfprotov6.DynamicValue, skills, signatures int) {
+	t.Helper()
+	attributes := protocolAttributeMap(t, schema, state)
+	var card map[string]tftypes.Value
+	if err := attributes["agent_card"].As(&card); err != nil {
+		t.Fatal(err)
+	}
+	var skillValues, signatureValues []tftypes.Value
+	if err := card["skills"].As(&skillValues); err != nil || len(skillValues) != skills {
+		t.Fatalf("skills=%d err=%v, want %d", len(skillValues), err, skills)
+	}
+	if err := card["signatures"].As(&signatureValues); err != nil || len(signatureValues) != signatures {
+		t.Fatalf("signatures=%d err=%v, want %d", len(signatureValues), err, signatures)
+	}
+}
+
+type agentBlockProjectionFixture struct {
+	ctx     context.Context
+	api     *agentBlockProjectionAPI
+	server  tfprotov6.ProviderServer
+	schema  *tfprotov6.Schema
+	state   *tfprotov6.DynamicValue
+	private []byte
+}
+
+func newAgentBlockProjectionFixture(t *testing.T) agentBlockProjectionFixture {
+	t.Helper()
+	ctx := context.Background()
+	api := &agentBlockProjectionAPI{}
+	httpServer := httptest.NewServer(http.HandlerFunc(api.handler))
+	t.Cleanup(httpServer.Close)
+	api.response = agentBlockProjectionSeed(httpServer.URL)
+	server, schemas := configuredImportProtocolServer(t, ctx, httpServer.URL)
+	schema := schemas.ResourceSchemas["litellm_agent"]
+	imported, err := server.ImportResourceState(ctx, &tfprotov6.ImportResourceStateRequest{TypeName: "litellm_agent", ID: agentClearProtocolID})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(imported.Diagnostics) || len(imported.ImportedResources) != 1 {
+		t.Fatalf("import: err=%v diagnostics=%s", err, agentProtocolDiagnosticsText(imported.Diagnostics))
+	}
+	read, err := server.ReadResource(ctx, &tfprotov6.ReadResourceRequest{TypeName: "litellm_agent", CurrentState: imported.ImportedResources[0].State, Private: imported.ImportedResources[0].Private})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(read.Diagnostics) {
+		t.Fatalf("import read: err=%v diagnostics=%s", err, agentProtocolDiagnosticsText(read.Diagnostics))
+	}
+	assertAgentBlockCollectionCounts(t, schema, read.NewState, 3, 5)
+	return agentBlockProjectionFixture{ctx: ctx, api: api, server: server, schema: schema, state: read.NewState, private: read.Private}
+}
+
+func planAgentBlockProjection(t *testing.T, f agentBlockProjectionFixture, values map[string]interface{}) (*tfprotov6.DynamicValue, *tfprotov6.PlanResourceChangeResponse) {
+	t.Helper()
+	config := agentProtocolDynamicValue(t, f.schema, values)
+	proposed := agentProtocolReplaceMany(t, f.schema, f.state, map[string]interface{}{
+		"litellm_params": values["litellm_params"], "static_headers": values["static_headers"], "extra_headers": values["extra_headers"],
+		"agent_card": values["agent_card"], "object_permission": values["object_permission"],
+	})
+	planned, err := f.server.PlanResourceChange(f.ctx, &tfprotov6.PlanResourceChangeRequest{
+		TypeName: "litellm_agent", Config: config, PriorState: f.state, ProposedNewState: proposed, PriorPrivate: f.private,
+	})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(planned.Diagnostics) {
+		t.Fatalf("plan: err=%v diagnostics=%s", err, agentProtocolDiagnosticsText(planned.Diagnostics))
+	}
+	return config, planned
+}
+
+func applyAgentBlockProjection(t *testing.T, f agentBlockProjectionFixture, values map[string]interface{}, skills int) agentBlockProjectionFixture {
+	t.Helper()
+	config, planned := planAgentBlockProjection(t, f, values)
+	assertAgentBlockCollectionCounts(t, f.schema, planned.PlannedState, skills, 0)
+	applied, err := f.server.ApplyResourceChange(f.ctx, &tfprotov6.ApplyResourceChangeRequest{
+		TypeName: "litellm_agent", Config: config, PriorState: f.state, PlannedState: planned.PlannedState, PlannedPrivate: planned.PlannedPrivate,
+	})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(applied.Diagnostics) {
+		preserved := false
+		if len(f.api.patches) > 0 {
+			preserved = (&agentPatchPreservation{cardBase: agentBlockProjectionSeed("")["agent_card_params"].(map[string]interface{}), cardPatch: f.api.patches[0]["agent_card_params"].(map[string]interface{})}).matches(f.api.response)
+		}
+		t.Fatalf("apply: err=%v diagnostics=%s preservation=%t patches=%#v response=%#v", err, agentProtocolDiagnosticsText(applied.Diagnostics), preserved, f.api.patches, f.api.response)
+	}
+	assertAgentBlockCollectionCounts(t, f.schema, applied.NewState, skills, 0)
+	plannedValues, appliedValues := protocolAttributeMap(t, f.schema, planned.PlannedState), protocolAttributeMap(t, f.schema, applied.NewState)
+	for _, field := range []string{"agent_name", "agent_card", "litellm_params", "litellm_params_json", "static_headers", "extra_headers", "object_permission", "tpm_limit", "rpm_limit", "session_tpm_limit", "session_rpm_limit"} {
+		if !plannedValues[field].Equal(appliedValues[field]) {
+			t.Fatalf("Apply %s differs from plan", field)
+		}
+	}
+	f.state, f.private = applied.NewState, applied.Private
+	return f
+}
+
+func TestAgentListNestedBlocksHideAndPreserveAPICollections(t *testing.T) {
+	f := newAgentBlockProjectionFixture(t)
+	seedCard := agentBlockProjectionSeed("")["agent_card_params"].(map[string]interface{})
+	f = applyAgentBlockProjection(t, f, agentBlockProjectionValues("", true), 1)
+	if len(f.api.patches) != 1 {
+		t.Fatalf("patches=%d", len(f.api.patches))
+	}
+	patchCard := f.api.patch(0)["agent_card_params"].(map[string]interface{})
+	if !reflect.DeepEqual(patchCard["skills"], seedCard["skills"]) || !reflect.DeepEqual(patchCard["signatures"], seedCard["signatures"]) {
+		t.Fatal("convergence PATCH did not preserve hidden skill/signature order, duplicates, nulls, omissions, and numbers")
+	}
+	provenance, err := decodeAgentCollectionProvenance(protocolPrivateValue(t, f.private, agentCollectionsPrivateKey))
+	if err != nil || len(provenance.Skills) != 2 || len(provenance.Signatures) != 5 {
+		t.Fatalf("hidden provenance: skills=%d signatures=%d err=%v", len(provenance.Skills), len(provenance.Signatures), err)
+	}
+
+	for i := 0; i < 2; i++ {
+		read, readErr := f.server.ReadResource(f.ctx, &tfprotov6.ReadResourceRequest{TypeName: "litellm_agent", CurrentState: f.state, Private: f.private})
+		if readErr != nil || accessGroupProtocolDiagnosticsHaveError(read.Diagnostics) {
+			t.Fatalf("read %d: err=%v diagnostics=%s", i+1, readErr, agentProtocolDiagnosticsText(read.Diagnostics))
+		}
+		assertAgentProtocolStateUnchanged(t, f.schema, f.state, read.NewState)
+		assertAgentProtocolPrivateUnchanged(t, f.private, read.Private)
+		f.state, f.private = read.NewState, read.Private
+	}
+	values := agentBlockProjectionValues("", true)
+	config := agentProtocolDynamicValue(t, f.schema, values)
+	noop, err := f.server.PlanResourceChange(f.ctx, &tfprotov6.PlanResourceChangeRequest{TypeName: "litellm_agent", Config: config, PriorState: f.state, ProposedNewState: f.state, PriorPrivate: f.private})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(noop.Diagnostics) || organizationProjectProtocolPlannedAction(t, f.schema, f.state, noop) != organizationProjectProtocolActionNoOp {
+		t.Fatalf("no-op: err=%v diagnostics=%s", err, agentProtocolDiagnosticsText(noop.Diagnostics))
+	}
+
+	ownedValues := agentBlockProjectionValues("unrelated update", true)
+	ownedValues["agent_card"].(map[string]interface{})["skills"].([]interface{})[0].(map[string]interface{})["description"] = "owned after convergence"
+	f = applyAgentBlockProjection(t, f, ownedValues, 1)
+	patchCard = f.api.patch(1)["agent_card_params"].(map[string]interface{})
+	if len(agentWireObjectList(patchCard["skills"])) != 3 || len(agentWireObjectList(patchCard["signatures"])) != 5 {
+		t.Fatal("unrelated update lost hidden API collections")
+	}
+
+	// The matching configured skill transferred ownership. Its removal is real,
+	// while the two hidden API skills and all hidden signatures survive remotely.
+	f = applyAgentBlockProjection(t, f, agentBlockProjectionValues("unrelated update", false), 0)
+	patchCard = f.api.patch(2)["agent_card_params"].(map[string]interface{})
+	if skills := agentSkillRawByID(patchCard); len(skills) != 2 || skills["acceptance"] != nil || skills["api-null"] == nil || skills["api-omitted"] == nil {
+		t.Fatalf("Terraform-owned skill removal did not preserve only hidden siblings: %#v", skills)
+	}
+	if len(agentWireObjectList(patchCard["signatures"])) != 5 {
+		t.Fatal("Terraform-owned removal lost hidden signatures")
+	}
+}
+
+func TestAgentConcurrentCollectionsStayDeferredAndCorruptionDispatchesNothing(t *testing.T) {
+	f := newAgentBlockProjectionFixture(t)
+	values := agentBlockProjectionValues("", true)
+	config, planned := planAgentBlockProjection(t, f, values)
+	assertAgentBlockCollectionCounts(t, f.schema, planned.PlannedState, 1, 0)
+	f.api.addConcurrent()
+	applied, err := f.server.ApplyResourceChange(f.ctx, &tfprotov6.ApplyResourceChangeRequest{TypeName: "litellm_agent", Config: config, PriorState: f.state, PlannedState: planned.PlannedState, PlannedPrivate: planned.PlannedPrivate})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(applied.Diagnostics) {
+		t.Fatalf("concurrent apply: err=%v diagnostics=%s patches=%#v response=%#v", err, agentProtocolDiagnosticsText(applied.Diagnostics), f.api.patches, f.api.response)
+	}
+	assertAgentBlockCollectionCounts(t, f.schema, applied.NewState, 1, 0)
+	patchCard := f.api.patch(0)["agent_card_params"].(map[string]interface{})
+	if len(agentWireObjectList(patchCard["skills"])) != 4 || len(agentWireObjectList(patchCard["signatures"])) != 6 {
+		t.Fatal("concurrent additions were not preserved remotely")
+	}
+	for i := 0; i < 2; i++ {
+		read, readErr := f.server.ReadResource(f.ctx, &tfprotov6.ReadResourceRequest{TypeName: "litellm_agent", CurrentState: applied.NewState, Private: applied.Private})
+		if readErr != nil || accessGroupProtocolDiagnosticsHaveError(read.Diagnostics) {
+			t.Fatalf("deferred read %d: err=%v diagnostics=%s", i+1, readErr, agentProtocolDiagnosticsText(read.Diagnostics))
+		}
+		assertAgentProtocolStateUnchanged(t, f.schema, applied.NewState, read.NewState)
+		assertAgentProtocolPrivateUnchanged(t, applied.Private, read.Private)
+		applied.NewState, applied.Private = read.NewState, read.Private
+	}
+
+	stable, planErr := f.server.PlanResourceChange(f.ctx, &tfprotov6.PlanResourceChangeRequest{
+		TypeName: "litellm_agent", Config: config, PriorState: applied.NewState, ProposedNewState: applied.NewState, PriorPrivate: applied.Private,
+	})
+	if planErr != nil || accessGroupProtocolDiagnosticsHaveError(stable.Diagnostics) || organizationProjectProtocolPlannedAction(t, f.schema, applied.NewState, stable) != organizationProjectProtocolActionNoOp {
+		t.Fatalf("concurrent no-op: err=%v diagnostics=%s", planErr, agentProtocolDiagnosticsText(stable.Diagnostics))
+	}
+
+	privateValues := map[string][]byte{}
+	if json.Unmarshal(applied.Private, &privateValues) != nil {
+		t.Fatal("decode private")
+	}
+	privateValues[agentCollectionsPrivateKey] = []byte(`{"skills":[{"id":"secret"}],"signatures":[],"extra":true}`)
+	corrupt, _ := json.Marshal(privateValues)
+	before := f.api.requests.Load()
+	failed, applyErr := f.server.ApplyResourceChange(f.ctx, &tfprotov6.ApplyResourceChangeRequest{TypeName: "litellm_agent", Config: config, PriorState: applied.NewState, PlannedState: planned.PlannedState, PlannedPrivate: corrupt})
+	if applyErr != nil || !accessGroupProtocolDiagnosticsHaveError(failed.Diagnostics) || f.api.requests.Load() != before {
+		t.Fatalf("corrupt provenance: err=%v diagnostics=%s requests=%d/%d", applyErr, agentProtocolDiagnosticsText(failed.Diagnostics), f.api.requests.Load(), before)
+	}
+	for _, protected := range []string{"secret", "api-null", "acceptance"} {
+		if strings.Contains(agentProtocolDiagnosticsText(failed.Diagnostics), protected) {
+			t.Fatal("content-bearing corrupt-provenance diagnostic")
+		}
+	}
+}

--- a/internal/provider/agent_patch.go
+++ b/internal/provider/agent_patch.go
@@ -362,9 +362,23 @@ func overlayAgentCardRaw(base map[string]interface{}, plan, prior, config AgentR
 		}
 		desiredObject := agentWireObject(desired[wire.wire])
 		for field, childWire := range wire.leaves {
-			if usePlan(field) {
-				setAgentWireField(current, desiredObject, childWire)
+			if !usePlan(field) {
+				continue
 			}
+			// LiteLLM v1.98 stores only truthy streaming in capabilities.
+			// A configured false is therefore a legitimate clear represented by
+			// wire omission, not a false value that the round-trip preflight must
+			// reject as lossy. Other nested objects retain ordinary exact
+			// omission/null/value overlay semantics.
+			if wire.wire == "capabilities" {
+				if value, present := desiredObject[childWire]; present {
+					if enabled, isBool := value.(bool); isBool && !enabled {
+						delete(current, childWire)
+						continue
+					}
+				}
+			}
+			setAgentWireField(current, desiredObject, childWire)
 		}
 		if len(current) == 0 {
 			delete(patch, wire.wire)

--- a/internal/provider/agent_patch.go
+++ b/internal/provider/agent_patch.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"strings"
@@ -11,10 +12,11 @@ import (
 )
 
 type agentPatchPreservation struct {
-	paramsBase  map[string]interface{}
-	paramsPatch map[string]interface{}
-	cardBase    map[string]interface{}
-	cardPatch   map[string]interface{}
+	paramsBase   map[string]interface{}
+	paramsPatch  map[string]interface{}
+	cardBase     map[string]interface{}
+	cardPatch    map[string]interface{}
+	confirmedRaw map[string]interface{}
 }
 
 func cloneAgentWireObject(source map[string]interface{}) map[string]interface{} {
@@ -389,14 +391,17 @@ func overlayAgentCardRaw(base map[string]interface{}, plan, prior, config AgentR
 	if config.AgentCard.Signatures != nil {
 		baseSignatures := agentWireObjectList(patch["signatures"])
 		desiredSignatures := agentWireObjectList(desired["signatures"])
-		merged := make([]interface{}, 0, len(baseSignatures)+len(desiredSignatures))
 		priorSignatureCount := 0
 		if prior.AgentCard != nil {
 			priorSignatureCount = len(prior.AgentCard.Signatures)
 		}
+		merged := make([]interface{}, 0, len(baseSignatures)+len(desiredSignatures))
 		for index, desiredSignature := range desiredSignatures {
 			current := map[string]interface{}{}
-			if index < len(baseSignatures) {
+			// Only a previously public slot may be overlaid in place. New
+			// configured slots are inserted before the privately represented tail;
+			// otherwise a hidden signature would be overwritten and lost.
+			if index < priorSignatureCount && index < len(baseSignatures) {
 				current = cloneAgentWireObject(baseSignatures[index])
 			}
 			for _, wire := range []string{"protected", "signature", "header"} {
@@ -407,8 +412,17 @@ func overlayAgentCardRaw(base map[string]interface{}, plan, prior, config AgentR
 			}
 			merged = append(merged, current)
 		}
-		for index := len(desiredSignatures); index < len(baseSignatures); index++ {
-			if agentFieldSetHasPrefix(imported, fmt.Sprintf("%s[%d].", agentFieldCardSignatures, index)) || (imported[agentScopeCardSignatures] && index >= priorSignatureCount) {
+		// Omitted prior public slots survive only while their leaf provenance is
+		// API-owned. This is what makes Terraform-owned removals real removals.
+		for index := len(desiredSignatures); index < priorSignatureCount && index < len(baseSignatures); index++ {
+			if agentFieldSetHasPrefix(imported, fmt.Sprintf("%s[%d].", agentFieldCardSignatures, index)) {
+				merged = append(merged, cloneAgentWireObject(baseSignatures[index]))
+			}
+		}
+		// Every authoritative entry beyond prior public cardinality is hidden or
+		// concurrently API-added. Retain it byte-semantically and in wire order.
+		for index := priorSignatureCount; index < len(baseSignatures); index++ {
+			if imported[agentScopeCardSignatures] || agentFieldSetHasPrefix(imported, fmt.Sprintf("%s[%d].", agentFieldCardSignatures, index)) {
 				merged = append(merged, cloneAgentWireObject(baseSignatures[index]))
 			}
 		}
@@ -475,7 +489,26 @@ func overlayAgentCardRaw(base map[string]interface{}, plan, prior, config AgentR
 	return patch, nil
 }
 
+func agentCanonicalWireEqual(left, right interface{}) bool {
+	leftJSON, leftErr := json.Marshal(left)
+	rightJSON, rightErr := json.Marshal(right)
+	if leftErr != nil || rightErr != nil {
+		return false
+	}
+	var leftValue, rightValue interface{}
+	if decodeJSONUseNumber(leftJSON, &leftValue) != nil || decodeJSONUseNumber(rightJSON, &rightValue) != nil {
+		return false
+	}
+	return exactJSONValuesEqual(leftValue, rightValue)
+}
+
 func agentPreservedValueMatches(base, patch, observed interface{}, path string) bool {
+	if path == "agent_card_params.skills" {
+		return agentPreservedSkillsMatch(base, patch, observed)
+	}
+	if path == "agent_card_params.signatures" {
+		return agentPreservedSignaturesMatch(base, patch, observed)
+	}
 	if exactJSONValuesEqual(base, patch) {
 		return exactJSONValuesEqual(base, observed)
 	}
@@ -512,70 +545,70 @@ func agentPreservedValueMatches(base, patch, observed interface{}, path string) 
 		}
 		return true
 	}
-	if path == "agent_card_params.skills" {
-		return agentPreservedSkillsMatch(base, patch, observed)
-	}
-	if path == "agent_card_params.signatures" {
-		return agentPreservedSignaturesMatch(base, patch, observed)
-	}
 	return true
 }
 
 func agentPreservedSignaturesMatch(base, patch, observed interface{}) bool {
-	baseList, patchList, observedList := agentWireObjectList(base), agentWireObjectList(patch), agentWireObjectList(observed)
-	max := len(baseList)
-	if len(patchList) > max {
-		max = len(patchList)
+	_ = base
+	patchList, observedList := agentWireObjectList(patch), agentWireObjectList(observed)
+	if len(observedList) < len(patchList) {
+		return false
 	}
-	if len(observedList) > max {
-		max = len(observedList)
-	}
-	for index := 0; index < max; index++ {
-		bp, pp, op := index < len(baseList), index < len(patchList), index < len(observedList)
-		if bp == pp && (!bp || exactJSONValuesEqual(baseList[index], patchList[index])) {
-			if bp != op || (bp && !exactJSONValuesEqual(baseList[index], observedList[index])) {
-				return false
-			}
-			continue
-		}
-		if bp && pp && (!op || !agentPreservedValueMatches(baseList[index], patchList[index], observedList[index], fmt.Sprintf("agent_card_params.signatures.%d", index))) {
+	for index := range patchList {
+		if !agentCanonicalWireEqual(patchList[index], observedList[index]) {
 			return false
 		}
 	}
+	// Stable concurrent API additions are allowed only as a tail. They are
+	// retained remotely and recorded privately after confirmation.
 	return true
 }
 
 func agentPreservedSkillsMatch(base, patch, observed interface{}) bool {
+	_ = base
 	asMap := func(value interface{}) map[string]map[string]interface{} {
-		card := map[string]interface{}{"skills": value}
-		return agentSkillRawByID(card)
+		return agentSkillRawByID(map[string]interface{}{"skills": value})
 	}
-	baseByID, patchByID, observedByID := asMap(base), asMap(patch), asMap(observed)
-	ids := map[string]bool{}
-	for id := range baseByID {
-		ids[id] = true
-	}
-	for id := range patchByID {
-		ids[id] = true
-	}
-	for id := range observedByID {
-		ids[id] = true
-	}
-	for id := range ids {
-		baseSkill, bp := baseByID[id]
-		patchSkill, pp := patchByID[id]
-		observedSkill, op := observedByID[id]
-		if bp == pp && (!bp || exactJSONValuesEqual(baseSkill, patchSkill)) {
-			if bp != op || (bp && !exactJSONValuesEqual(baseSkill, observedSkill)) {
-				return false
-			}
-			continue
-		}
-		if bp && pp && (!op || !agentPreservedValueMatches(baseSkill, patchSkill, observedSkill, "agent_card_params.skills."+id)) {
+	patchByID, observedByID := asMap(patch), asMap(observed)
+	for id, expected := range patchByID {
+		actual, present := observedByID[id]
+		if !present || !agentCanonicalWireEqual(expected, actual) {
 			return false
 		}
 	}
+	// Observed-only identities are concurrent API additions. Missing, changed,
+	// or resurrected Terraform-owned identities are still rejected above or by
+	// the collection ownership matcher.
 	return true
+}
+
+func agentHiddenCollectionsFromRaw(raw map[string]interface{}, public AgentResourceModel) agentCollectionProvenance {
+	result := emptyAgentCollectionProvenance()
+	card, _ := raw["agent_card_params"].(map[string]interface{})
+	if card == nil || public.AgentCard == nil {
+		return result
+	}
+	publicSkillIDs := map[string]bool{}
+	for _, skill := range public.AgentCard.Skills {
+		if !skill.ID.IsNull() && !skill.ID.IsUnknown() {
+			publicSkillIDs[skill.ID.ValueString()] = true
+		}
+	}
+	for _, skill := range agentWireObjectList(card["skills"]) {
+		id, _ := skill["id"].(string)
+		if !publicSkillIDs[id] {
+			result.Skills = append(result.Skills, cloneAgentWireObject(skill))
+		}
+	}
+	signatures := agentWireObjectList(card["signatures"])
+	publicCount := len(public.AgentCard.Signatures)
+	if publicCount > len(signatures) {
+		publicCount = len(signatures)
+	}
+	for _, signature := range signatures[publicCount:] {
+		result.Signatures = append(result.Signatures, cloneAgentWireObject(signature))
+	}
+	return result
 }
 
 func (e *agentPatchPreservation) matches(raw map[string]interface{}) bool {

--- a/internal/provider/agent_structured_test.go
+++ b/internal/provider/agent_structured_test.go
@@ -3,8 +3,10 @@ package provider
 import (
 	"context"
 	"encoding/json"
+	"reflect"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	datasourceschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -463,6 +465,117 @@ func agentWireModelsForSkillsForTest(byID map[string]map[string]interface{}) []A
 		result = append(result, AgentSkillModel{ID: types.StringValue(id), Name: types.StringValue(raw["name"].(string))})
 	}
 	return result
+}
+
+func TestAgentMergedLifecycleFixtureClearOverlay(t *testing.T) {
+	securityType := types.MapType{ElemType: types.ListType{ElemType: types.StringType}}
+	security := types.ListValueMust(securityType, []attr.Value{
+		types.MapValueMust(types.ListType{ElemType: types.StringType}, map[string]attr.Value{
+			"oauth2": types.ListValueMust(types.StringType, []attr.Value{types.StringValue("read"), types.StringValue("read")}),
+		}),
+	})
+	prior := emptyKnownAgentResourceModel()
+	prior.AgentName = types.StringValue("smoke-agent-lifecycle")
+	prior.AgentCard = &AgentCardModel{
+		Name: types.StringValue("Smoke Agent Lifecycle"), Description: types.StringValue("set then clear"), URL: types.StringValue("https://agent.example.com/lifecycle"),
+		Version: types.StringValue("1.0.0"), ProtocolVersion: types.StringValue("1.0"), DefaultInputModes: stringListValue("text"), DefaultOutputModes: stringListValue("text"),
+		PreferredTransport: types.StringValue("JSONRPC"), IconURL: types.StringValue("https://agent.example.com/icon.png"), DocumentationURL: types.StringValue("https://agent.example.com/docs"), SupportsAuthenticatedExtendedCard: types.BoolValue(true),
+		Capabilities: &AgentCapabilitiesModel{Streaming: types.BoolValue(true), PushNotifications: types.BoolValue(false), StateTransitionHistory: types.BoolValue(false)},
+		Provider:     &AgentProviderModel{Organization: types.StringValue("Acceptance"), URL: types.StringValue("https://agent.example.com")},
+		Skills: []AgentSkillModel{{
+			ID: types.StringValue("acceptance"), Name: types.StringValue("Acceptance"), Description: types.StringValue("set then clear"),
+			Tags: stringListValue("lifecycle"), Examples: stringListValue("test"), InputModes: stringListValue("text"), OutputModes: stringListValue("text"), Security: security, SecurityJSON: types.StringNull(),
+		}},
+		Signatures: []AgentCardSignatureModel{
+			{Protected: types.StringValue("acceptance-protected"), Signature: types.StringValue("acceptance-signature"), Header: types.StringValue(`{"duplicate":0,"exact":9007199254740993}`), HeaderJSON: types.StringNull()},
+			{Protected: types.StringValue("acceptance-protected"), Signature: types.StringValue("acceptance-signature"), Header: types.StringValue(`{"duplicate":1,"exact":9007199254740993}`), HeaderJSON: types.StringNull()},
+		},
+	}
+	plan := cloneAgentResourceModel(prior)
+	plan.AgentCard.Description = types.StringNull()
+	plan.AgentCard.PreferredTransport = types.StringNull()
+	plan.AgentCard.IconURL = types.StringNull()
+	plan.AgentCard.DocumentationURL = types.StringNull()
+	plan.AgentCard.SupportsAuthenticatedExtendedCard = types.BoolValue(false)
+	plan.AgentCard.Capabilities = &AgentCapabilitiesModel{Streaming: types.BoolValue(false), PushNotifications: types.BoolValue(false), StateTransitionHistory: types.BoolValue(false)}
+	plan.AgentCard.Provider.Organization = types.StringNull()
+	plan.AgentCard.Skills[0].Description = types.StringNull()
+	plan.AgentCard.Skills[0].Tags = stringListValue()
+	plan.AgentCard.Skills[0].Examples = stringListValue()
+	plan.AgentCard.Skills[0].InputModes = stringListValue()
+	plan.AgentCard.Skills[0].OutputModes = stringListValue()
+	plan.AgentCard.Skills[0].Security = types.ListValueMust(securityType, []attr.Value{})
+	plan.AgentCard.Signatures = []AgentCardSignatureModel{}
+	config := cloneAgentResourceModel(plan)
+
+	base := map[string]interface{}{
+		"name": "Smoke Agent Lifecycle", "description": "set then clear", "url": "https://agent.example.com/lifecycle", "version": "1.0.0", "protocolVersion": "1.0",
+		"defaultInputModes": []interface{}{"text"}, "defaultOutputModes": []interface{}{"text"}, "preferredTransport": "JSONRPC", "iconUrl": "https://agent.example.com/icon.png", "documentationUrl": "https://agent.example.com/docs", "supportsAuthenticatedExtendedCard": true,
+		"capabilities": map[string]interface{}{"streaming": true}, "provider": map[string]interface{}{"organization": "Acceptance", "url": "https://agent.example.com"},
+		"skills": []interface{}{map[string]interface{}{
+			"id": "acceptance", "name": "Acceptance", "description": "set then clear", "tags": []interface{}{"lifecycle"}, "examples": []interface{}{"test"}, "inputModes": []interface{}{"text"}, "outputModes": []interface{}{"text"},
+			"security": []interface{}{map[string]interface{}{"oauth2": []interface{}{"read", "read"}}}, "x-api-owned": map[string]interface{}{"exact": json.Number("9007199254740993"), "present": nil},
+		}},
+		"signatures": []interface{}{
+			map[string]interface{}{"protected": "acceptance-protected", "signature": "acceptance-signature", "header": map[string]interface{}{"duplicate": json.Number("0"), "exact": json.Number("9007199254740993")}},
+			map[string]interface{}{"protected": "acceptance-protected", "signature": "acceptance-signature", "header": map[string]interface{}{"duplicate": json.Number("1"), "exact": json.Number("9007199254740993")}},
+		},
+		"security": []interface{}{}, "securitySchemes": map[string]interface{}{}, "supportedInterfaces": []interface{}{},
+	}
+	patch, err := overlayAgentCardRaw(base, plan, prior, config, agentFieldSet{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, present := patch["capabilities"]; present {
+		t.Fatalf("false capability clear was not normalized to v1.98 wire omission: %#v", patch["capabilities"])
+	}
+	if err := validateAgentCardV198RoundTrip(patch); err != nil {
+		t.Fatalf("exact merged lifecycle clear failed preflight: %v", err)
+	}
+	for _, cleared := range []string{"description", "preferredTransport", "iconUrl", "documentationUrl"} {
+		if _, present := patch[cleared]; present {
+			t.Fatalf("card clear retained %s", cleared)
+		}
+	}
+	if patch["supportsAuthenticatedExtendedCard"] != false {
+		t.Fatal("authenticated-card flag did not clear")
+	}
+	provider := agentWireObject(patch["provider"])
+	if _, present := provider["organization"]; present || provider["url"] != "https://agent.example.com" {
+		t.Fatal("provider leaf clear changed its configured sibling")
+	}
+	skill := agentSkillRawByID(patch)["acceptance"]
+	if skill == nil || !exactJSONValuesEqual(skill["x-api-owned"], base["skills"].([]interface{})[0].(map[string]interface{})["x-api-owned"]) {
+		t.Fatal("API-owned unknown structured skill value was not preserved exactly")
+	}
+	if _, present := skill["description"]; present {
+		t.Fatal("skill description clear was not represented by omission")
+	}
+	for _, cleared := range []string{"tags", "examples", "inputModes", "outputModes", "security"} {
+		items := reflect.ValueOf(skill[cleared])
+		if !items.IsValid() || items.Kind() != reflect.Slice || items.Len() != 0 {
+			t.Fatalf("skill collection clear did not remain explicit empty: %s", cleared)
+		}
+	}
+	if signatures := agentWireObjectList(patch["signatures"]); len(signatures) != 0 {
+		t.Fatalf("signature clear retained %d entries", len(signatures))
+	}
+	for _, adversarial := range []map[string]interface{}{
+		func() map[string]interface{} {
+			value := cloneAgentWireObject(patch)
+			value["x-unknown"] = true
+			return value
+		}(),
+		func() map[string]interface{} {
+			value := cloneAgentWireObject(patch)
+			value["capabilities"] = map[string]interface{}{"unknown": true}
+			return value
+		}(),
+	} {
+		if validateAgentCardV198RoundTrip(adversarial) == nil {
+			t.Fatal("adversarial filtered key passed the strict v1.98 preflight")
+		}
+	}
 }
 
 func TestAgentV198RoundTripPreflightRejectsFilteredPaths(t *testing.T) {

--- a/internal/provider/agent_structured_test.go
+++ b/internal/provider/agent_structured_test.go
@@ -454,8 +454,8 @@ func TestAgentRemoveOwnedSkillsPreservesAPISiblings(t *testing.T) {
 	for _, skill := range confirmed.AgentCard.Skills {
 		confirmedByID[skill.ID.ValueString()] = true
 	}
-	if confirmedByID["owned"] || !confirmedByID["imported"] || !confirmedByID["fresh"] {
-		t.Fatalf("confirmed state forgot preserved siblings: %#v", confirmedByID)
+	if len(confirmedByID) != 0 {
+		t.Fatalf("confirmed Apply state did not retain planned block cardinality: %#v", confirmedByID)
 	}
 }
 

--- a/internal/provider/resource_agent.go
+++ b/internal/provider/resource_agent.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"slices"
 	"strings"
 	"time"
 
@@ -441,6 +440,7 @@ func (r *AgentResource) Create(ctx context.Context, req resource.CreateRequest, 
 		resp.Diagnostics.Append(resp.Private.SetKey(ctx, agentImportedFieldsPrivateKey, encodeAgentFieldSet(agentFieldSet{}))...)
 		resp.Diagnostics.Append(resp.Private.SetKey(ctx, agentOwnershipInitializedPrivateKey, []byte("true"))...)
 		resp.Diagnostics.Append(resp.Private.SetKey(ctx, agentOwnershipPendingPrivateKey, nil)...)
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, agentCollectionsPrivateKey, encodeAgentCollectionProvenance(emptyAgentCollectionProvenance()))...)
 	}
 }
 
@@ -452,6 +452,7 @@ func setAgentIdentityOnlyCreateState(ctx context.Context, resp *resource.CreateR
 		resp.Diagnostics.Append(resp.Private.SetKey(ctx, agentImportedFieldsPrivateKey, encodeAgentFieldSet(agentFieldSet{}))...)
 		resp.Diagnostics.Append(resp.Private.SetKey(ctx, agentOwnershipInitializedPrivateKey, []byte("true"))...)
 		resp.Diagnostics.Append(resp.Private.SetKey(ctx, agentOwnershipPendingPrivateKey, nil)...)
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, agentCollectionsPrivateKey, encodeAgentCollectionProvenance(emptyAgentCollectionProvenance()))...)
 	}
 }
 
@@ -504,6 +505,7 @@ func (r *AgentResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		resp.Diagnostics.Append(resp.Private.SetKey(ctx, agentImportedFieldsPrivateKey, encodeAgentFieldSet(apiOwned))...)
 		resp.Diagnostics.Append(resp.Private.SetKey(ctx, agentOwnershipInitializedPrivateKey, []byte("true"))...)
 		resp.Diagnostics.Append(resp.Private.SetKey(ctx, agentOwnershipPendingPrivateKey, nil)...)
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, agentCollectionsPrivateKey, encodeAgentCollectionProvenance(emptyAgentCollectionProvenance()))...)
 		resp.Diagnostics.Append(resp.Private.SetKey(ctx, numericImportedPrivateKey, nil)...)
 	}
 }
@@ -641,21 +643,37 @@ func (r *AgentResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		if committed == nil {
 			committed = cloneAgentFieldSet(importedFields)
 		}
-		if preservation.cardBase != nil && state.AgentCard != nil {
-			priorIDs := map[string]bool{}
-			for _, skill := range state.AgentCard.Skills {
+		collections := bundle.collections
+		if preservation.confirmedRaw != nil && planned.AgentCard != nil {
+			collections = agentHiddenCollectionsFromRaw(preservation.confirmedRaw, planned)
+			card, _ := preservation.confirmedRaw["agent_card_params"].(map[string]interface{})
+			publicSkillIDs := map[string]bool{}
+			for _, skill := range planned.AgentCard.Skills {
 				if !skill.ID.IsNull() && !skill.ID.IsUnknown() {
-					priorIDs[skill.ID.ValueString()] = true
+					publicSkillIDs[skill.ID.ValueString()] = true
 				}
 			}
-			for id, rawSkill := range agentSkillRawByID(preservation.cardBase) {
-				if !priorIDs[id] && importedFields[agentScopeCardSkills] {
+			for id, rawSkill := range agentSkillRawByID(card) {
+				if !publicSkillIDs[id] && importedFields[agentScopeCardSkills] {
 					markAgentSkillWireLeaves(committed, id, rawSkill)
+				}
+			}
+			if importedFields[agentScopeCardSignatures] {
+				for index, rawSignature := range agentWireObjectList(card["signatures"]) {
+					if index < len(planned.AgentCard.Signatures) {
+						continue
+					}
+					for _, field := range []string{"protected", "signature", "header"} {
+						if _, present := rawSignature[field]; present {
+							committed[agentSignatureLeaf(index, field)] = true
+						}
+					}
 				}
 			}
 		}
 		resp.Diagnostics.Append(resp.Private.SetKey(ctx, agentImportedFieldsPrivateKey, encodeAgentFieldSet(committed))...)
 		resp.Diagnostics.Append(resp.Private.SetKey(ctx, agentOwnershipPendingPrivateKey, nil)...)
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, agentCollectionsPrivateKey, encodeAgentCollectionProvenance(collections))...)
 	}
 }
 
@@ -688,6 +706,7 @@ func (r *AgentResource) ImportState(ctx context.Context, req resource.ImportStat
 		resp.Diagnostics.Append(resp.Private.SetKey(ctx, agentImportedFieldsPrivateKey, nil)...)
 		resp.Diagnostics.Append(resp.Private.SetKey(ctx, agentOwnershipInitializedPrivateKey, nil)...)
 		resp.Diagnostics.Append(resp.Private.SetKey(ctx, agentOwnershipPendingPrivateKey, nil)...)
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, agentCollectionsPrivateKey, nil)...)
 	}
 }
 
@@ -1731,24 +1750,16 @@ func (r *AgentResource) reconcileAgentCardWithOwnership(cardRaw map[string]inter
 	reconcileString(agentFieldCardIcon, &out.IconURL, observed.IconURL)
 	reconcileString(agentFieldCardDocumentation, &out.DocumentationURL, observed.DocumentationURL)
 	reconcileBool(agentFieldCardAuthenticated, &out.SupportsAuthenticatedExtendedCard, observed.SupportsAuthenticatedExtendedCard)
-	rawSignatures, signaturesWirePresent := cardRaw["signatures"]
-	signatureMarkers := agentFieldSetHasPrefix(apiOwned, agentFieldCardSignatures+"[")
-	if prior.Signatures != nil || (apiOwned[agentScopeCardSignatures] && signaturesWirePresent && !signatureMarkers) {
-		out.Signatures = append([]AgentCardSignatureModel(nil), observed.Signatures...)
-		if apiOwned[agentScopeCardSignatures] && signaturesWirePresent {
-			for index, signature := range agentWireObjectList(rawSignatures) {
-				for _, field := range []string{"protected", "signature", "header"} {
-					_, present := signature[field]
-					adopt := index >= len(prior.Signatures)
-					if field == "header" && index < len(prior.Signatures) {
-						adopt = prior.Signatures[index].Header.IsNull() && prior.Signatures[index].HeaderJSON.IsNull()
-					}
-					if present && adopt {
-						apiOwned[agentSignatureLeaf(index, field)] = true
-					}
-				}
-			}
+	_, signaturesWirePresent := cardRaw["signatures"]
+	if prior.Signatures != nil {
+		// ListNestedBlock cardinality is configuration/state authority. A normal
+		// Read refreshes only the previously public prefix and never resurrects
+		// privately preserved or concurrently API-added signature entries.
+		count := len(prior.Signatures)
+		if count > len(observed.Signatures) {
+			count = len(observed.Signatures)
 		}
+		out.Signatures = append([]AgentCardSignatureModel(nil), observed.Signatures[:count]...)
 		if !apiOwned[agentFieldCardSignatures] && len(prior.Signatures) == len(out.Signatures) {
 			for index := range out.Signatures {
 				oldHeader, newHeader := prior.Signatures[index].Header, out.Signatures[index].Header
@@ -1758,12 +1769,8 @@ func (r *AgentResource) reconcileAgentCardWithOwnership(cardRaw map[string]inter
 				}
 			}
 		}
-		if observed.Signatures == nil {
-			for field := range apiOwned {
-				if strings.HasPrefix(field, agentFieldCardSignatures+"[") {
-					delete(apiOwned, field)
-				}
-			}
+		if !signaturesWirePresent {
+			out.Signatures = make([]AgentCardSignatureModel, 0)
 		}
 	}
 
@@ -1843,7 +1850,6 @@ func (r *AgentResource) reconcileAgentCardWithOwnership(cardRaw map[string]inter
 		}
 	}
 
-	rawSkillsByID := agentSkillRawByID(cardRaw)
 	remoteByID := map[string]AgentSkillModel{}
 	for _, skill := range observed.Skills {
 		remoteByID[skill.ID.ValueString()] = skill
@@ -1861,16 +1867,29 @@ func (r *AgentResource) reconcileAgentCardWithOwnership(cardRaw map[string]inter
 		}
 		current := old
 		reconcileString(agentSkillLeaf(id, "name"), &current.Name, remote.Name)
-		reconcileString(agentSkillLeaf(id, "description"), &current.Description, remote.Description)
-		reconcileList(agentSkillLeaf(id, "tags"), &current.Tags, remote.Tags, true)
-		reconcileList(agentSkillLeaf(id, "examples"), &current.Examples, remote.Examples, false)
-		reconcileList(agentSkillLeaf(id, "input_modes"), &current.InputModes, remote.InputModes, false)
-		reconcileList(agentSkillLeaf(id, "output_modes"), &current.OutputModes, remote.OutputModes, false)
-		securityField := agentSkillLeaf(id, "security")
-		if _, present := rawSkillsByID[id]["security"]; present && apiOwned[agentScopeCardSkills] && current.Security.IsNull() && current.SecurityJSON.IsNull() {
-			apiOwned[securityField] = true
+		// An omitted optional leaf in prior public block state remains omitted.
+		// Its API-owned raw value is provenance for the next overlay, not license
+		// for an ordinary Read to expand the public block after convergence.
+		if !current.Description.IsNull() {
+			reconcileString(agentSkillLeaf(id, "description"), &current.Description, remote.Description)
 		}
-		if apiOwned[securityField] || (!current.Security.IsNull() || !current.SecurityJSON.IsNull()) {
+		for _, leaf := range []struct {
+			name    string
+			target  *types.List
+			value   types.List
+			setLike bool
+		}{
+			{"tags", &current.Tags, remote.Tags, true},
+			{"examples", &current.Examples, remote.Examples, false},
+			{"input_modes", &current.InputModes, remote.InputModes, false},
+			{"output_modes", &current.OutputModes, remote.OutputModes, false},
+		} {
+			if !leaf.target.IsNull() {
+				reconcileList(agentSkillLeaf(id, leaf.name), leaf.target, leaf.value, leaf.setLike)
+			}
+		}
+		securityField := agentSkillLeaf(id, "security")
+		if !current.Security.IsNull() || !current.SecurityJSON.IsNull() {
 			current.Security = remote.Security
 			current.SecurityJSON = remote.SecurityJSON
 			if remote.Security.IsNull() && remote.SecurityJSON.IsNull() {
@@ -1880,22 +1899,9 @@ func (r *AgentResource) reconcileAgentCardWithOwnership(cardRaw map[string]inter
 		skills = append(skills, current)
 		seen[id] = true
 	}
-	newIDs := make([]string, 0)
-	for id := range remoteByID {
-		if !seen[id] {
-			newIDs = append(newIDs, id)
-		}
-	}
-	slices.Sort(newIDs)
-	for _, id := range newIDs {
-		if !apiOwned[agentScopeCardSkills] || agentFieldSetHasPrefix(apiOwned, agentLeaf(agentFieldCardSkills, id)+".") {
-			// Previously adopted API skills may be hidden after a configured-list
-			// apply. Preserve them privately/on wire without perpetual plan drift.
-			continue
-		}
-		skills = append(skills, remoteByID[id])
-		markAgentSkillWireLeaves(apiOwned, id, rawSkillsByID[id])
-	}
+	// Remote identities absent from prior public state remain hidden. Initial
+	// import uses readAgentCard above and is the sole full-resource projection;
+	// ordinary Reads never adopt API additions into ListNestedBlock state.
 	if prior.Skills == nil && len(skills) == 0 {
 		out.Skills = nil
 	} else {

--- a/internal/provider/resource_agent_lifecycle.go
+++ b/internal/provider/resource_agent_lifecycle.go
@@ -22,7 +22,68 @@ const (
 	agentImportedFieldsPrivateKey       = "agent_imported_fields_v1"
 	agentOwnershipInitializedPrivateKey = "agent_ownership_initialized_v1"
 	agentOwnershipPendingPrivateKey     = "agent_ownership_pending_v1"
+	agentCollectionsPrivateKey          = "agent_hidden_collections_v1"
 )
+
+type agentCollectionProvenance struct {
+	Skills     []interface{} `json:"skills"`
+	Signatures []interface{} `json:"signatures"`
+}
+
+func emptyAgentCollectionProvenance() agentCollectionProvenance {
+	return agentCollectionProvenance{Skills: []interface{}{}, Signatures: []interface{}{}}
+}
+
+func encodeAgentCollectionProvenance(value agentCollectionProvenance) []byte {
+	if value.Skills == nil {
+		value.Skills = []interface{}{}
+	}
+	if value.Signatures == nil {
+		value.Signatures = []interface{}{}
+	}
+	encoded, _ := json.Marshal(value)
+	return encoded
+}
+
+func decodeAgentCollectionProvenance(raw []byte) (agentCollectionProvenance, error) {
+	result := emptyAgentCollectionProvenance()
+	if raw == nil {
+		return result, nil
+	}
+	var decoded interface{}
+	if err := decodeJSONUseNumber(raw, &decoded); err != nil {
+		return result, fmt.Errorf("provider-private agent collection data is malformed")
+	}
+	object, ok := decoded.(map[string]interface{})
+	if !ok || len(object) != 2 {
+		return result, fmt.Errorf("provider-private agent collection data is malformed")
+	}
+	skills, skillsOK := object["skills"].([]interface{})
+	signatures, signaturesOK := object["signatures"].([]interface{})
+	if !skillsOK || !signaturesOK {
+		return result, fmt.Errorf("provider-private agent collection data is malformed")
+	}
+	for _, rawSkill := range skills {
+		skill, ok := rawSkill.(map[string]interface{})
+		if !ok {
+			return result, fmt.Errorf("provider-private agent collection data is malformed")
+		}
+		id, idOK := skill["id"].(string)
+		if !idOK || strings.TrimSpace(id) == "" || id != strings.TrimSpace(id) {
+			return result, fmt.Errorf("provider-private agent collection data is malformed")
+		}
+	}
+	for _, rawSignature := range signatures {
+		if _, ok := rawSignature.(map[string]interface{}); !ok {
+			return result, fmt.Errorf("provider-private agent collection data is malformed")
+		}
+	}
+	result.Skills, result.Signatures = skills, signatures
+	if !bytes.Equal(raw, encodeAgentCollectionProvenance(result)) {
+		return emptyAgentCollectionProvenance(), fmt.Errorf("provider-private agent collection data is not canonical")
+	}
+	return result, nil
+}
 
 type agentPrivateReader interface {
 	GetKey(context.Context, string) ([]byte, diag.Diagnostics)
@@ -112,13 +173,14 @@ func decodeAgentFieldSet(raw []byte) (agentFieldSet, error) {
 }
 
 type agentOwnershipBundle struct {
-	committed agentFieldSet
-	pending   agentFieldSet
-	versioned bool
+	committed   agentFieldSet
+	pending     agentFieldSet
+	collections agentCollectionProvenance
+	versioned   bool
 }
 
 func readAgentOwnershipBundle(ctx context.Context, private agentPrivateReader) (agentOwnershipBundle, diag.Diagnostics) {
-	result := agentOwnershipBundle{committed: agentFieldSet{}}
+	result := agentOwnershipBundle{committed: agentFieldSet{}, collections: emptyAgentCollectionProvenance()}
 	var diagnostics diag.Diagnostics
 	if private == nil {
 		return result, diagnostics
@@ -126,13 +188,15 @@ func readAgentOwnershipBundle(ctx context.Context, private agentPrivateReader) (
 	committedRaw, committedDiags := private.GetKey(ctx, agentImportedFieldsPrivateKey)
 	initializedRaw, initializedDiags := private.GetKey(ctx, agentOwnershipInitializedPrivateKey)
 	pendingRaw, pendingDiags := private.GetKey(ctx, agentOwnershipPendingPrivateKey)
+	collectionsRaw, collectionsDiags := private.GetKey(ctx, agentCollectionsPrivateKey)
 	diagnostics.Append(committedDiags...)
 	diagnostics.Append(initializedDiags...)
 	diagnostics.Append(pendingDiags...)
+	diagnostics.Append(collectionsDiags...)
 	if diagnostics.HasError() {
 		return result, diagnostics
 	}
-	any := committedRaw != nil || initializedRaw != nil || pendingRaw != nil
+	any := committedRaw != nil || initializedRaw != nil || pendingRaw != nil || collectionsRaw != nil
 	if !any {
 		return result, diagnostics
 	}
@@ -147,7 +211,11 @@ func readAgentOwnershipBundle(ctx context.Context, private agentPrivateReader) (
 	if err != nil {
 		return invalid()
 	}
-	result.committed, result.versioned = committed, true
+	collections, err := decodeAgentCollectionProvenance(collectionsRaw)
+	if err != nil {
+		return invalid()
+	}
+	result.committed, result.collections, result.versioned = committed, collections, true
 	if pendingRaw != nil {
 		pending, err := decodeAgentFieldSet(pendingRaw)
 		if err != nil {
@@ -497,6 +565,7 @@ func (r *AgentResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanR
 		if resp.Private != nil {
 			resp.Diagnostics.Append(resp.Private.SetKey(ctx, agentImportedFieldsPrivateKey, encodeAgentFieldSet(imported))...)
 			resp.Diagnostics.Append(resp.Private.SetKey(ctx, agentOwnershipInitializedPrivateKey, []byte("true"))...)
+			resp.Diagnostics.Append(resp.Private.SetKey(ctx, agentCollectionsPrivateKey, encodeAgentCollectionProvenance(emptyAgentCollectionProvenance()))...)
 		}
 	}
 	mergeAPIMapLeavesIntoPlan := func(target *types.Map, prior types.Map, prefix string) bool {
@@ -1668,6 +1737,9 @@ func (r *AgentResource) confirmAgentMutationWithPreservation(ctx context.Context
 			if validateAgentModelSkillIdentities(observed) == nil && preservation.matches(raw) && len(agentMutationMismatches(planned, prior, config, imported, observed)) == 0 && !agentResourceHasUnknowns(observed) {
 				consecutive++
 				lastConfirmed = reconcileConfirmedAgentState(planned, observed, config, prior, imported)
+				if preservation != nil {
+					preservation.confirmedRaw = cloneAgentWireObject(raw)
+				}
 				if consecutive >= 2 {
 					return lastConfirmed, nil
 				}
@@ -1865,14 +1937,14 @@ func agentSignaturesMutationMatch(planned []AgentCardSignatureModel, priorCard *
 			}
 		}
 	}
-	for index := len(config); index < len(prior); index++ {
-		if agentFieldSetHasPrefix(imported, fmt.Sprintf("%s[%d].", agentFieldCardSignatures, index)) {
-			continue
-		}
-		if index < len(observed) {
-			return false
-		}
+	// With API-owned hidden signatures, cardinality alone cannot identify a
+	// removed public entry. The raw preservation confirmation verifies the exact
+	// complete-list PATCH. Non-imported resources have no hidden tail and retain
+	// strict cardinality confirmation here.
+	if !imported[agentScopeCardSignatures] && len(observed) != len(planned) {
+		return false
 	}
+	_ = prior
 	return true
 }
 
@@ -2062,38 +2134,12 @@ func reconcileConfirmedAgentState(planned, observed, config, prior AgentResource
 	} else {
 		result.StaticHeaders = config.StaticHeaders
 	}
-	// Keep preserved API-owned and concurrently API-added skill siblings in the
-	// confirmed state. Terraform-owned removals were already required absent by
-	// agentSkillsMutationMatch; publishing only the planned list here would forget
-	// the remote siblings that made the full-card mutation safe.
-	if result.AgentCard != nil && observed.AgentCard != nil {
-		plannedIDs, priorIDs := map[string]bool{}, map[string]bool{}
-		for _, skill := range result.AgentCard.Skills {
-			if !skill.ID.IsNull() && !skill.ID.IsUnknown() {
-				plannedIDs[skill.ID.ValueString()] = true
-			}
-		}
-		if prior.AgentCard != nil {
-			for _, skill := range prior.AgentCard.Skills {
-				if !skill.ID.IsNull() && !skill.ID.IsUnknown() {
-					priorIDs[skill.ID.ValueString()] = true
-				}
-			}
-		}
-		for _, skill := range observed.AgentCard.Skills {
-			if skill.ID.IsNull() || skill.ID.IsUnknown() {
-				continue
-			}
-			id := skill.ID.ValueString()
-			if plannedIDs[id] {
-				continue
-			}
-			if agentFieldSetHasPrefix(imported, agentLeaf(agentFieldCardSkills, id)+".") || (imported[agentScopeCardSkills] && !priorIDs[id]) {
-				result.AgentCard.Skills = append(result.AgentCard.Skills, skill)
-				plannedIDs[id] = true
-			}
-		}
-	}
+	// Apply must publish exactly the planned ListNestedBlock cardinality. Remote
+	// API-owned siblings are confirmed against the canonical raw response and
+	// retained only in provider-private provenance for future wire overlays.
+	_ = observed
+	_ = prior
+	_ = imported
 	_ = config
 	resolveAgentUnknowns(&result)
 	return result

--- a/internal/provider/resource_agent_lifecycle_test.go
+++ b/internal/provider/resource_agent_lifecycle_test.go
@@ -355,7 +355,7 @@ func TestAgentProtocolMinimalCreateReadNoDriftDestroyWithServerDefaults(t *testi
 	}
 }
 
-func TestAgentProtocolImportAdoptsLaterAPISkillSibling(t *testing.T) {
+func TestAgentProtocolImportDoesNotAdoptLaterAPISkillSibling(t *testing.T) {
 	ctx := context.Background()
 	var added atomic.Bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -388,16 +388,8 @@ func TestAgentProtocolImportAdoptsLaterAPISkillSibling(t *testing.T) {
 		t.Fatal(err)
 	}
 	var skills []tftypes.Value
-	if err := card["skills"].As(&skills); err != nil || len(skills) != 2 {
-		t.Fatalf("imported skills=%d err=%v", len(skills), err)
-	}
-	var second map[string]tftypes.Value
-	if err := skills[1].As(&second); err != nil {
-		t.Fatal(err)
-	}
-	var secondID string
-	if err := second["id"].As(&secondID); err != nil || secondID != "added" {
-		t.Fatalf("added skill id=%q err=%v", secondID, err)
+	if err := card["skills"].As(&skills); err != nil || len(skills) != 1 {
+		t.Fatalf("ordinary Read changed imported public skill cardinality=%d err=%v", len(skills), err)
 	}
 }
 
@@ -610,7 +602,7 @@ func TestConfiguredMinimalAgentDoesNotAdoptServerCardDefaults(t *testing.T) {
 	}
 }
 
-func TestImportedAgentSkillScopeAdoptsAddedSiblingWithoutOwnershipTransfer(t *testing.T) {
+func TestImportedAgentSkillScopeKeepsAddedSiblingPrivate(t *testing.T) {
 	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -626,8 +618,8 @@ func TestImportedAgentSkillScopeAdoptsAddedSiblingWithoutOwnershipTransfer(t *te
 	if err := r.readAgentWithOwnership(context.Background(), &data, false, owned); err != nil {
 		t.Fatal(err)
 	}
-	if len(data.AgentCard.Skills) != 2 || data.AgentCard.Skills[0].Description.ValueString() != "remote" || !owned[agentSkillLeaf("api-added", "name")] {
-		t.Fatalf("skill reconciliation=%#v ownership=%#v", data.AgentCard.Skills, owned)
+	if len(data.AgentCard.Skills) != 1 || data.AgentCard.Skills[0].Description.ValueString() != "remote" || owned[agentSkillLeaf("api-added", "name")] {
+		t.Fatalf("ordinary Read promoted hidden API skill: reconciliation=%#v ownership=%#v", data.AgentCard.Skills, owned)
 	}
 	if owned[agentSkillLeaf("configured", "description")] {
 		t.Fatal("structural scope transferred configured sibling ownership")

--- a/internal/provider/testdata/agent-schema-origin-issues.golden.json
+++ b/internal/provider/testdata/agent-schema-origin-issues.golden.json
@@ -1,0 +1,23 @@
+{
+  "version": 0,
+  "agent_card_nesting": "SINGLE",
+  "skills_nesting": "LIST",
+  "signatures_nesting": "LIST",
+  "skills_attributes": [
+    "description",
+    "examples",
+    "id",
+    "input_modes",
+    "name",
+    "output_modes",
+    "security",
+    "security_json",
+    "tags"
+  ],
+  "signatures_attributes": [
+    "header",
+    "header_json",
+    "protected",
+    "signature"
+  ]
+}


### PR DESCRIPTION
### Summary

Related to #199 and follow-up to #260. This fixes two live LiteLLM v1.98 Agent lifecycle regressions: configured false capabilities now use v1.98's omission-based clear semantics, and imported API-owned skills/signatures remain preserved remotely without violating Terraform's planned nested-block cardinality.

Existing `skills` and `signatures` block schemas, HCL, state shape, schema version, IDs, and imports remain unchanged. Hidden API-owned blocks stay lossless through private provenance and authoritative overlays, while Apply and ordinary Read expose only blocks represented by planned/prior resource state.

### Validation

The complete release-owned Agent lifecycle passed against a fresh disposable v1.98 stack: create, clear, direct verification, API-owned null/omission/exact-number seed, import convergence, unrelated update, no drift, destroy, empty state, and remote absence. Focused protocol/schema coverage, full and race suites, contract gates, pinned contract diff, and acceptance assembly also passed; independent review returned **SHIP**.

### Checklist

- [x] Tests cover successful, adversarial, failure-recovery, and compatibility behavior.
- [x] Existing public schemas, HCL, state, IDs, and imports are preserved.
- [x] Disposable live lifecycle validation completed with owned cleanup.
- [x] No credentials or live environment data are included.

### Diff size

**Docs** — 0 files · `+0 / -0`

No documentation syntax changes are required because the existing nested-block contract is preserved.

**Implementation** — 6 files · `+264 / -165`

Adds capability wire normalization, hidden-collection projection, confirmation/reconciliation safeguards, and regenerated contract metadata without changing public schemas.

**Tests** — 6 files · `+1181 / -16`

Protocol lifecycles and schema goldens dominate the diff because they prove exact request/read-back behavior, remote preservation, no resurrection drift, concurrent additions, corruption handling, and compatibility with the pre-fix schema.
