### PR TITLE
fix: make data source projection presence-complete

### DIFF
--- a/internal/contract/manifest.json
+++ b/internal/contract/manifest.json
@@ -16,7 +16,7 @@
   "provider_golden": {
     "operation_count": 108,
     "path": "internal/contractapi/testdata/provider-operations.golden.json",
-    "sha256": "030602c10584fdbead80a0124f423484cd7a963de09e17e9ec0f5b1a34381fd0"
+    "sha256": "dcca9f2e21642a628cebd7df2649e87b8bc6a754bf67c3b1374cefc8ec5e9ba5"
   },
   "provider_operations": [
     {
@@ -518,11 +518,11 @@
       "evidence": [
         {
           "file": "internal/provider/datasource_keys_list.go",
-          "line": 150
+          "line": 156
         },
         {
           "file": "internal/provider/datasource_keys_list.go",
-          "line": 185
+          "line": 191
         },
         {
           "file": "internal/provider/resource_unified_access_group.go",
@@ -603,7 +603,7 @@
         },
         {
           "file": "internal/provider/datasource_models_list.go",
-          "line": 127
+          "line": 131
         },
         {
           "file": "internal/provider/resource_model.go",
@@ -702,7 +702,7 @@
       "evidence": [
         {
           "file": "internal/provider/datasource_organizations_list.go",
-          "line": 92
+          "line": 96
         }
       ],
       "method": "GET",
@@ -1256,7 +1256,7 @@
       "evidence": [
         {
           "file": "internal/provider/datasource_team.go",
-          "line": 238
+          "line": 158
         },
         {
           "file": "internal/provider/resource_team.go",
@@ -1348,11 +1348,11 @@
       "evidence": [
         {
           "file": "internal/provider/datasource_users_list.go",
-          "line": 133
+          "line": 137
         },
         {
           "file": "internal/provider/datasource_users_list.go",
-          "line": 169
+          "line": 173
         },
         {
           "file": "internal/provider/resource_team_member.go",

--- a/internal/contract/manifest.json
+++ b/internal/contract/manifest.json
@@ -16,7 +16,7 @@
   "provider_golden": {
     "operation_count": 108,
     "path": "internal/contractapi/testdata/provider-operations.golden.json",
-    "sha256": "bfe9355a278160b7bf16435de2c15213c5916d94875f56bf72b9af14ad05bd20"
+    "sha256": "030602c10584fdbead80a0124f423484cd7a963de09e17e9ec0f5b1a34381fd0"
   },
   "provider_operations": [
     {
@@ -1124,7 +1124,7 @@
       "evidence": [
         {
           "file": "internal/provider/resource_team.go",
-          "line": 486
+          "line": 563
         }
       ],
       "method": "POST",
@@ -1140,7 +1140,7 @@
         },
         {
           "file": "internal/provider/resource_team.go",
-          "line": 754
+          "line": 828
         },
         {
           "file": "internal/provider/resource_team_block.go",
@@ -1244,7 +1244,7 @@
       "evidence": [
         {
           "file": "internal/provider/resource_team.go",
-          "line": 372
+          "line": 421
         }
       ],
       "method": "POST",
@@ -1260,7 +1260,7 @@
         },
         {
           "file": "internal/provider/resource_team.go",
-          "line": 983
+          "line": 912
         }
       ],
       "method": "GET",
@@ -1274,7 +1274,7 @@
       "evidence": [
         {
           "file": "internal/provider/resource_team.go",
-          "line": 462
+          "line": 534
         }
       ],
       "method": "POST",
@@ -1298,11 +1298,11 @@
       "evidence": [
         {
           "file": "internal/provider/resource_team.go",
-          "line": 443
+          "line": 515
         },
         {
           "file": "internal/provider/resource_team.go",
-          "line": 449
+          "line": 521
         }
       ],
       "method": "POST",
@@ -1579,7 +1579,7 @@
       "evidence": [
         {
           "file": "internal/provider/datasource_mcp_servers_list.go",
-          "line": 147
+          "line": 146
         },
         {
           "file": "internal/provider/resource_mcp_server.go",
@@ -1633,11 +1633,15 @@
       "evidence": [
         {
           "file": "internal/provider/datasource_mcp_server.go",
-          "line": 214
+          "line": 220
         },
         {
           "file": "internal/provider/resource_mcp_server.go",
           "line": 1041
+        },
+        {
+          "file": "internal/provider/resource_mcp_server.go",
+          "line": 1045
         }
       ],
       "method": "GET",

--- a/internal/contract/manifest.json
+++ b/internal/contract/manifest.json
@@ -16,14 +16,14 @@
   "provider_golden": {
     "operation_count": 108,
     "path": "internal/contractapi/testdata/provider-operations.golden.json",
-    "sha256": "8a2e10a2ae9007ff222422fbb10487c9df809b096c0a752cd8123749b970b908"
+    "sha256": "bfe9355a278160b7bf16435de2c15213c5916d94875f56bf72b9af14ad05bd20"
   },
   "provider_operations": [
     {
       "evidence": [
         {
           "file": "internal/provider/datasource_access_groups_list.go",
-          "line": 91
+          "line": 86
         }
       ],
       "method": "GET",
@@ -121,7 +121,7 @@
       "evidence": [
         {
           "file": "internal/provider/datasource_budgets_list.go",
-          "line": 135
+          "line": 130
         }
       ],
       "method": "GET",
@@ -413,7 +413,7 @@
       "evidence": [
         {
           "file": "internal/provider/jwt_key_mapping_api.go",
-          "line": 261
+          "line": 278
         }
       ],
       "method": "GET",
@@ -518,11 +518,11 @@
       "evidence": [
         {
           "file": "internal/provider/datasource_keys_list.go",
-          "line": 148
+          "line": 150
         },
         {
           "file": "internal/provider/datasource_keys_list.go",
-          "line": 183
+          "line": 185
         },
         {
           "file": "internal/provider/resource_unified_access_group.go",
@@ -603,7 +603,7 @@
         },
         {
           "file": "internal/provider/datasource_models_list.go",
-          "line": 126
+          "line": 127
         },
         {
           "file": "internal/provider/resource_model.go",
@@ -702,7 +702,7 @@
       "evidence": [
         {
           "file": "internal/provider/datasource_organizations_list.go",
-          "line": 91
+          "line": 92
         }
       ],
       "method": "GET",
@@ -802,7 +802,7 @@
       "evidence": [
         {
           "file": "internal/provider/datasource_projects_list.go",
-          "line": 96
+          "line": 92
         }
       ],
       "method": "GET",
@@ -850,11 +850,11 @@
       "evidence": [
         {
           "file": "internal/provider/datasource_prompts_list.go",
-          "line": 200
+          "line": 204
         },
         {
           "file": "internal/provider/datasource_prompts_list.go",
-          "line": 221
+          "line": 230
         }
       ],
       "method": "GET",
@@ -892,7 +892,7 @@
         },
         {
           "file": "internal/provider/datasource_prompts_list.go",
-          "line": 239
+          "line": 253
         },
         {
           "file": "internal/provider/prompt_helpers.go",
@@ -986,7 +986,7 @@
       "evidence": [
         {
           "file": "internal/provider/datasource_search_tools_list.go",
-          "line": 111
+          "line": 106
         }
       ],
       "method": "GET",
@@ -1072,7 +1072,7 @@
       "evidence": [
         {
           "file": "internal/provider/datasource_tags_list.go",
-          "line": 86
+          "line": 82
         },
         {
           "file": "internal/provider/resource_tag.go",
@@ -1124,7 +1124,7 @@
       "evidence": [
         {
           "file": "internal/provider/resource_team.go",
-          "line": 563
+          "line": 486
         }
       ],
       "method": "POST",
@@ -1140,7 +1140,7 @@
         },
         {
           "file": "internal/provider/resource_team.go",
-          "line": 828
+          "line": 754
         },
         {
           "file": "internal/provider/resource_team_block.go",
@@ -1244,7 +1244,7 @@
       "evidence": [
         {
           "file": "internal/provider/resource_team.go",
-          "line": 421
+          "line": 372
         }
       ],
       "method": "POST",
@@ -1260,7 +1260,7 @@
         },
         {
           "file": "internal/provider/resource_team.go",
-          "line": 912
+          "line": 983
         }
       ],
       "method": "GET",
@@ -1274,7 +1274,7 @@
       "evidence": [
         {
           "file": "internal/provider/resource_team.go",
-          "line": 534
+          "line": 462
         }
       ],
       "method": "POST",
@@ -1298,11 +1298,11 @@
       "evidence": [
         {
           "file": "internal/provider/resource_team.go",
-          "line": 515
+          "line": 443
         },
         {
           "file": "internal/provider/resource_team.go",
-          "line": 521
+          "line": 449
         }
       ],
       "method": "POST",
@@ -1348,11 +1348,11 @@
       "evidence": [
         {
           "file": "internal/provider/datasource_users_list.go",
-          "line": 132
+          "line": 133
         },
         {
           "file": "internal/provider/datasource_users_list.go",
-          "line": 168
+          "line": 169
         },
         {
           "file": "internal/provider/resource_team_member.go",
@@ -1493,7 +1493,7 @@
       "evidence": [
         {
           "file": "internal/provider/datasource_agents_list.go",
-          "line": 89
+          "line": 85
         },
         {
           "file": "internal/provider/resource_agent_lifecycle.go",
@@ -1579,7 +1579,7 @@
       "evidence": [
         {
           "file": "internal/provider/datasource_mcp_servers_list.go",
-          "line": 153
+          "line": 147
         },
         {
           "file": "internal/provider/resource_mcp_server.go",
@@ -1633,15 +1633,11 @@
       "evidence": [
         {
           "file": "internal/provider/datasource_mcp_server.go",
-          "line": 220
+          "line": 214
         },
         {
           "file": "internal/provider/resource_mcp_server.go",
           "line": 1041
-        },
-        {
-          "file": "internal/provider/resource_mcp_server.go",
-          "line": 1045
         }
       ],
       "method": "GET",

--- a/internal/contract/reviewed-pins.json
+++ b/internal/contract/reviewed-pins.json
@@ -9,7 +9,7 @@
     },
     "manifest": {
       "path": "internal/contract/manifest.json",
-      "sha256": "cfd9e000a03d79d5aa9cbee8d660bbcdb3721587af247f2174ad3a5bf416d45e"
+      "sha256": "22b87551705c691467170228717773c10dfcdf2ae35f7fb3b78b25547c9f7748"
     },
     "openapi": {
       "operation_count": 800,
@@ -20,7 +20,7 @@
     "provider_golden": {
       "operation_count": 108,
       "path": "internal/contractapi/testdata/provider-operations.golden.json",
-      "sha256": "bfe9355a278160b7bf16435de2c15213c5916d94875f56bf72b9af14ad05bd20"
+      "sha256": "030602c10584fdbead80a0124f423484cd7a963de09e17e9ec0f5b1a34381fd0"
     },
     "supplemental": {
       "operation_count": 1,

--- a/internal/contract/reviewed-pins.json
+++ b/internal/contract/reviewed-pins.json
@@ -9,7 +9,7 @@
     },
     "manifest": {
       "path": "internal/contract/manifest.json",
-      "sha256": "9c6ff5bb2bb2930a538fefcca6f65319e39602d999ede4810918aec223129da9"
+      "sha256": "cfd9e000a03d79d5aa9cbee8d660bbcdb3721587af247f2174ad3a5bf416d45e"
     },
     "openapi": {
       "operation_count": 800,
@@ -20,7 +20,7 @@
     "provider_golden": {
       "operation_count": 108,
       "path": "internal/contractapi/testdata/provider-operations.golden.json",
-      "sha256": "8a2e10a2ae9007ff222422fbb10487c9df809b096c0a752cd8123749b970b908"
+      "sha256": "bfe9355a278160b7bf16435de2c15213c5916d94875f56bf72b9af14ad05bd20"
     },
     "supplemental": {
       "operation_count": 1,

--- a/internal/contract/reviewed-pins.json
+++ b/internal/contract/reviewed-pins.json
@@ -9,7 +9,7 @@
     },
     "manifest": {
       "path": "internal/contract/manifest.json",
-      "sha256": "22b87551705c691467170228717773c10dfcdf2ae35f7fb3b78b25547c9f7748"
+      "sha256": "5d1e84e22d01ee6d2049ed7d0e4c65061fdc65009bf210e6f99d40eda0f82cc7"
     },
     "openapi": {
       "operation_count": 800,
@@ -20,7 +20,7 @@
     "provider_golden": {
       "operation_count": 108,
       "path": "internal/contractapi/testdata/provider-operations.golden.json",
-      "sha256": "030602c10584fdbead80a0124f423484cd7a963de09e17e9ec0f5b1a34381fd0"
+      "sha256": "dcca9f2e21642a628cebd7df2649e87b8bc6a754bf67c3b1374cefc8ec5e9ba5"
     },
     "supplemental": {
       "operation_count": 1,

--- a/internal/contractapi/testdata/provider-operations.golden.json
+++ b/internal/contractapi/testdata/provider-operations.golden.json
@@ -511,11 +511,11 @@
     "evidence": [
       {
         "file": "internal/provider/datasource_keys_list.go",
-        "line": 150
+        "line": 156
       },
       {
         "file": "internal/provider/datasource_keys_list.go",
-        "line": 185
+        "line": 191
       },
       {
         "file": "internal/provider/resource_unified_access_group.go",
@@ -590,7 +590,7 @@
       },
       {
         "file": "internal/provider/datasource_models_list.go",
-        "line": 127
+        "line": 131
       },
       {
         "file": "internal/provider/resource_model.go",
@@ -688,7 +688,7 @@
     "evidence": [
       {
         "file": "internal/provider/datasource_organizations_list.go",
-        "line": 92
+        "line": 96
       }
     ]
   },
@@ -1242,7 +1242,7 @@
     "evidence": [
       {
         "file": "internal/provider/datasource_team.go",
-        "line": 238
+        "line": 158
       },
       {
         "file": "internal/provider/resource_team.go",
@@ -1339,11 +1339,11 @@
     "evidence": [
       {
         "file": "internal/provider/datasource_users_list.go",
-        "line": 133
+        "line": 137
       },
       {
         "file": "internal/provider/datasource_users_list.go",
-        "line": 169
+        "line": 173
       },
       {
         "file": "internal/provider/resource_team_member.go",

--- a/internal/contractapi/testdata/provider-operations.golden.json
+++ b/internal/contractapi/testdata/provider-operations.golden.json
@@ -1563,7 +1563,7 @@
     "evidence": [
       {
         "file": "internal/provider/datasource_mcp_servers_list.go",
-        "line": 153
+        "line": 146
       },
       {
         "file": "internal/provider/resource_mcp_server.go",

--- a/internal/contractapi/testdata/provider-operations.golden.json
+++ b/internal/contractapi/testdata/provider-operations.golden.json
@@ -7,7 +7,7 @@
     "evidence": [
       {
         "file": "internal/provider/datasource_access_groups_list.go",
-        "line": 91
+        "line": 86
       }
     ]
   },
@@ -105,7 +105,7 @@
     "evidence": [
       {
         "file": "internal/provider/datasource_budgets_list.go",
-        "line": 135
+        "line": 130
       }
     ]
   },
@@ -400,7 +400,7 @@
     "evidence": [
       {
         "file": "internal/provider/jwt_key_mapping_api.go",
-        "line": 261
+        "line": 278
       }
     ]
   },
@@ -511,11 +511,11 @@
     "evidence": [
       {
         "file": "internal/provider/datasource_keys_list.go",
-        "line": 148
+        "line": 150
       },
       {
         "file": "internal/provider/datasource_keys_list.go",
-        "line": 183
+        "line": 185
       },
       {
         "file": "internal/provider/resource_unified_access_group.go",
@@ -590,7 +590,7 @@
       },
       {
         "file": "internal/provider/datasource_models_list.go",
-        "line": 126
+        "line": 127
       },
       {
         "file": "internal/provider/resource_model.go",
@@ -688,7 +688,7 @@
     "evidence": [
       {
         "file": "internal/provider/datasource_organizations_list.go",
-        "line": 91
+        "line": 92
       }
     ]
   },
@@ -786,7 +786,7 @@
     "evidence": [
       {
         "file": "internal/provider/datasource_projects_list.go",
-        "line": 96
+        "line": 92
       }
     ]
   },
@@ -836,11 +836,11 @@
     "evidence": [
       {
         "file": "internal/provider/datasource_prompts_list.go",
-        "line": 200
+        "line": 204
       },
       {
         "file": "internal/provider/datasource_prompts_list.go",
-        "line": 221
+        "line": 230
       }
     ]
   },
@@ -880,7 +880,7 @@
       },
       {
         "file": "internal/provider/datasource_prompts_list.go",
-        "line": 239
+        "line": 253
       },
       {
         "file": "internal/provider/prompt_helpers.go",
@@ -970,7 +970,7 @@
     "evidence": [
       {
         "file": "internal/provider/datasource_search_tools_list.go",
-        "line": 111
+        "line": 106
       }
     ]
   },
@@ -1056,7 +1056,7 @@
     "evidence": [
       {
         "file": "internal/provider/datasource_tags_list.go",
-        "line": 86
+        "line": 82
       },
       {
         "file": "internal/provider/resource_tag.go",
@@ -1339,11 +1339,11 @@
     "evidence": [
       {
         "file": "internal/provider/datasource_users_list.go",
-        "line": 132
+        "line": 133
       },
       {
         "file": "internal/provider/datasource_users_list.go",
-        "line": 168
+        "line": 169
       },
       {
         "file": "internal/provider/resource_team_member.go",
@@ -1477,7 +1477,7 @@
     "evidence": [
       {
         "file": "internal/provider/datasource_agents_list.go",
-        "line": 89
+        "line": 85
       },
       {
         "file": "internal/provider/resource_agent_lifecycle.go",

--- a/internal/provider/datasource_access_group.go
+++ b/internal/provider/datasource_access_group.go
@@ -68,33 +68,44 @@ func (d *AccessGroupDataSource) Configure(ctx context.Context, req datasource.Co
 }
 
 func (d *AccessGroupDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
-	var data AccessGroupDataSourceModel
-
-	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	var config AccessGroupDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	accessGroup := data.AccessGroup.ValueString()
-	endpoint := endpointWithPathSegment("/access_group/", accessGroup, "/info")
-
+	accessGroup := config.AccessGroup.ValueString()
+	if accessGroup == "" {
+		resp.Diagnostics.AddError("Invalid Access Group Lookup", "access_group must be known and nonempty")
+		return
+	}
 	var result map[string]interface{}
-	if err := d.client.DoRequestWithResponse(ctx, "GET", endpoint, nil, &result); err != nil {
+	if err := d.client.DoRequestWithResponse(ctx, "GET", endpointWithPathSegment("/access_group/", accessGroup, "/info"), nil, &result); err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read access group: %s", err))
 		return
 	}
 
-	// Populate the data model
-	data.ID = types.StringValue(accessGroup)
-
-	if rawModelNames, ok := result["model_names"]; ok {
-		modelNames, err := reconcileAccessGroupModelNames(ctx, types.ListNull(types.StringType), rawModelNames)
+	actualAccessGroup, err := dataSourceRequiredStringAt(result, "access_group")
+	if err != nil || actualAccessGroup.ValueString() != accessGroup {
+		resp.Diagnostics.AddError("Invalid API Response", "Access group response identity did not match the requested access group.")
+		return
+	}
+	modelNames, err := dataSourceNullableStringListAt(result, "model_names")
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", fmt.Sprintf("Unable to decode model_names: %s", err))
+		return
+	}
+	if !modelNames.IsNull() {
+		modelNames, err = reconcileAccessGroupModelNames(ctx, types.ListNull(types.StringType), result["model_names"])
 		if err != nil {
 			resp.Diagnostics.AddError("Invalid API Response", fmt.Sprintf("Unable to decode model_names: %s", err))
 			return
 		}
-		data.ModelNames = modelNames
 	}
 
+	data := AccessGroupDataSourceModel{
+		ID:          types.StringValue(accessGroup),
+		AccessGroup: config.AccessGroup,
+		ModelNames:  modelNames,
+	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/provider/datasource_access_groups_list.go
+++ b/internal/provider/datasource_access_groups_list.go
@@ -83,11 +83,6 @@ func (d *AccessGroupsListDataSource) Configure(ctx context.Context, req datasour
 func (d *AccessGroupsListDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	var data AccessGroupsListDataSourceModel
 
-	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
 	groups, err := fetchEnvelopeListObjects(ctx, d.client, "/access_group/list", "access_groups", "access group item")
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to list access groups: %s", err))
@@ -95,19 +90,30 @@ func (d *AccessGroupsListDataSource) Read(ctx context.Context, req datasource.Re
 	}
 
 	accessGroups := make([]AccessGroupListItemModel, 0, len(groups))
+	seen := make(map[string]struct{}, len(groups))
 	for _, groupMap := range groups {
 		item := AccessGroupListItemModel{}
-		if accessGroup, ok := groupMap["access_group"].(string); ok && accessGroup != "" {
-			item.AccessGroup = types.StringValue(accessGroup)
-		} else {
-			resp.Diagnostics.AddError("Invalid API Response", "/access_group/list returned an access group object without access_group")
+		item.AccessGroup, err = dataSourceRequiredStringAt(groupMap, "access_group")
+		if err != nil {
+			resp.Diagnostics.AddError("Invalid API Response", "/access_group/list returned an access group object without a canonical access_group")
+			return
+		}
+		if err := dataSourceListIdentity(seen, item.AccessGroup.ValueString(), "/access_group/list", "access_group"); err != nil {
+			resp.Diagnostics.AddError("Invalid API Response", err.Error())
 			return
 		}
 
-		modelNames, err := reconcileAccessGroupModelNames(ctx, types.ListNull(types.StringType), groupMap["model_names"])
+		modelNames, err := dataSourceNullableStringListAt(groupMap, "model_names")
 		if err != nil {
-			resp.Diagnostics.AddError("Invalid API Response", fmt.Sprintf("Unable to decode model_names for access group %q: %s", item.AccessGroup.ValueString(), err))
+			resp.Diagnostics.AddError("Invalid API Response", "Unable to decode model_names for an access group.")
 			return
+		}
+		if !modelNames.IsNull() {
+			modelNames, err = reconcileAccessGroupModelNames(ctx, types.ListNull(types.StringType), groupMap["model_names"])
+			if err != nil {
+				resp.Diagnostics.AddError("Invalid API Response", "Unable to decode model_names for an access group.")
+				return
+			}
 		}
 		item.ModelNames = modelNames
 

--- a/internal/provider/datasource_agents_list.go
+++ b/internal/provider/datasource_agents_list.go
@@ -82,25 +82,37 @@ func agentListItem(projected AgentDataSourceModel) AgentListItemModel {
 
 func (d *AgentsListDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	var data AgentsListDataSourceModel
-	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 	result, err := fetchTopLevelListObjects(ctx, d.client, "/v1/agents", "agent item")
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", "Unable to list agents authoritatively.")
 		return
 	}
 	agents := make([]AgentListItemModel, 0, len(result))
+	seen := make(map[string]struct{}, len(result))
 	for _, item := range result {
-		id, ok := item["agent_id"].(string)
-		if !ok || id == "" {
+		identity, identityErr := dataSourceRequiredStringAt(item, "agent_id")
+		if identityErr != nil {
 			resp.Diagnostics.AddError("Invalid API Response", "/v1/agents returned an agent object without a valid agent_id.")
+			return
+		}
+		id := identity.ValueString()
+		for _, field := range []string{"tpm_limit", "rpm_limit", "session_tpm_limit", "session_rpm_limit"} {
+			if _, fieldErr := dataSourceNullableInt64At(item, field); fieldErr != nil {
+				resp.Diagnostics.AddError("Invalid API Response", "/v1/agents returned a malformed agent object.")
+				return
+			}
+		}
+		if _, fieldErr := dataSourceNullableFloat64At(item, "spend"); fieldErr != nil {
+			resp.Diagnostics.AddError("Invalid API Response", "/v1/agents returned a malformed agent object.")
 			return
 		}
 		projected, err := projectAgentData(item, id)
 		if err != nil {
 			resp.Diagnostics.AddError("Invalid API Response", "/v1/agents returned a malformed agent object.")
+			return
+		}
+		if err := dataSourceListIdentity(seen, id, "/v1/agents", "agent_id"); err != nil {
+			resp.Diagnostics.AddError("Invalid API Response", err.Error())
 			return
 		}
 		agents = append(agents, agentListItem(projected))

--- a/internal/provider/datasource_budget.go
+++ b/internal/provider/datasource_budget.go
@@ -102,26 +102,25 @@ func (d *BudgetDataSource) Configure(ctx context.Context, req datasource.Configu
 }
 
 func (d *BudgetDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
-	var data BudgetDataSourceModel
-
-	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	var config BudgetDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	budgetID := data.BudgetID.ValueString()
-
-	// /budget/info expects POST with budgets array
-	infoReq := map[string]interface{}{
-		"budgets": []string{budgetID},
+	budgetID := config.BudgetID.ValueString()
+	if config.BudgetID.IsNull() || config.BudgetID.IsUnknown() || budgetID == "" {
+		resp.Diagnostics.AddError("Invalid Budget Lookup", "budget_id must be known and nonempty")
+		return
 	}
+
+	// /budget/info expects POST with a budgets array.
+	infoReq := map[string]interface{}{"budgets": []string{budgetID}}
 
 	var results []map[string]interface{}
 	if err := d.client.DoRequestWithResponse(ctx, "POST", "/budget/info", infoReq, &results); err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read budget: %s", err))
 		return
 	}
-
 	if len(results) != 1 {
 		if len(results) == 0 {
 			resp.Diagnostics.AddError("Not Found", fmt.Sprintf("Budget not found: %s", budgetID))
@@ -130,52 +129,45 @@ func (d *BudgetDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 		}
 		return
 	}
-
 	result := results[0]
-	actualBudgetID, ok := result["budget_id"].(string)
-	if !ok || actualBudgetID == "" || actualBudgetID != budgetID {
+	actualBudgetID, err := dataSourceRequiredStringAt(result, "budget_id")
+	if err != nil || actualBudgetID.ValueString() != budgetID {
 		resp.Diagnostics.AddError("Invalid API Response", "Budget response identity did not match the requested budget.")
 		return
 	}
 
-	// Populate the data model
-	data.ID = types.StringValue(actualBudgetID)
-
-	for _, field := range []struct {
-		name   string
-		target *types.Float64
-	}{
-		{"max_budget", &data.MaxBudget},
-		{"soft_budget", &data.SoftBudget},
-	} {
-		if err := updateFloat64FromAPI(field.target, result, true, true, field.name); err != nil {
-			resp.Diagnostics.AddError("Invalid API Response", err.Error())
-			return
-		}
-	}
-	for _, field := range []struct {
-		name   string
-		target *types.Int64
-	}{
-		{"max_parallel_requests", &data.MaxParallelRequests},
-		{"tpm_limit", &data.TPMLimit},
-		{"rpm_limit", &data.RPMLimit},
-	} {
-		if err := updateInt64FromAPI(field.target, result, true, true, field.name); err != nil {
-			resp.Diagnostics.AddError("Invalid API Response", err.Error())
-			return
-		}
-	}
-	if budgetDuration, ok := result["budget_duration"].(string); ok {
-		data.BudgetDuration = types.StringValue(budgetDuration)
-	}
-	if budgetResetAt, ok := result["budget_reset_at"].(string); ok {
-		data.BudgetResetAt = types.StringValue(budgetResetAt)
-	}
-	if err := updateModelBudgetStringState(&data.ModelMaxBudget, result, "model_max_budget", true); err != nil {
+	data := BudgetDataSourceModel{ID: actualBudgetID, BudgetID: config.BudgetID}
+	if data.MaxBudget, err = dataSourceNullableFloat64At(result, "max_budget"); err != nil {
 		resp.Diagnostics.AddError("Invalid API Response", err.Error())
 		return
 	}
-
+	if data.SoftBudget, err = dataSourceNullableFloat64At(result, "soft_budget"); err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
+	}
+	if data.MaxParallelRequests, err = dataSourceNullableInt64At(result, "max_parallel_requests"); err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
+	}
+	if data.TPMLimit, err = dataSourceNullableInt64At(result, "tpm_limit"); err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
+	}
+	if data.RPMLimit, err = dataSourceNullableInt64At(result, "rpm_limit"); err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
+	}
+	if data.BudgetDuration, err = dataSourceNullableStringAt(result, "budget_duration"); err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
+	}
+	if data.BudgetResetAt, err = dataSourceNullableStringAt(result, "budget_reset_at"); err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
+	}
+	if data.ModelMaxBudget, err = dataSourceNullableCanonicalJSONObjectAt(result, "model_max_budget"); err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
+	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/provider/datasource_budgets_list.go
+++ b/internal/provider/datasource_budgets_list.go
@@ -127,11 +127,6 @@ func (d *BudgetsListDataSource) Configure(ctx context.Context, req datasource.Co
 func (d *BudgetsListDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	var data BudgetsListDataSourceModel
 
-	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
 	results, err := fetchTopLevelListObjects(ctx, d.client, "/budget/list", "budget item")
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to list budgets: %s", err))
@@ -139,13 +134,17 @@ func (d *BudgetsListDataSource) Read(ctx context.Context, req datasource.ReadReq
 	}
 
 	budgets := make([]BudgetListItemModel, 0, len(results))
+	seen := make(map[string]struct{}, len(results))
 	for _, result := range results {
 		budget := BudgetListItemModel{}
 
-		if budgetID, ok := result["budget_id"].(string); ok && budgetID != "" {
-			budget.BudgetID = types.StringValue(budgetID)
-		} else {
-			resp.Diagnostics.AddError("Invalid API Response", "/budget/list returned a budget object without budget_id")
+		budget.BudgetID, err = dataSourceRequiredStringAt(result, "budget_id")
+		if err != nil {
+			resp.Diagnostics.AddError("Invalid API Response", "/budget/list returned a budget object without a canonical budget_id")
+			return
+		}
+		if err := dataSourceListIdentity(seen, budget.BudgetID.ValueString(), "/budget/list", "budget_id"); err != nil {
+			resp.Diagnostics.AddError("Invalid API Response", err.Error())
 			return
 		}
 		for _, field := range []struct {
@@ -155,10 +154,12 @@ func (d *BudgetsListDataSource) Read(ctx context.Context, req datasource.ReadReq
 			{"max_budget", &budget.MaxBudget},
 			{"soft_budget", &budget.SoftBudget},
 		} {
-			if err := updateFloat64FromAPI(field.target, result, true, true, field.name); err != nil {
-				resp.Diagnostics.AddError("Invalid API Response", err.Error())
+			value, fieldErr := dataSourceNullableFloat64At(result, field.name)
+			if fieldErr != nil {
+				resp.Diagnostics.AddError("Invalid API Response", fieldErr.Error())
 				return
 			}
+			*field.target = value
 		}
 		for _, field := range []struct {
 			name   string
@@ -168,26 +169,32 @@ func (d *BudgetsListDataSource) Read(ctx context.Context, req datasource.ReadReq
 			{"tpm_limit", &budget.TPMLimit},
 			{"rpm_limit", &budget.RPMLimit},
 		} {
-			if err := updateInt64FromAPI(field.target, result, true, true, field.name); err != nil {
-				resp.Diagnostics.AddError("Invalid API Response", err.Error())
+			value, fieldErr := dataSourceNullableInt64At(result, field.name)
+			if fieldErr != nil {
+				resp.Diagnostics.AddError("Invalid API Response", fieldErr.Error())
 				return
 			}
+			*field.target = value
 		}
-		if budgetDuration, ok := result["budget_duration"].(string); ok {
-			budget.BudgetDuration = types.StringValue(budgetDuration)
+		for _, field := range []struct {
+			name   string
+			target *types.String
+		}{
+			{"budget_duration", &budget.BudgetDuration},
+			{"budget_reset_at", &budget.BudgetResetAt},
+			{"created_at", &budget.CreatedAt},
+			{"updated_at", &budget.UpdatedAt},
+		} {
+			value, fieldErr := dataSourceNullableStringAt(result, field.name)
+			if fieldErr != nil {
+				resp.Diagnostics.AddError("Invalid API Response", fieldErr.Error())
+				return
+			}
+			*field.target = value
 		}
 		if err := updateModelBudgetStringState(&budget.ModelMaxBudget, result, "model_max_budget", true); err != nil {
 			resp.Diagnostics.AddError("Invalid API Response", err.Error())
 			return
-		}
-		if value, ok := result["budget_reset_at"].(string); ok {
-			budget.BudgetResetAt = types.StringValue(value)
-		}
-		if value, ok := result["created_at"].(string); ok {
-			budget.CreatedAt = types.StringValue(value)
-		}
-		if value, ok := result["updated_at"].(string); ok {
-			budget.UpdatedAt = types.StringValue(value)
 		}
 
 		budgets = append(budgets, budget)

--- a/internal/provider/datasource_completion_protocol_test.go
+++ b/internal/provider/datasource_completion_protocol_test.go
@@ -1,0 +1,477 @@
+package provider
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// assertDataSourceReadComputedKnown is protocol-test-only. Call it after a
+// successful ReadDataSource RPC to enforce that every computed schema path is
+// known (a typed null is known). Collection element paths use [*], so failures
+// never disclose map keys, set values, IDs, URLs, response bodies, or secrets.
+func assertDataSourceReadComputedKnown(t testing.TB, schema *tfprotov6.Schema, response *tfprotov6.ReadDataSourceResponse) {
+	t.Helper()
+	if schema == nil || response == nil {
+		t.Fatal("data source completion assertion requires schema and response")
+	}
+	for _, diagnostic := range response.Diagnostics {
+		if diagnostic != nil && diagnostic.Severity == tfprotov6.DiagnosticSeverityError {
+			t.Fatal("data source completion assertion requires a successful Read")
+		}
+	}
+	if response.Deferred != nil {
+		t.Fatal("data source completion assertion requires a non-deferred Read")
+	}
+	if response.State == nil {
+		t.Fatal("successful data source Read returned no state")
+	}
+	value, err := response.State.Unmarshal(schema.ValueType())
+	if err != nil {
+		t.Fatal("successful data source Read returned state with an unexpected schema shape")
+	}
+	paths, err := dataSourceUnknownComputedPaths(schema, value)
+	if err != nil {
+		t.Fatalf("inspect successful data source state: %v", err)
+	}
+	if len(paths) != 0 {
+		t.Fatalf("successful data source Read left computed paths unknown: %s", strings.Join(paths, ", "))
+	}
+}
+
+func dataSourceUnknownComputedPaths(schema *tfprotov6.Schema, value tftypes.Value) ([]string, error) {
+	if schema == nil || schema.Block == nil {
+		return nil, fmt.Errorf("invalid data source schema: expected a root object")
+	}
+	paths, err := dataSourceUnknownComputedBlock(schema.Block, value, "")
+	if err != nil {
+		return nil, err
+	}
+	unique := make(map[string]struct{}, len(paths))
+	for _, path := range paths {
+		unique[path] = struct{}{}
+	}
+	paths = paths[:0]
+	for path := range unique {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	return paths, nil
+}
+
+func dataSourceUnknownComputedBlock(block *tfprotov6.SchemaBlock, value tftypes.Value, path string) ([]string, error) {
+	if !value.IsKnown() {
+		return dataSourceComputedPathsInBlock(block, path), nil
+	}
+	if value.IsNull() {
+		return nil, nil
+	}
+	attributes := map[string]tftypes.Value{}
+	if err := value.As(&attributes); err != nil {
+		return nil, dataSourceCompletionShapeError(path, "an object")
+	}
+
+	var paths []string
+	for _, attribute := range block.Attributes {
+		if attribute == nil {
+			continue
+		}
+		attributePath := dataSourceCompletionAttributePath(path, attribute.Name)
+		attributeValue, ok := attributes[attribute.Name]
+		if !ok {
+			return nil, dataSourceCompletionShapeError(attributePath, "a schema attribute")
+		}
+		if attribute.Computed {
+			unknown, err := dataSourceUnknownValuePaths(attributeValue, attributePath)
+			if err != nil {
+				return nil, err
+			}
+			paths = append(paths, unknown...)
+			if !attributeValue.IsKnown() {
+				continue
+			}
+		}
+		if attribute.NestedType == nil {
+			continue
+		}
+		if !attributeValue.IsKnown() {
+			paths = append(paths, dataSourceComputedPathsInObject(attribute.NestedType, attributePath)...)
+			continue
+		}
+		nested, err := dataSourceUnknownComputedObject(attribute.NestedType, attributeValue, attributePath)
+		if err != nil {
+			return nil, err
+		}
+		paths = append(paths, nested...)
+	}
+	for _, nestedBlock := range block.BlockTypes {
+		if nestedBlock == nil {
+			continue
+		}
+		blockPath := dataSourceCompletionAttributePath(path, nestedBlock.TypeName)
+		blockValue, ok := attributes[nestedBlock.TypeName]
+		if !ok {
+			return nil, dataSourceCompletionShapeError(blockPath, "a nested block")
+		}
+		if !blockValue.IsKnown() {
+			paths = append(paths, dataSourceComputedPathsInNestedBlock(nestedBlock, blockPath)...)
+			continue
+		}
+		nested, err := dataSourceUnknownComputedNestedBlock(nestedBlock, blockValue, blockPath)
+		if err != nil {
+			return nil, err
+		}
+		paths = append(paths, nested...)
+	}
+	return paths, nil
+}
+
+func dataSourceUnknownComputedObject(object *tfprotov6.SchemaObject, value tftypes.Value, path string) ([]string, error) {
+	if value.IsNull() {
+		return nil, nil
+	}
+	switch object.Nesting {
+	case tfprotov6.SchemaObjectNestingModeSingle:
+		return dataSourceUnknownComputedAttributes(object.Attributes, value, path)
+	case tfprotov6.SchemaObjectNestingModeList, tfprotov6.SchemaObjectNestingModeSet:
+		values := []tftypes.Value{}
+		if err := value.As(&values); err != nil {
+			return nil, dataSourceCompletionShapeError(path, "a collection")
+		}
+		return dataSourceUnknownComputedAttributeElements(object.Attributes, values, path+"[*]")
+	case tfprotov6.SchemaObjectNestingModeMap:
+		values := map[string]tftypes.Value{}
+		if err := value.As(&values); err != nil {
+			return nil, dataSourceCompletionShapeError(path, "a map")
+		}
+		var paths []string
+		for _, element := range values {
+			nested, err := dataSourceUnknownComputedAttributes(object.Attributes, element, path+"[*]")
+			if err != nil {
+				return nil, err
+			}
+			paths = append(paths, nested...)
+		}
+		return paths, nil
+	default:
+		return nil, dataSourceCompletionShapeError(path, "a supported nested object")
+	}
+}
+
+func dataSourceUnknownComputedNestedBlock(block *tfprotov6.SchemaNestedBlock, value tftypes.Value, path string) ([]string, error) {
+	if value.IsNull() {
+		return nil, nil
+	}
+	switch block.Nesting {
+	case tfprotov6.SchemaNestedBlockNestingModeSingle, tfprotov6.SchemaNestedBlockNestingModeGroup:
+		return dataSourceUnknownComputedBlock(block.Block, value, path)
+	case tfprotov6.SchemaNestedBlockNestingModeList, tfprotov6.SchemaNestedBlockNestingModeSet:
+		values := []tftypes.Value{}
+		if err := value.As(&values); err != nil {
+			return nil, dataSourceCompletionShapeError(path, "a collection")
+		}
+		var paths []string
+		for _, element := range values {
+			nested, err := dataSourceUnknownComputedBlock(block.Block, element, path+"[*]")
+			if err != nil {
+				return nil, err
+			}
+			paths = append(paths, nested...)
+		}
+		return paths, nil
+	case tfprotov6.SchemaNestedBlockNestingModeMap:
+		values := map[string]tftypes.Value{}
+		if err := value.As(&values); err != nil {
+			return nil, dataSourceCompletionShapeError(path, "a map")
+		}
+		var paths []string
+		for _, element := range values {
+			nested, err := dataSourceUnknownComputedBlock(block.Block, element, path+"[*]")
+			if err != nil {
+				return nil, err
+			}
+			paths = append(paths, nested...)
+		}
+		return paths, nil
+	default:
+		return nil, dataSourceCompletionShapeError(path, "a supported nested block")
+	}
+}
+
+func dataSourceUnknownComputedAttributes(attributes []*tfprotov6.SchemaAttribute, value tftypes.Value, path string) ([]string, error) {
+	if !value.IsKnown() {
+		return dataSourceComputedPathsInAttributes(attributes, path), nil
+	}
+	if value.IsNull() {
+		return nil, nil
+	}
+	values := map[string]tftypes.Value{}
+	if err := value.As(&values); err != nil {
+		return nil, dataSourceCompletionShapeError(path, "an object")
+	}
+	var paths []string
+	for _, attribute := range attributes {
+		if attribute == nil {
+			continue
+		}
+		attributePath := dataSourceCompletionAttributePath(path, attribute.Name)
+		attributeValue, ok := values[attribute.Name]
+		if !ok {
+			return nil, dataSourceCompletionShapeError(attributePath, "a schema attribute")
+		}
+		if attribute.Computed {
+			unknown, err := dataSourceUnknownValuePaths(attributeValue, attributePath)
+			if err != nil {
+				return nil, err
+			}
+			paths = append(paths, unknown...)
+			if !attributeValue.IsKnown() {
+				continue
+			}
+		}
+		if attribute.NestedType != nil {
+			if !attributeValue.IsKnown() {
+				paths = append(paths, dataSourceComputedPathsInObject(attribute.NestedType, attributePath)...)
+				continue
+			}
+			nested, err := dataSourceUnknownComputedObject(attribute.NestedType, attributeValue, attributePath)
+			if err != nil {
+				return nil, err
+			}
+			paths = append(paths, nested...)
+		}
+	}
+	return paths, nil
+}
+
+func dataSourceUnknownValuePaths(value tftypes.Value, path string) ([]string, error) {
+	if !value.IsKnown() {
+		return []string{path}, nil
+	}
+	if value.IsNull() {
+		return nil, nil
+	}
+	switch value.Type().(type) {
+	case tftypes.Object:
+		values := map[string]tftypes.Value{}
+		if err := value.As(&values); err != nil {
+			return nil, dataSourceCompletionShapeError(path, "an object")
+		}
+		var paths []string
+		for name, element := range values {
+			nested, err := dataSourceUnknownValuePaths(element, dataSourceCompletionAttributePath(path, name))
+			if err != nil {
+				return nil, err
+			}
+			paths = append(paths, nested...)
+		}
+		return paths, nil
+	case tftypes.Map:
+		values := map[string]tftypes.Value{}
+		if err := value.As(&values); err != nil {
+			return nil, dataSourceCompletionShapeError(path, "a map")
+		}
+		var paths []string
+		for _, element := range values {
+			nested, err := dataSourceUnknownValuePaths(element, path+"[*]")
+			if err != nil {
+				return nil, err
+			}
+			paths = append(paths, nested...)
+		}
+		return paths, nil
+	case tftypes.List, tftypes.Set, tftypes.Tuple:
+		values := []tftypes.Value{}
+		if err := value.As(&values); err != nil {
+			return nil, dataSourceCompletionShapeError(path, "a collection")
+		}
+		var paths []string
+		for _, element := range values {
+			nested, err := dataSourceUnknownValuePaths(element, path+"[*]")
+			if err != nil {
+				return nil, err
+			}
+			paths = append(paths, nested...)
+		}
+		return paths, nil
+	default:
+		return nil, nil
+	}
+}
+
+func dataSourceUnknownComputedAttributeElements(attributes []*tfprotov6.SchemaAttribute, values []tftypes.Value, path string) ([]string, error) {
+	var paths []string
+	for _, element := range values {
+		nested, err := dataSourceUnknownComputedAttributes(attributes, element, path)
+		if err != nil {
+			return nil, err
+		}
+		paths = append(paths, nested...)
+	}
+	return paths, nil
+}
+
+func dataSourceComputedPathsInBlock(block *tfprotov6.SchemaBlock, path string) []string {
+	if block == nil {
+		return nil
+	}
+	paths := dataSourceComputedPathsInAttributes(block.Attributes, path)
+	for _, nestedBlock := range block.BlockTypes {
+		if nestedBlock == nil {
+			continue
+		}
+		paths = append(paths, dataSourceComputedPathsInNestedBlock(nestedBlock, dataSourceCompletionAttributePath(path, nestedBlock.TypeName))...)
+	}
+	return paths
+}
+
+func dataSourceComputedPathsInAttributes(attributes []*tfprotov6.SchemaAttribute, path string) []string {
+	var paths []string
+	for _, attribute := range attributes {
+		if attribute == nil {
+			continue
+		}
+		attributePath := dataSourceCompletionAttributePath(path, attribute.Name)
+		if attribute.Computed {
+			paths = append(paths, attributePath)
+			continue
+		}
+		if attribute.NestedType != nil {
+			paths = append(paths, dataSourceComputedPathsInObject(attribute.NestedType, attributePath)...)
+		}
+	}
+	return paths
+}
+
+func dataSourceComputedPathsInObject(object *tfprotov6.SchemaObject, path string) []string {
+	if object == nil {
+		return nil
+	}
+	if object.Nesting != tfprotov6.SchemaObjectNestingModeSingle {
+		path += "[*]"
+	}
+	return dataSourceComputedPathsInAttributes(object.Attributes, path)
+}
+
+func dataSourceComputedPathsInNestedBlock(block *tfprotov6.SchemaNestedBlock, path string) []string {
+	if block == nil {
+		return nil
+	}
+	if block.Nesting != tfprotov6.SchemaNestedBlockNestingModeSingle && block.Nesting != tfprotov6.SchemaNestedBlockNestingModeGroup {
+		path += "[*]"
+	}
+	return dataSourceComputedPathsInBlock(block.Block, path)
+}
+
+func dataSourceCompletionAttributePath(parent, name string) string {
+	if parent == "" {
+		return name
+	}
+	return parent + "." + name
+}
+
+func dataSourceCompletionShapeError(path, expected string) error {
+	if path == "" {
+		return fmt.Errorf("invalid data source state at root: expected %s", expected)
+	}
+	return fmt.Errorf("invalid data source state at %q: expected %s", path, expected)
+}
+
+func TestDataSourceUnknownComputedPathsRecursesWithoutContent(t *testing.T) {
+	t.Parallel()
+
+	schema := dataSourceCompletionTestSchema()
+	value := dataSourceCompletionTestValue(t, schema, tftypes.UnknownValue)
+	paths, err := dataSourceUnknownComputedPaths(schema, value)
+	if err != nil {
+		t.Fatalf("completion paths: %v", err)
+	}
+	want := []string{"list[*].leaf", "map[*].leaf", "object.leaf", "scalar", "set[*].leaf"}
+	if strings.Join(paths, ",") != strings.Join(want, ",") {
+		t.Fatalf("unknown computed paths = %v, want %v", paths, want)
+	}
+	for _, forbidden := range []string{"private-map-key", "private-set-value", "private-list-value"} {
+		if strings.Contains(strings.Join(paths, ","), forbidden) {
+			t.Fatalf("computed path disclosed collection content %q", forbidden)
+		}
+	}
+}
+
+func TestDataSourceUnknownComputedPathsAcceptsTypedNullAndKnownEmpty(t *testing.T) {
+	t.Parallel()
+
+	schema := dataSourceCompletionTestSchema()
+	value := dataSourceCompletionTestValue(t, schema, nil)
+	paths, err := dataSourceUnknownComputedPaths(schema, value)
+	if err != nil {
+		t.Fatalf("completion paths: %v", err)
+	}
+	if len(paths) != 0 {
+		t.Fatalf("typed nulls or known empties reported unknown: %v", paths)
+	}
+
+	dynamic, err := tfprotov6.NewDynamicValue(schema.ValueType(), value)
+	if err != nil {
+		t.Fatalf("dynamic test value: %v", err)
+	}
+	assertDataSourceReadComputedKnown(t, schema, &tfprotov6.ReadDataSourceResponse{State: &dynamic})
+}
+
+func dataSourceCompletionTestSchema() *tfprotov6.Schema {
+	nested := func(nesting tfprotov6.SchemaObjectNestingMode) *tfprotov6.SchemaObject {
+		return &tfprotov6.SchemaObject{Nesting: nesting, Attributes: []*tfprotov6.SchemaAttribute{
+			{Name: "marker", Type: tftypes.String, Optional: true},
+			{Name: "leaf", Type: tftypes.String, Computed: true},
+		}}
+	}
+	return &tfprotov6.Schema{Block: &tfprotov6.SchemaBlock{Attributes: []*tfprotov6.SchemaAttribute{
+		{Name: "scalar", Type: tftypes.String, Computed: true},
+		{Name: "object", NestedType: nested(tfprotov6.SchemaObjectNestingModeSingle), Computed: true},
+		{Name: "list", NestedType: nested(tfprotov6.SchemaObjectNestingModeList), Computed: true},
+		{Name: "map", NestedType: nested(tfprotov6.SchemaObjectNestingModeMap), Computed: true},
+		{Name: "set", NestedType: nested(tfprotov6.SchemaObjectNestingModeSet), Computed: true},
+	}}}
+}
+
+func dataSourceCompletionTestValue(t *testing.T, schema *tfprotov6.Schema, leaf interface{}) tftypes.Value {
+	t.Helper()
+	rootType := schema.ValueType().(tftypes.Object)
+	leafValue := tftypes.NewValue(tftypes.String, leaf)
+	element := func(elementType tftypes.Type, marker string) tftypes.Value {
+		return tftypes.NewValue(elementType, map[string]tftypes.Value{
+			"marker": tftypes.NewValue(tftypes.String, marker),
+			"leaf":   leafValue,
+		})
+	}
+	objectType := rootType.AttributeTypes["object"].(tftypes.Object)
+	listType := rootType.AttributeTypes["list"].(tftypes.List)
+	mapType := rootType.AttributeTypes["map"].(tftypes.Map)
+	setType := rootType.AttributeTypes["set"].(tftypes.Set)
+
+	var scalar interface{} = leaf
+	var object interface{} = map[string]tftypes.Value{
+		"marker": tftypes.NewValue(tftypes.String, "private-object-value"),
+		"leaf":   leafValue,
+	}
+	var list interface{} = []tftypes.Value{element(listType.ElementType, "private-list-value")}
+	var mapped interface{} = map[string]tftypes.Value{"private-map-key": element(mapType.ElementType, "private-map-value")}
+	var set interface{} = []tftypes.Value{element(setType.ElementType, "private-set-value")}
+	if leaf == nil {
+		scalar = nil
+		object = nil
+		list = []tftypes.Value{}
+		mapped = map[string]tftypes.Value{}
+		set = []tftypes.Value{}
+	}
+	return tftypes.NewValue(rootType, map[string]tftypes.Value{
+		"scalar": tftypes.NewValue(tftypes.String, scalar),
+		"object": tftypes.NewValue(objectType, object),
+		"list":   tftypes.NewValue(listType, list),
+		"map":    tftypes.NewValue(mapType, mapped),
+		"set":    tftypes.NewValue(setType, set),
+	})
+}

--- a/internal/provider/datasource_guardrails_list.go
+++ b/internal/provider/datasource_guardrails_list.go
@@ -165,9 +165,13 @@ func fetchGuardrailListItems(ctx context.Context, client *Client) ([]GuardrailLi
 		return nil, err
 	}
 	guardrails := make([]GuardrailListItemModel, 0, len(results))
+	seen := make(map[string]struct{}, len(results))
 	for _, result := range results {
 		guardrail, err := guardrailListItemFromAPI(result)
 		if err != nil {
+			return nil, err
+		}
+		if err := dataSourceListIdentity(seen, guardrail.GuardrailID.ValueString(), endpoint, "guardrail_id"); err != nil {
 			return nil, err
 		}
 		guardrails = append(guardrails, guardrail)
@@ -177,11 +181,6 @@ func fetchGuardrailListItems(ctx context.Context, client *Client) ([]GuardrailLi
 
 func (d *GuardrailsListDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	var data GuardrailsListDataSourceModel
-
-	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 
 	guardrails, err := fetchGuardrailListItems(ctx, d.client)
 	if err != nil {

--- a/internal/provider/datasource_key.go
+++ b/internal/provider/datasource_key.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/datasourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
-	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -207,6 +206,7 @@ func (d *KeyDataSource) Read(ctx context.Context, req datasource.ReadRequest, re
 		resp.Diagnostics.AddError("Invalid Key Lookup", err.Error())
 		return
 	}
+
 	query := url.Values{"key": []string{lookupValue}}
 	endpoint := endpointWithQuery("/key/info", query)
 
@@ -216,131 +216,155 @@ func (d *KeyDataSource) Read(ctx context.Context, req datasource.ReadRequest, re
 		return
 	}
 
-	// The /key/info endpoint may return key data nested inside "info"
+	actualKey, err := dataSourceRequiredStringAt(result, "key")
+	if err != nil || actualKey.ValueString() != lookupValue {
+		resp.Diagnostics.AddError("Invalid API Response", "Key response identity did not match the requested key.")
+		return
+	}
 	info := result
-	if nested, ok := result["info"].(map[string]interface{}); ok {
-		info = nested
-	}
-
-	// Never copy the sensitive raw key into the non-sensitive data source ID.
-	data.ID = types.StringValue(managementID)
-
-	// Update fields from response
-	if keyAlias, ok := info["key_alias"].(string); ok {
-		data.KeyAlias = types.StringValue(keyAlias)
-	}
-	if userID, ok := info["user_id"].(string); ok {
-		data.UserID = types.StringValue(userID)
-	}
-	if teamID, ok := info["team_id"].(string); ok {
-		data.TeamID = types.StringValue(teamID)
-	}
-	if projectID, ok := info["project_id"].(string); ok {
-		data.ProjectID = types.StringValue(projectID)
-	}
-	if budgetDuration, ok := info["budget_duration"].(string); ok {
-		data.BudgetDuration = types.StringValue(budgetDuration)
-	}
-
-	// max_budget belongs to the v1.98 verification-token row; soft_budget
-	// belongs to the budget relation. Retain the opposite locations only as
-	// historical compatibility fallbacks.
-	if err := updateFloat64FromAPIPaths(&data.MaxBudget, info, true, true,
-		[]string{"max_budget"},
-		[]string{"litellm_budget_table", "max_budget"},
-	); err != nil {
-		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+	if raw, presence, infoErr := apiValueAt(result, "info"); infoErr != nil {
+		resp.Diagnostics.AddError("Invalid API Response", infoErr.Error())
 		return
-	}
-	if err := updateFloat64FromAPIPaths(&data.SoftBudget, info, true, true,
-		[]string{"litellm_budget_table", "soft_budget"},
-		[]string{"soft_budget"},
-	); err != nil {
-		resp.Diagnostics.AddError("Invalid API Response", err.Error())
-		return
-	}
-	if err := updateFloat64FromAPI(&data.Spend, info, true, true, "spend"); err != nil {
-		resp.Diagnostics.AddError("Invalid API Response", err.Error())
-		return
-	}
-	for _, field := range []struct {
-		name   string
-		target *types.Int64
-	}{
-		{"max_parallel_requests", &data.MaxParallelRequests},
-		{"tpm_limit", &data.TPMLimit},
-		{"rpm_limit", &data.RPMLimit},
-	} {
-		if err := updateInt64FromAPI(field.target, info, true, true, field.name); err != nil {
-			resp.Diagnostics.AddError("Invalid API Response", err.Error())
+	} else if presence == apiValuePresent {
+		var ok bool
+		info, ok = raw.(map[string]interface{})
+		if !ok {
+			resp.Diagnostics.AddError("Invalid API Response", dataSourceShapeError([]string{"info"}, "an object or null").Error())
 			return
 		}
 	}
 
-	// Boolean fields
-	if blocked, ok := info["blocked"].(bool); ok {
-		data.Blocked = types.BoolValue(blocked)
-	} else {
-		data.Blocked = types.BoolValue(false)
+	complete := KeyDataSourceModel{
+		ID:      types.StringValue(managementID),
+		Key:     data.Key,
+		KeyHash: data.KeyHash,
 	}
-
-	// Handle models list
-	if models, ok := info["models"].([]interface{}); ok {
-		modelsList := make([]attr.Value, len(models))
-		for i, m := range models {
-			if str, ok := m.(string); ok {
-				modelsList[i] = types.StringValue(str)
-			}
-		}
-		data.Models, _ = types.ListValue(types.StringType, modelsList)
-	} else {
-		data.Models, _ = types.ListValue(types.StringType, []attr.Value{})
+	if complete.KeyAlias, err = dataSourceRoleRedactedNullableStringAt(info, "key_alias"); err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
 	}
-
-	// Handle tags list.
-	// LiteLLM stores tags inside metadata["tags"] rather than as a top-level field in /key/info,
-	// so we check both locations.
-	var rawTags []interface{}
-	if tags, ok := info["tags"].([]interface{}); ok {
-		rawTags = tags
-	} else if metadata, ok := info["metadata"].(map[string]interface{}); ok {
-		if tags, ok := metadata["tags"].([]interface{}); ok {
-			rawTags = tags
-		}
+	if complete.UserID, err = dataSourceRoleRedactedNullableStringAt(info, "user_id"); err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
 	}
-	if len(rawTags) > 0 {
-		tagsList := make([]attr.Value, 0, len(rawTags))
-		for _, t := range rawTags {
-			if str, ok := t.(string); ok {
-				tagsList = append(tagsList, types.StringValue(str))
-			}
-		}
-		data.Tags, _ = types.ListValue(types.StringType, tagsList)
-	} else {
-		data.Tags, _ = types.ListValue(types.StringType, []attr.Value{})
+	if complete.TeamID, err = dataSourceRoleRedactedNullableStringAt(info, "team_id"); err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
 	}
-
-	if routerSettings, present, err := keyRouterSettingsFromAPI(info["router_settings"], types.ObjectNull(keyRouterSettingsAttrTypes)); err != nil {
+	if complete.ProjectID, err = dataSourceRoleRedactedNullableStringAt(info, "project_id"); err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
+	}
+	if complete.BudgetDuration, err = dataSourceRoleRedactedNullableStringAt(info, "budget_duration"); err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
+	}
+	if complete.Models, err = dataSourceRoleRedactedNullableStringListAt(info, "models"); err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
+	}
+	if complete.MaxBudget, err = keyDataSourceNullableFloat64AtPaths(info,
+		[]string{"max_budget"}, []string{"litellm_budget_table", "max_budget"}); err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
+	}
+	if complete.SoftBudget, err = keyDataSourceNullableFloat64AtPaths(info,
+		[]string{"litellm_budget_table", "soft_budget"}, []string{"soft_budget"}); err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
+	}
+	if complete.Spend, err = dataSourceRoleRedactedNullableFloat64At(info, "spend"); err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
+	}
+	if complete.MaxParallelRequests, err = dataSourceRoleRedactedNullableInt64At(info, "max_parallel_requests"); err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
+	}
+	if complete.TPMLimit, err = dataSourceRoleRedactedNullableInt64At(info, "tpm_limit"); err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
+	}
+	if complete.RPMLimit, err = dataSourceRoleRedactedNullableInt64At(info, "rpm_limit"); err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
+	}
+	if complete.Blocked, err = dataSourceRoleRedactedNullableBoolAt(info, "blocked"); err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
+	}
+	if complete.Tags, complete.Metadata, err = keyDataSourceCollections(info); err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
+	}
+	if complete.RouterSettings, _, err = keyRouterSettingsFromAPI(info["router_settings"], types.ObjectNull(keyRouterSettingsAttrTypes)); err != nil {
 		resp.Diagnostics.AddError("Router Settings Read Error", err.Error())
 		return
-	} else if present {
-		data.RouterSettings = routerSettings
-	} else {
-		data.RouterSettings = types.ObjectNull(keyRouterSettingsAttrTypes)
 	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &complete)...)
+}
 
-	// Handle metadata map
-	if metadata, ok := info["metadata"].(map[string]interface{}); ok {
-		metaMap := make(map[string]attr.Value)
-		for k, v := range metadata {
-			if str, ok := v.(string); ok {
-				metaMap[k] = types.StringValue(str)
-			}
+func keyDataSourceNullableFloat64AtPaths(object map[string]interface{}, paths ...[]string) (types.Float64, error) {
+	selected, err := firstAPIFieldPath(object, paths...)
+	if err != nil {
+		return types.Float64Null(), err
+	}
+	if selected == nil {
+		return types.Float64Null(), nil
+	}
+	return dataSourceNullableFloat64At(object, selected...)
+}
+
+func keyDataSourceCollections(info map[string]interface{}) (types.List, types.Map, error) {
+	metadataRaw, metadataPresence, err := apiValueAt(info, "metadata")
+	if err != nil {
+		return types.ListNull(types.StringType), types.MapNull(types.StringType), err
+	}
+	var metadataObject map[string]interface{}
+	if metadataPresence == apiValuePresent {
+		var ok bool
+		metadataObject, ok = metadataRaw.(map[string]interface{})
+		if !ok {
+			return types.ListNull(types.StringType), types.MapNull(types.StringType), dataSourceShapeError([]string{"metadata"}, "an object of strings or null")
 		}
-		data.Metadata, _ = types.MapValue(types.StringType, metaMap)
-	} else {
-		data.Metadata, _ = types.MapValue(types.StringType, map[string]attr.Value{})
 	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	// LiteLLM stores tags in metadata while historical versions also projected
+	// them at the top level. Validate both locations before applying the
+	// top-level compatibility precedence.
+	metadataTags := types.ListNull(types.StringType)
+	if metadataPresence == apiValuePresent {
+		metadataTags, err = dataSourceNullableStringListAt(info, "metadata", "tags")
+		if err != nil {
+			return types.ListNull(types.StringType), types.MapNull(types.StringType), err
+		}
+	}
+	_, topTagsPresence, err := apiValueAt(info, "tags")
+	if err != nil {
+		return types.ListNull(types.StringType), types.MapNull(types.StringType), err
+	}
+	tags := metadataTags
+	if topTagsPresence != apiValueAbsent {
+		tags, err = dataSourceNullableStringListAt(info, "tags")
+		if err != nil {
+			return types.ListNull(types.StringType), types.MapNull(types.StringType), err
+		}
+	}
+
+	if metadataPresence != apiValuePresent {
+		metadata, mapErr := dataSourceNullableStringMapAt(info, "metadata")
+		return tags, metadata, mapErr
+	}
+	projected := make(map[string]interface{}, len(metadataObject))
+	for key, value := range metadataObject {
+		if key != "tags" {
+			projected[key] = value
+		}
+	}
+	wrapper := map[string]interface{}{"metadata": projected}
+	metadata, err := dataSourceNullableStringMapAt(wrapper, "metadata")
+	if err != nil {
+		return types.ListNull(types.StringType), types.MapNull(types.StringType), err
+	}
+	return tags, metadata, nil
 }

--- a/internal/provider/datasource_keys_list.go
+++ b/internal/provider/datasource_keys_list.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -138,7 +139,8 @@ func (d *KeysListDataSource) Configure(ctx context.Context, req datasource.Confi
 func (d *KeysListDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	var data KeysListDataSourceModel
 
-	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("team_id"), &data.TeamID)...)
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("user_id"), &data.UserID)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -252,22 +254,24 @@ func decodeKeyListItem(raw json.RawMessage) (KeyListItem, error) {
 	// LiteLLM v1.98 key_name includes a raw-token suffix. Never read it into
 	// Terraform state; token is the endpoint's hash-only management identity.
 	item.KeyName = types.StringValue(canonicalHash)
-	if keyAlias, ok := keyMap["key_alias"].(string); ok {
-		item.KeyAlias = types.StringValue(keyAlias)
-	}
-	if userID, ok := keyMap["user_id"].(string); ok {
-		item.UserID = types.StringValue(userID)
-	}
-	if teamID, ok := keyMap["team_id"].(string); ok {
-		item.TeamID = types.StringValue(teamID)
-	}
-	if err := updateFloat64FromAPIPaths(&item.MaxBudget, keyMap, true, true,
-		[]string{"max_budget"},
-		[]string{"litellm_budget_table", "max_budget"},
-	); err != nil {
+	if item.KeyAlias, err = dataSourceNullableStringAt(keyMap, "key_alias"); err != nil {
 		return KeyListItem{}, err
 	}
-	if err := updateFloat64FromAPI(&item.Spend, keyMap, true, true, "spend"); err != nil {
+	if item.UserID, err = dataSourceNullableStringAt(keyMap, "user_id"); err != nil {
+		return KeyListItem{}, err
+	}
+	if item.TeamID, err = dataSourceNullableStringAt(keyMap, "team_id"); err != nil {
+		return KeyListItem{}, err
+	}
+	item.MaxBudget, err = dataSourceNullableFloat64AtPaths(keyMap,
+		[]string{"max_budget"},
+		[]string{"litellm_budget_table", "max_budget"},
+	)
+	if err != nil {
+		return KeyListItem{}, err
+	}
+	item.Spend, err = dataSourceNullableFloat64At(keyMap, "spend")
+	if err != nil {
 		return KeyListItem{}, err
 	}
 	for _, field := range []struct {
@@ -277,12 +281,22 @@ func decodeKeyListItem(raw json.RawMessage) (KeyListItem, error) {
 		{"tpm_limit", &item.TPMLimit},
 		{"rpm_limit", &item.RPMLimit},
 	} {
-		if err := updateInt64FromAPI(field.target, keyMap, true, true, field.name); err != nil {
-			return KeyListItem{}, err
+		value, fieldErr := dataSourceNullableInt64At(keyMap, field.name)
+		if fieldErr != nil {
+			return KeyListItem{}, fieldErr
 		}
+		*field.target = value
 	}
-	if blocked, ok := keyMap["blocked"].(bool); ok {
-		item.Blocked = types.BoolValue(blocked)
+	if rawBlocked, exists := keyMap["blocked"]; exists {
+		if rawBlocked == nil {
+			item.Blocked = types.BoolNull()
+		} else {
+			blocked, ok := rawBlocked.(bool)
+			if !ok {
+				return KeyListItem{}, dataSourceShapeError([]string{"blocked"}, "a boolean or null")
+			}
+			item.Blocked = types.BoolValue(blocked)
+		}
 	}
 	return item, nil
 }

--- a/internal/provider/datasource_keys_list.go
+++ b/internal/provider/datasource_keys_list.go
@@ -144,6 +144,12 @@ func (d *KeysListDataSource) Read(ctx context.Context, req datasource.ReadReques
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	for name, value := range map[string]types.String{"team_id": data.TeamID, "user_id": data.UserID} {
+		if err := validateOptionalStringFilter(name, value); err != nil {
+			resp.Diagnostics.AddError("Invalid Key List Filter", err.Error())
+			return
+		}
+	}
 
 	filters := keyListFilters(data.TeamID, data.UserID)
 
@@ -238,14 +244,14 @@ func decodeKeyListItem(raw json.RawMessage) (KeyListItem, error) {
 		if !ok {
 			return KeyListItem{}, fmt.Errorf("/key/list returned a key string without a valid SHA256 management hash")
 		}
-		return KeyListItem{KeyName: types.StringValue(canonicalHash), Blocked: types.BoolValue(false)}, nil
+		return KeyListItem{KeyName: types.StringValue(canonicalHash), Blocked: types.BoolNull()}, nil
 	}
 
 	keyMap, err := decodeListObject(trimmed, "/key/list", "key item")
 	if err != nil {
 		return KeyListItem{}, err
 	}
-	item := KeyListItem{Blocked: types.BoolValue(false)}
+	item := KeyListItem{Blocked: types.BoolNull()}
 	token, ok := keyMap["token"].(string)
 	canonicalHash, validHash := canonicalSHA256ManagementHash(token)
 	if !ok || !validHash {

--- a/internal/provider/datasource_list_presence_protocol_test.go
+++ b/internal/provider/datasource_list_presence_protocol_test.go
@@ -1,0 +1,178 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+type listPresenceCase struct {
+	name, typeName, path, listField, nullField string
+	empty, item, malformed                     string
+}
+
+func listPresenceCases() []listPresenceCase {
+	hash := strings.Repeat("a", 64)
+	mappingID := "11111111-1111-4111-8111-111111111111"
+	return []listPresenceCase{
+		{name: "access_groups", typeName: "litellm_access_groups", path: "/access_group/list", listField: "access_groups", nullField: "model_names", empty: `{"access_groups":[]}`, item: `{"access_group":"presence-access","model_names":null}`, malformed: `{"access_group":"presence-access-bad","model_names":["ok",1]}`},
+		{name: "agents", typeName: "litellm_agents", path: "/v1/agents", listField: "agents", nullField: "created_at", empty: `[]`, item: `{"agent_id":"presence-agent","agent_name":"agent"}`, malformed: `{"agent_id":"presence-agent-bad","agent_name":"agent","created_at":false}`},
+		{name: "budgets", typeName: "litellm_budgets", path: "/budget/list", listField: "budgets", nullField: "max_budget", empty: `[]`, item: `{"budget_id":"presence-budget","max_budget":null}`, malformed: `{"budget_id":"presence-budget-bad","max_budget":"0"}`},
+		{name: "guardrails", typeName: "litellm_guardrails", path: "/v2/guardrails/list", listField: "guardrails", nullField: "default_on", empty: `{"guardrails":[]}`, item: `{"guardrail_id":"presence-guardrail","guardrail_name":"guardrail","litellm_params":{"guardrail":"integration","mode":"pre_call","default_on":null}}`, malformed: `{"guardrail_id":"presence-guardrail-bad","guardrail_name":"guardrail","litellm_params":{"guardrail":"integration","mode":"pre_call","default_on":"false"}}`},
+		{name: "jwt_key_mappings", typeName: "litellm_jwt_key_mappings", path: jwtKeyMappingListPath, listField: "mappings", nullField: "description", empty: `{"mappings":[],"total_count":0,"current_page":1,"total_pages":0}`, item: fmt.Sprintf(`{"id":%q,"jwt_claim_name":"sub","jwt_claim_value":"value","description":null,"is_active":false,"created_at":"2026-08-26T00:00:00Z","updated_at":"2026-08-26T00:01:00Z"}`, mappingID), malformed: fmt.Sprintf(`{"id":%q,"jwt_claim_name":"sub","jwt_claim_value":"value","description":false,"is_active":false,"created_at":"2026-08-26T00:00:00Z","updated_at":"2026-08-26T00:01:00Z"}`, "22222222-2222-4222-8222-222222222222")},
+		{name: "keys", typeName: "litellm_keys", path: "/key/list", listField: "keys", nullField: "key_alias", empty: `{"keys":[],"total_count":0,"current_page":1,"total_pages":0}`, item: fmt.Sprintf(`{"token":%q,"key_alias":null}`, hash), malformed: fmt.Sprintf(`{"token":%q,"key_alias":false}`, strings.Repeat("b", 64))},
+		{name: "models", typeName: "litellm_models", path: "/model/info", listField: "models", nullField: "base_model", empty: `{"data":[]}`, item: `{"model_name":null,"litellm_params":null,"model_info":{"id":"presence-model","base_model":null}}`, malformed: `{"model_info":{"id":"presence-model-bad","base_model":false}}`},
+		{name: "organizations", typeName: "litellm_organizations", path: "/organization/list", listField: "organizations", nullField: "organization_alias", empty: `[]`, item: `{"organization_id":"presence-org","organization_alias":null}`, malformed: `{"organization_id":"presence-org-bad","organization_alias":false}`},
+		{name: "projects", typeName: "litellm_projects", path: "/project/list", listField: "projects", nullField: "project_alias", empty: `[]`, item: `{"project_id":"presence-project","project_alias":null}`, malformed: `{"project_id":"presence-project-bad","project_alias":false}`},
+		{name: "prompts", typeName: "litellm_prompts", path: "/prompts/list", listField: "prompts", nullField: "api_base", empty: `{"prompts":[]}`, item: `{"prompt_id":"presence-prompt","litellm_params":{"prompt_integration":"provider","api_base":null},"prompt_info":null}`, malformed: `{"prompt_id":"presence-prompt-bad","litellm_params":{"prompt_integration":"provider","api_base":false}}`},
+		{name: "search_tools", typeName: "litellm_search_tools", path: "/search_tools/list", listField: "search_tools", nullField: "api_base", empty: `{"search_tools":[]}`, item: `{"search_tool_id":"presence-search","search_tool_name":"search","litellm_params":{"api_base":null}}`, malformed: `{"search_tool_id":"presence-search-bad","search_tool_name":"search","litellm_params":{"api_base":false}}`},
+		{name: "tags", typeName: "litellm_tags", path: "/tag/list", listField: "tags", nullField: "models", empty: `[]`, item: `{"name":"presence-tag","models":null}`, malformed: `{"name":"presence-tag-bad","models":["ok",1]}`},
+		{name: "unified_access_groups", typeName: "litellm_unified_access_groups", path: "/v1/access_group", listField: "access_groups", nullField: "access_group_name", empty: `[]`, item: `{"access_group_id":"presence-unified","access_group_name":null}`, malformed: `{"access_group_id":"presence-unified-bad","access_group_name":false}`},
+		{name: "users", typeName: "litellm_users", path: "/user/list", listField: "users", nullField: "user_alias", empty: `{"users":[],"total":0,"page":1,"page_size":100,"total_pages":0}`, item: `{"user_id":"presence-user","user_alias":null}`, malformed: `{"user_id":"presence-user-bad","user_alias":false}`},
+	}
+}
+
+func (test listPresenceCase) response(mode string) string {
+	if mode == "empty" {
+		return test.empty
+	}
+	if mode == "wrong_envelope" {
+		switch test.name {
+		case "agents", "budgets", "organizations", "projects", "tags", "unified_access_groups":
+			return `{"items":[]}`
+		default:
+			return `[]`
+		}
+	}
+	items := []string{test.item}
+	if mode == "duplicate" {
+		items = append(items, test.item)
+	}
+	if mode == "malformed" {
+		items = append(items, test.malformed)
+	}
+	joined := strings.Join(items, ",")
+	switch test.name {
+	case "access_groups":
+		return `{"access_groups":[` + joined + `]}`
+	case "guardrails":
+		return `{"guardrails":[` + joined + `]}`
+	case "jwt_key_mappings":
+		return fmt.Sprintf(`{"mappings":[%s],"total_count":%d,"current_page":1,"total_pages":1}`, joined, len(items))
+	case "keys":
+		return fmt.Sprintf(`{"keys":[%s],"total_count":%d,"current_page":1,"total_pages":1}`, joined, len(items))
+	case "models":
+		return `{"data":[` + joined + `]}`
+	case "prompts":
+		return `{"prompts":[` + joined + `]}`
+	case "search_tools":
+		return `{"search_tools":[` + joined + `]}`
+	case "users":
+		return fmt.Sprintf(`{"users":[%s],"total":%d,"page":1,"page_size":100,"total_pages":1}`, joined, len(items))
+	default:
+		return `[` + joined + `]`
+	}
+}
+
+func TestRegisteredListDataSourcesPresenceProtocol(t *testing.T) {
+	// Team and MCP list/source files are intentionally reserved for the #217
+	// and #215 rebases. Credential and vector-store have no registered list
+	// data source on this baseline. Every other registered list is covered.
+	reserved := map[string]string{
+		"litellm_teams":       "#217",
+		"litellm_mcp_servers": "#215",
+	}
+	cases := listPresenceCases()
+	covered := make(map[string]struct{}, len(cases))
+	for _, test := range cases {
+		covered[test.typeName] = struct{}{}
+	}
+	for _, typeName := range []string{
+		"litellm_models", "litellm_keys", "litellm_teams", "litellm_organizations", "litellm_users", "litellm_budgets", "litellm_tags",
+		"litellm_access_groups", "litellm_unified_access_groups", "litellm_prompts", "litellm_guardrails", "litellm_mcp_servers",
+		"litellm_search_tools", "litellm_agents", "litellm_projects", "litellm_jwt_key_mappings",
+	} {
+		if _, ok := covered[typeName]; !ok {
+			if _, reservedForRebase := reserved[typeName]; !reservedForRebase {
+				t.Fatalf("registered list data source %s lacks presence protocol coverage", typeName)
+			}
+		}
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			var mode atomic.Value
+			mode.Store("empty")
+			httpServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				if request.URL.Path != test.path {
+					http.NotFound(writer, request)
+					return
+				}
+				writer.Header().Set("Content-Type", "application/json")
+				_, _ = fmt.Fprint(writer, test.response(mode.Load().(string)))
+			}))
+			defer httpServer.Close()
+			server, schemas := configuredImportProtocolServer(t, ctx, httpServer.URL)
+			schema := schemas.DataSourceSchemas[test.typeName]
+			config := singularPresenceConfig(t, schema, map[string]interface{}{})
+
+			mode.Store("empty")
+			empty, err := server.ReadDataSource(ctx, &tfprotov6.ReadDataSourceRequest{TypeName: test.typeName, Config: config})
+			if err != nil || accessGroupProtocolDiagnosticsHaveError(empty.Diagnostics) {
+				t.Fatalf("empty list read: err=%v diagnostics=%v", err, empty.Diagnostics)
+			}
+			assertDataSourceReadComputedKnown(t, schema, empty)
+			assertProtocolListLength(t, schema, empty.State, test.listField, 0)
+
+			mode.Store("null")
+			nullRead, err := server.ReadDataSource(ctx, &tfprotov6.ReadDataSourceRequest{TypeName: test.typeName, Config: config})
+			if err != nil || accessGroupProtocolDiagnosticsHaveError(nullRead.Diagnostics) {
+				t.Fatalf("nullable list item read: err=%v diagnostics=%v", err, nullRead.Diagnostics)
+			}
+			assertDataSourceReadComputedKnown(t, schema, nullRead)
+			assertProtocolListItemNull(t, schema, nullRead.State, test.listField, test.nullField)
+
+			for _, failureMode := range []string{"duplicate", "malformed", "wrong_envelope"} {
+				mode.Store(failureMode)
+				failed, err := server.ReadDataSource(ctx, &tfprotov6.ReadDataSourceRequest{TypeName: test.typeName, Config: config})
+				if err != nil || !accessGroupProtocolDiagnosticsHaveError(failed.Diagnostics) {
+					t.Fatalf("%s response accepted: err=%v diagnostics=%v", failureMode, err, failed.Diagnostics)
+				}
+				assertSingularPresenceStateUnchanged(t, schema, config, failed.State)
+			}
+		})
+	}
+}
+
+func assertProtocolListLength(t *testing.T, schema *tfprotov6.Schema, state *tfprotov6.DynamicValue, field string, want int) {
+	t.Helper()
+	attributes := protocolAttributeMap(t, schema, state)
+	var values []tftypes.Value
+	if err := attributes[field].As(&values); err != nil || len(values) != want {
+		t.Fatalf("%s length=%d want=%d err=%v", field, len(values), want, err)
+	}
+}
+
+func assertProtocolListItemNull(t *testing.T, schema *tfprotov6.Schema, state *tfprotov6.DynamicValue, listField, nullField string) {
+	t.Helper()
+	attributes := protocolAttributeMap(t, schema, state)
+	var values []tftypes.Value
+	if err := attributes[listField].As(&values); err != nil || len(values) != 1 {
+		t.Fatalf("decode %s item: len=%d err=%v", listField, len(values), err)
+	}
+	var item map[string]tftypes.Value
+	if err := values[0].As(&item); err != nil {
+		t.Fatalf("decode %s element: %v", listField, err)
+	}
+	if value, ok := item[nullField]; !ok || !value.IsKnown() || !value.IsNull() {
+		t.Fatalf("%s[*].%s was not a known typed null: %v", listField, nullField, value)
+	}
+}

--- a/internal/provider/datasource_mcp_presence_protocol_test.go
+++ b/internal/provider/datasource_mcp_presence_protocol_test.go
@@ -1,0 +1,247 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+const mcpDataSourceV198Item = `{
+	"server_id":"presence-mcp",
+	"server_name":"",
+	"alias":null,
+	"description":"server",
+	"url":"",
+	"spec_path":null,
+	"transport":"http",
+	"auth_type":"none",
+	"mcp_access_groups":[],
+	"mcp_info":{"access":false,"nested":[9007199254740993,null]},
+	"command":null,
+	"args":[],
+	"env":{},
+	"allowed_tools":["search"],
+	"extra_headers":[],
+	"static_headers":{},
+	"authorization_url":"",
+	"token_url":null,
+	"registration_url":"",
+	"allow_all_keys":false,
+	"created_at":null,
+	"created_by":"",
+	"updated_at":"2026-08-26T00:00:00Z",
+	"updated_by":null,
+	"status":"unknown",
+	"last_health_check":null,
+	"health_check_error":""
+}`
+
+func TestMCPDataSourcesCompleteEveryComputedPathProtocol(t *testing.T) {
+	ctx := context.Background()
+	var mode atomic.Value
+	mode.Store("valid")
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		item := mcpDataSourceV198Item
+		switch mode.Load().(string) {
+		case "minimal":
+			item = `{"server_id":"presence-mcp","transport":"stdio"}`
+		case "masked":
+			item = `{"server_id":"presence-mcp","transport":"http","mcp_info":{"is_public":true}}`
+		case "null":
+			item = `{"server_id":"presence-mcp","transport":"http","server_name":null,"mcp_access_groups":null,"args":null,"env":null,"allowed_tools":null,"extra_headers":null,"static_headers":null,"allow_all_keys":null,"mcp_info":null}`
+		case "empty":
+			if request.URL.Path == "/v1/mcp/server" {
+				_, _ = writer.Write([]byte(`[]`))
+				return
+			}
+		}
+		if request.URL.Path == "/v1/mcp/server" {
+			_, _ = fmt.Fprintf(writer, "[%s]", item)
+			return
+		}
+		if request.URL.Path == "/v1/mcp/server/presence-mcp" {
+			_, _ = writer.Write([]byte(item))
+			return
+		}
+		http.NotFound(writer, request)
+	}))
+	defer server.Close()
+
+	protocolServer, schemas := configuredImportProtocolServer(t, ctx, server.URL)
+	singleSchema := schemas.DataSourceSchemas["litellm_mcp_server"]
+	listSchema := schemas.DataSourceSchemas["litellm_mcp_servers"]
+	singleConfig := singularPresenceConfig(t, singleSchema, map[string]interface{}{"server_id": "presence-mcp"})
+	listConfig := singularPresenceConfig(t, listSchema, map[string]interface{}{})
+
+	for _, readMode := range []string{"valid", "minimal", "null", "masked"} {
+		t.Run(readMode, func(t *testing.T) {
+			mode.Store(readMode)
+			single, err := protocolServer.ReadDataSource(ctx, &tfprotov6.ReadDataSourceRequest{TypeName: "litellm_mcp_server", Config: singleConfig})
+			if err != nil || accessGroupProtocolDiagnosticsHaveError(single.Diagnostics) {
+				t.Fatalf("singular read: err=%v diagnostics=%v", err, single.Diagnostics)
+			}
+			assertDataSourceReadComputedKnown(t, singleSchema, single)
+
+			list, err := protocolServer.ReadDataSource(ctx, &tfprotov6.ReadDataSourceRequest{TypeName: "litellm_mcp_servers", Config: listConfig})
+			if err != nil || accessGroupProtocolDiagnosticsHaveError(list.Diagnostics) {
+				t.Fatalf("list read: err=%v diagnostics=%s", err, agentProtocolDiagnosticsText(list.Diagnostics))
+			}
+			assertDataSourceReadComputedKnown(t, listSchema, list)
+			assertProtocolListLength(t, listSchema, list.State, "mcp_servers", 1)
+
+			singleAttributes := protocolAttributeMap(t, singleSchema, single.State)
+			listItem := mcpProtocolListItem(t, listSchema, list.State)
+			switch readMode {
+			case "valid":
+				assertMCPProtocolFalse(t, singleAttributes["allow_all_keys"])
+				assertMCPProtocolFalse(t, listItem["allow_all_keys"])
+				for _, field := range []string{"mcp_access_groups", "args", "env", "extra_headers", "static_headers"} {
+					assertMCPProtocolEmptyCollection(t, singleAttributes[field])
+				}
+				for name, value := range map[string]tftypes.Value{
+					"singular": singleAttributes["mcp_info_json"],
+					"list":     listItem["mcp_info_json"],
+				} {
+					var document string
+					if err := value.As(&document); err != nil || document != `{"access":false,"nested":[9007199254740993,null]}` {
+						t.Fatalf("%s mcp_info_json=%q err=%v", name, document, err)
+					}
+				}
+			case "minimal", "null":
+				for _, field := range []string{"server_name", "mcp_access_groups", "args", "env", "allow_all_keys", "mcp_info_json"} {
+					if value := singleAttributes[field]; !value.IsKnown() || !value.IsNull() {
+						t.Fatalf("%s was not a known typed null: %v", field, value)
+					}
+				}
+			case "masked":
+				if !singleAttributes["mcp_info_json"].IsNull() || !listItem["mcp_info_json"].IsNull() {
+					t.Fatal("restricted mcp_info singleton became incomplete authority")
+				}
+			}
+		})
+	}
+
+	mode.Store("empty")
+	empty, err := protocolServer.ReadDataSource(ctx, &tfprotov6.ReadDataSourceRequest{TypeName: "litellm_mcp_servers", Config: listConfig})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(empty.Diagnostics) {
+		t.Fatalf("empty list read: err=%v diagnostics=%s", err, agentProtocolDiagnosticsText(empty.Diagnostics))
+	}
+	assertDataSourceReadComputedKnown(t, listSchema, empty)
+	assertProtocolListLength(t, listSchema, empty.State, "mcp_servers", 0)
+}
+
+func TestMCPDataSourcesRejectMalformedResponsesAtomicallyProtocol(t *testing.T) {
+	ctx := context.Background()
+	const secret = "response-secret-mcp"
+	var mode atomic.Value
+	mode.Store("wrong_identity")
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		valid := mcpDataSourceV198Item
+		var payload string
+		switch mode.Load().(string) {
+		case "wrong_identity":
+			payload = `{"server_id":"` + secret + `","transport":"http"}`
+		case "single_wrong_root":
+			payload = `[{"server_id":"presence-mcp","transport":"http"}]`
+		case "single_late_nested":
+			payload = `{"server_id":"presence-mcp","transport":"http","allowed_tools":["valid",false]}`
+		case "list_wrong_root":
+			payload = `{}`
+		case "list_wrong_element":
+			payload = `[` + valid + `,false]`
+		case "list_duplicate":
+			payload = `[` + valid + `,` + valid + `]`
+		case "list_late_nested":
+			payload = `[` + valid + `,{"server_id":"late-mcp","transport":"http","static_headers":{"valid":"value","invalid":false}}]`
+		default:
+			t.Fatalf("unsupported test mode %q", mode.Load().(string))
+		}
+		_, _ = writer.Write([]byte(payload))
+	}))
+	defer server.Close()
+
+	protocolServer, schemas := configuredImportProtocolServer(t, ctx, server.URL)
+	singleSchema := schemas.DataSourceSchemas["litellm_mcp_server"]
+	listSchema := schemas.DataSourceSchemas["litellm_mcp_servers"]
+	singleConfig := singularPresenceConfig(t, singleSchema, map[string]interface{}{"server_id": "presence-mcp"})
+	listConfig := singularPresenceConfig(t, listSchema, map[string]interface{}{})
+
+	for _, failureMode := range []string{"wrong_identity", "single_wrong_root", "single_late_nested"} {
+		mode.Store(failureMode)
+		failed, err := protocolServer.ReadDataSource(ctx, &tfprotov6.ReadDataSourceRequest{TypeName: "litellm_mcp_server", Config: singleConfig})
+		if err != nil || !accessGroupProtocolDiagnosticsHaveError(failed.Diagnostics) {
+			t.Fatalf("%s accepted: err=%v diagnostics=%v", failureMode, err, failed.Diagnostics)
+		}
+		assertSingularPresenceStateUnchanged(t, singleSchema, singleConfig, failed.State)
+		assertMCPDiagnosticsContentSafe(t, failed.Diagnostics, secret)
+	}
+	for _, failureMode := range []string{"list_wrong_root", "list_wrong_element", "list_duplicate", "list_late_nested"} {
+		mode.Store(failureMode)
+		failed, err := protocolServer.ReadDataSource(ctx, &tfprotov6.ReadDataSourceRequest{TypeName: "litellm_mcp_servers", Config: listConfig})
+		if err != nil || !accessGroupProtocolDiagnosticsHaveError(failed.Diagnostics) {
+			t.Fatalf("%s accepted: err=%v diagnostics=%v", failureMode, err, failed.Diagnostics)
+		}
+		assertSingularPresenceStateUnchanged(t, listSchema, listConfig, failed.State)
+		assertMCPDiagnosticsContentSafe(t, failed.Diagnostics, secret)
+	}
+}
+
+func mcpProtocolListItem(t *testing.T, schema *tfprotov6.Schema, state *tfprotov6.DynamicValue) map[string]tftypes.Value {
+	t.Helper()
+	var items []tftypes.Value
+	if err := protocolAttributeMap(t, schema, state)["mcp_servers"].As(&items); err != nil || len(items) != 1 {
+		t.Fatalf("decode MCP server list: len=%d err=%v", len(items), err)
+	}
+	item := map[string]tftypes.Value{}
+	if err := items[0].As(&item); err != nil {
+		t.Fatal(err)
+	}
+	return item
+}
+
+func assertMCPProtocolFalse(t *testing.T, value tftypes.Value) {
+	t.Helper()
+	var actual bool
+	if err := value.As(&actual); err != nil || actual {
+		t.Fatalf("value was not known false: value=%v err=%v", value, err)
+	}
+}
+
+func assertMCPProtocolEmptyCollection(t *testing.T, value tftypes.Value) {
+	t.Helper()
+	if !value.IsKnown() || value.IsNull() {
+		t.Fatalf("empty collection was not known: %v", value)
+	}
+	switch value.Type().(type) {
+	case tftypes.List, tftypes.Set, tftypes.Tuple:
+		var values []tftypes.Value
+		if err := value.As(&values); err != nil || len(values) != 0 {
+			t.Fatalf("collection was not empty: len=%d err=%v", len(values), err)
+		}
+	case tftypes.Map, tftypes.Object:
+		var values map[string]tftypes.Value
+		if err := value.As(&values); err != nil || len(values) != 0 {
+			t.Fatalf("collection was not empty: len=%d err=%v", len(values), err)
+		}
+	default:
+		t.Fatalf("unexpected collection type %T", value.Type())
+	}
+}
+
+func assertMCPDiagnosticsContentSafe(t *testing.T, diagnostics []*tfprotov6.Diagnostic, forbidden string) {
+	t.Helper()
+	for _, diagnostic := range diagnostics {
+		if diagnostic != nil && (strings.Contains(diagnostic.Summary, forbidden) || strings.Contains(diagnostic.Detail, forbidden)) {
+			t.Fatalf("diagnostic disclosed response content: %#v", diagnostic)
+		}
+	}
+}

--- a/internal/provider/datasource_mcp_presence_test.go
+++ b/internal/provider/datasource_mcp_presence_test.go
@@ -1,0 +1,126 @@
+package provider
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestProjectMCPServerDataSourceV198Presence(t *testing.T) {
+	t.Parallel()
+
+	response := map[string]interface{}{
+		"server_id":          "presence-mcp",
+		"server_name":        "",
+		"alias":              nil,
+		"description":        "server",
+		"url":                "",
+		"spec_path":          nil,
+		"transport":          "http",
+		"auth_type":          "none",
+		"mcp_access_groups":  []interface{}{},
+		"mcp_info":           map[string]interface{}{"access": false, "nested": []interface{}{json.Number("9007199254740993"), nil}},
+		"command":            nil,
+		"args":               []interface{}{},
+		"env":                map[string]interface{}{},
+		"allowed_tools":      []interface{}{"search"},
+		"extra_headers":      []interface{}{},
+		"static_headers":     map[string]interface{}{},
+		"authorization_url":  "",
+		"token_url":          nil,
+		"registration_url":   "",
+		"allow_all_keys":     false,
+		"created_at":         nil,
+		"created_by":         "",
+		"updated_at":         "2026-08-26T00:00:00Z",
+		"updated_by":         nil,
+		"status":             "unknown",
+		"last_health_check":  nil,
+		"health_check_error": "",
+	}
+	state, err := projectMCPServerDataSource(response, "presence-mcp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.ID.ValueString() != "presence-mcp" || state.ServerID.ValueString() != "presence-mcp" || state.Transport.ValueString() != "http" {
+		t.Fatal("required identity or transport was not projected exactly")
+	}
+	if state.ServerName.IsNull() || state.ServerName.ValueString() != "" || !state.Alias.IsNull() {
+		t.Fatal("empty and null strings were collapsed")
+	}
+	if state.AllowAllKeys.IsNull() || state.AllowAllKeys.ValueBool() {
+		t.Fatal("explicit false was not projected as known false")
+	}
+	for name, value := range map[string]interface {
+		IsNull() bool
+		IsUnknown() bool
+	}{
+		"mcp_access_groups": state.MCPAccessGroups,
+		"args":              state.Args,
+		"env":               state.Env,
+		"extra_headers":     state.ExtraHeaders,
+		"static_headers":    state.StaticHeaders,
+	} {
+		if value.IsNull() || value.IsUnknown() {
+			t.Fatalf("explicit empty %s was not known", name)
+		}
+	}
+	if got := state.MCPInfoJSON.ValueString(); got != `{"access":false,"nested":[9007199254740993,null]}` {
+		t.Fatalf("mcp_info_json = %q", got)
+	}
+	if !state.SpecVersion.IsNull() || state.SpecVersion.IsUnknown() {
+		t.Fatal("unreturned compatibility field was not a typed null")
+	}
+}
+
+func TestProjectMCPServerDataSourceNullableAbsenceAndMasking(t *testing.T) {
+	t.Parallel()
+
+	for name, response := range map[string]map[string]interface{}{
+		"absent":               {"server_id": "presence-mcp", "transport": "stdio"},
+		"null":                 {"server_id": "presence-mcp", "transport": "stdio", "server_name": nil, "mcp_access_groups": nil, "args": nil, "env": nil, "allow_all_keys": nil, "mcp_info": nil},
+		"restricted singleton": {"server_id": "presence-mcp", "transport": "stdio", "mcp_info": map[string]interface{}{"is_public": true}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			state, err := projectMCPServerDataSource(response, "presence-mcp")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !state.ServerName.IsNull() || !state.MCPAccessGroups.IsNull() || !state.Args.IsNull() || !state.Env.IsNull() || !state.AllowAllKeys.IsNull() || !state.MCPInfoJSON.IsNull() {
+				t.Fatal("nullable absence or masking did not resolve to typed nulls")
+			}
+		})
+	}
+
+	state, err := projectMCPServerDataSource(map[string]interface{}{
+		"server_id": "presence-mcp", "transport": "stdio", "mcp_info": map[string]interface{}{"is_public": false},
+	}, "presence-mcp")
+	if err != nil || state.MCPInfoJSON.ValueString() != `{"is_public":false}` {
+		t.Fatalf("complete is_public object was masked: value=%q err=%v", state.MCPInfoJSON.ValueString(), err)
+	}
+}
+
+func TestProjectMCPServerDataSourceRejectsMalformedShapes(t *testing.T) {
+	t.Parallel()
+
+	secret := "response-secret-mcp"
+	tests := map[string]map[string]interface{}{
+		"wrong identity":        {"server_id": secret, "transport": "http"},
+		"missing identity":      {"transport": "http"},
+		"wrong transport type":  {"server_id": "presence-mcp", "transport": false},
+		"wrong transport value": {"server_id": "presence-mcp", "transport": "websocket"},
+		"wrong scalar":          {"server_id": "presence-mcp", "transport": "http", "description": false},
+		"wrong boolean":         {"server_id": "presence-mcp", "transport": "http", "allow_all_keys": "false"},
+		"wrong list root":       {"server_id": "presence-mcp", "transport": "http", "args": map[string]interface{}{}},
+		"late list element":     {"server_id": "presence-mcp", "transport": "http", "allowed_tools": []interface{}{"valid", false}},
+		"wrong map root":        {"server_id": "presence-mcp", "transport": "http", "env": []interface{}{}},
+		"late map element":      {"server_id": "presence-mcp", "transport": "http", "static_headers": map[string]interface{}{"valid": "value", "invalid": false}},
+		"wrong mcp info root":   {"server_id": "presence-mcp", "transport": "http", "mcp_info": []interface{}{secret}},
+	}
+	for name, response := range tests {
+		t.Run(name, func(t *testing.T) {
+			if _, err := projectMCPServerDataSource(response, "presence-mcp"); err == nil {
+				t.Fatal("malformed MCP response was accepted")
+			}
+		})
+	}
+}

--- a/internal/provider/datasource_mcp_server.go
+++ b/internal/provider/datasource_mcp_server.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -206,193 +205,141 @@ func (d *MCPServerDataSource) Configure(ctx context.Context, req datasource.Conf
 }
 
 func (d *MCPServerDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
-	var data MCPServerDataSourceModel
-
-	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	var config MCPServerDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	if config.ServerID.IsNull() || config.ServerID.IsUnknown() || config.ServerID.ValueString() == "" {
+		resp.Diagnostics.AddError("Invalid Data Source Configuration", "The MCP server lookup requires a known nonempty server_id.")
+		return
+	}
 
-	serverID := data.ServerID.ValueString()
-	endpoint := mcpServerEndpoint(serverID)
-
+	serverID := config.ServerID.ValueString()
 	var result map[string]interface{}
-	if err := d.client.DoRequestWithResponse(ctx, "GET", endpoint, nil, &result); err != nil {
+	if err := d.client.DoRequestWithResponse(ctx, "GET", mcpServerEndpoint(serverID), nil, &result); err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read MCP server: %s", err))
 		return
 	}
-	if err := validateMCPServerResponse(result, serverID); err != nil {
+
+	data, err := projectMCPServerDataSource(result, serverID)
+	if err != nil {
 		resp.Diagnostics.AddError("Invalid API Response", "LiteLLM returned a malformed MCP server response.")
 		return
 	}
-	mcpInfo, mcpInfoPresence, err := mcpInfoDocumentFromResponse(result)
-	if err != nil {
-		resp.Diagnostics.AddError("Invalid API Response", "LiteLLM returned a malformed non-object MCP info value.")
-		return
-	}
-	if mcpInfoPresence == apiValuePresent {
-		canonical, err := canonicalMCPInfoJSONObject(mcpInfo)
-		if err != nil {
-			resp.Diagnostics.AddError("Invalid API Response", "LiteLLM returned MCP info that could not be represented safely.")
-			return
-		}
-		data.MCPInfoJSON = types.StringValue(canonical)
-	} else {
-		data.MCPInfoJSON = types.StringNull()
-	}
-	if err := validateMCPServerOptionalResponseFields(
-		result,
-		[]string{"server_name", "alias", "description", "url", "spec_path", "auth_type", "command", "created_at", "created_by", "updated_at", "updated_by", "status", "last_health_check", "health_check_error", "authorization_url", "token_url", "registration_url"},
-		[]string{"allow_all_keys"},
-		[]string{"mcp_access_groups", "args", "allowed_tools", "extra_headers"},
-		[]string{"env", "static_headers"},
-	); err != nil {
-		resp.Diagnostics.AddError("Invalid API Response", "LiteLLM returned malformed optional MCP server fields.")
-		return
-	}
-
-	// Update fields from response
-	if sid, ok := result["server_id"].(string); ok {
-		data.ServerID = types.StringValue(sid)
-		data.ID = types.StringValue(sid)
-	}
-	if serverName, ok := result["server_name"].(string); ok {
-		data.ServerName = types.StringValue(serverName)
-	}
-	if alias, ok := result["alias"].(string); ok {
-		data.Alias = types.StringValue(alias)
-	}
-	if desc, ok := result["description"].(string); ok {
-		data.Description = types.StringValue(desc)
-	}
-	if remoteURL, ok := result["url"].(string); ok {
-		data.URL = types.StringValue(remoteURL)
-	}
-	if specPath, ok := result["spec_path"].(string); ok {
-		data.SpecPath = types.StringValue(specPath)
-	}
-	if transport, ok := result["transport"].(string); ok {
-		data.Transport = types.StringValue(transport)
-	}
-	if authType, ok := result["auth_type"].(string); ok {
-		data.AuthType = types.StringValue(authType)
-	}
-	if command, ok := result["command"].(string); ok {
-		data.Command = types.StringValue(command)
-	}
-	if createdAt, ok := result["created_at"].(string); ok {
-		data.CreatedAt = types.StringValue(createdAt)
-	}
-	if createdBy, ok := result["created_by"].(string); ok {
-		data.CreatedBy = types.StringValue(createdBy)
-	}
-	if updatedAt, ok := result["updated_at"].(string); ok {
-		data.UpdatedAt = types.StringValue(updatedAt)
-	}
-	if updatedBy, ok := result["updated_by"].(string); ok {
-		data.UpdatedBy = types.StringValue(updatedBy)
-	}
-	if status, ok := result["status"].(string); ok {
-		data.Status = types.StringValue(status)
-	}
-	if lastHealthCheck, ok := result["last_health_check"].(string); ok {
-		data.LastHealthCheck = types.StringValue(lastHealthCheck)
-	}
-	if healthCheckError, ok := result["health_check_error"].(string); ok {
-		data.HealthCheckError = types.StringValue(healthCheckError)
-	}
-
-	// Handle access groups
-	if accessGroups, ok := result["mcp_access_groups"].([]interface{}); ok {
-		groups := make([]attr.Value, len(accessGroups))
-		for i, g := range accessGroups {
-			if str, ok := g.(string); ok {
-				groups[i] = types.StringValue(str)
-			}
-		}
-		data.MCPAccessGroups, _ = types.ListValue(types.StringType, groups)
-	} else {
-		data.MCPAccessGroups, _ = types.ListValue(types.StringType, []attr.Value{})
-	}
-
-	// Handle args
-	if args, ok := result["args"].([]interface{}); ok {
-		argsList := make([]attr.Value, len(args))
-		for i, a := range args {
-			if str, ok := a.(string); ok {
-				argsList[i] = types.StringValue(str)
-			}
-		}
-		data.Args, _ = types.ListValue(types.StringType, argsList)
-	} else {
-		data.Args, _ = types.ListValue(types.StringType, []attr.Value{})
-	}
-
-	// Handle env
-	if env, ok := result["env"].(map[string]interface{}); ok {
-		envMap := make(map[string]attr.Value)
-		for k, v := range env {
-			if str, ok := v.(string); ok {
-				envMap[k] = types.StringValue(str)
-			}
-		}
-		data.Env, _ = types.MapValue(types.StringType, envMap)
-	} else {
-		data.Env, _ = types.MapValue(types.StringType, map[string]attr.Value{})
-	}
-
-	// Handle allowed_tools
-	if allowedTools, ok := result["allowed_tools"].([]interface{}); ok {
-		tools := make([]attr.Value, len(allowedTools))
-		for i, t := range allowedTools {
-			if str, ok := t.(string); ok {
-				tools[i] = types.StringValue(str)
-			}
-		}
-		data.AllowedTools, _ = types.ListValue(types.StringType, tools)
-	} else {
-		data.AllowedTools, _ = types.ListValue(types.StringType, []attr.Value{})
-	}
-
-	// Handle extra_headers
-	if extraHeaders, ok := result["extra_headers"].([]interface{}); ok {
-		headers := make([]attr.Value, 0, len(extraHeaders))
-		for _, v := range extraHeaders {
-			if str, ok := v.(string); ok {
-				headers = append(headers, types.StringValue(str))
-			}
-		}
-		data.ExtraHeaders, _ = types.ListValue(types.StringType, headers)
-	} else {
-		data.ExtraHeaders, _ = types.ListValue(types.StringType, []attr.Value{})
-	}
-
-	// Handle static_headers
-	if staticHeaders, ok := result["static_headers"].(map[string]interface{}); ok {
-		headersMap := make(map[string]attr.Value)
-		for k, v := range staticHeaders {
-			if str, ok := v.(string); ok {
-				headersMap[k] = types.StringValue(str)
-			}
-		}
-		data.StaticHeaders, _ = types.MapValue(types.StringType, headersMap)
-	} else {
-		data.StaticHeaders, _ = types.MapValue(types.StringType, map[string]attr.Value{})
-	}
-
-	// Handle OAuth URLs
-	if authURL, ok := result["authorization_url"].(string); ok {
-		data.AuthorizationURL = types.StringValue(authURL)
-	}
-	if tokenURL, ok := result["token_url"].(string); ok {
-		data.TokenURL = types.StringValue(tokenURL)
-	}
-	if regURL, ok := result["registration_url"].(string); ok {
-		data.RegistrationURL = types.StringValue(regURL)
-	}
-	if allowAllKeys, ok := result["allow_all_keys"].(bool); ok {
-		data.AllowAllKeys = types.BoolValue(allowAllKeys)
-	}
-
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func projectMCPServerDataSource(result map[string]interface{}, expectedServerID string) (MCPServerDataSourceModel, error) {
+	var data MCPServerDataSourceModel
+	serverID, err := dataSourceRequiredStringAt(result, "server_id")
+	if err != nil || serverID.ValueString() != expectedServerID {
+		return data, fmt.Errorf("MCP server response identity mismatch")
+	}
+	transport, err := dataSourceRequiredStringAt(result, "transport")
+	if err != nil || !mcpDataSourceTransportValid(transport.ValueString()) {
+		return data, fmt.Errorf("MCP server response transport is invalid")
+	}
+
+	data.ID = serverID
+	data.ServerID = serverID
+	data.Transport = transport
+	data.SpecVersion = types.StringNull()
+	if data.ServerName, err = dataSourceNullableStringAt(result, "server_name"); err != nil {
+		return MCPServerDataSourceModel{}, err
+	}
+	if data.Alias, err = dataSourceNullableStringAt(result, "alias"); err != nil {
+		return MCPServerDataSourceModel{}, err
+	}
+	if data.Description, err = dataSourceNullableStringAt(result, "description"); err != nil {
+		return MCPServerDataSourceModel{}, err
+	}
+	if data.URL, err = dataSourceNullableStringAt(result, "url"); err != nil {
+		return MCPServerDataSourceModel{}, err
+	}
+	if data.SpecPath, err = dataSourceNullableStringAt(result, "spec_path"); err != nil {
+		return MCPServerDataSourceModel{}, err
+	}
+	if data.AuthType, err = dataSourceNullableStringAt(result, "auth_type"); err != nil {
+		return MCPServerDataSourceModel{}, err
+	}
+	if data.MCPAccessGroups, err = dataSourceNullableStringListAt(result, "mcp_access_groups"); err != nil {
+		return MCPServerDataSourceModel{}, err
+	}
+	if data.MCPInfoJSON, err = mcpInfoDataSourceValue(result); err != nil {
+		return MCPServerDataSourceModel{}, err
+	}
+	if data.Command, err = dataSourceNullableStringAt(result, "command"); err != nil {
+		return MCPServerDataSourceModel{}, err
+	}
+	if data.Args, err = dataSourceNullableStringListAt(result, "args"); err != nil {
+		return MCPServerDataSourceModel{}, err
+	}
+	if data.Env, err = dataSourceNullableStringMapAt(result, "env"); err != nil {
+		return MCPServerDataSourceModel{}, err
+	}
+	if data.AllowedTools, err = dataSourceNullableStringListAt(result, "allowed_tools"); err != nil {
+		return MCPServerDataSourceModel{}, err
+	}
+	if data.ExtraHeaders, err = dataSourceNullableStringListAt(result, "extra_headers"); err != nil {
+		return MCPServerDataSourceModel{}, err
+	}
+	if data.StaticHeaders, err = dataSourceNullableStringMapAt(result, "static_headers"); err != nil {
+		return MCPServerDataSourceModel{}, err
+	}
+	if data.AuthorizationURL, err = dataSourceNullableStringAt(result, "authorization_url"); err != nil {
+		return MCPServerDataSourceModel{}, err
+	}
+	if data.TokenURL, err = dataSourceNullableStringAt(result, "token_url"); err != nil {
+		return MCPServerDataSourceModel{}, err
+	}
+	if data.RegistrationURL, err = dataSourceNullableStringAt(result, "registration_url"); err != nil {
+		return MCPServerDataSourceModel{}, err
+	}
+	if data.AllowAllKeys, err = dataSourceNullableBoolAt(result, "allow_all_keys"); err != nil {
+		return MCPServerDataSourceModel{}, err
+	}
+	if data.CreatedAt, err = dataSourceNullableStringAt(result, "created_at"); err != nil {
+		return MCPServerDataSourceModel{}, err
+	}
+	if data.CreatedBy, err = dataSourceNullableStringAt(result, "created_by"); err != nil {
+		return MCPServerDataSourceModel{}, err
+	}
+	if data.UpdatedAt, err = dataSourceNullableStringAt(result, "updated_at"); err != nil {
+		return MCPServerDataSourceModel{}, err
+	}
+	if data.UpdatedBy, err = dataSourceNullableStringAt(result, "updated_by"); err != nil {
+		return MCPServerDataSourceModel{}, err
+	}
+	if data.Status, err = dataSourceNullableStringAt(result, "status"); err != nil {
+		return MCPServerDataSourceModel{}, err
+	}
+	if data.LastHealthCheck, err = dataSourceNullableStringAt(result, "last_health_check"); err != nil {
+		return MCPServerDataSourceModel{}, err
+	}
+	if data.HealthCheckError, err = dataSourceNullableStringAt(result, "health_check_error"); err != nil {
+		return MCPServerDataSourceModel{}, err
+	}
+	return data, nil
+}
+
+func mcpInfoDataSourceValue(result map[string]interface{}) (types.String, error) {
+	document, presence, err := mcpInfoDocumentFromResponse(result)
+	if err != nil || presence != apiValuePresent {
+		return types.StringNull(), err
+	}
+	canonical, err := canonicalMCPInfoJSONObject(document)
+	if err != nil {
+		return types.StringNull(), err
+	}
+	return types.StringValue(canonical), nil
+}
+
+func mcpDataSourceTransportValid(transport string) bool {
+	for _, allowed := range mcpTransportsV198 {
+		if transport == allowed {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/provider/datasource_mcp_servers_list.go
+++ b/internal/provider/datasource_mcp_servers_list.go
@@ -142,13 +142,6 @@ func (d *MCPServersListDataSource) Configure(ctx context.Context, req datasource
 }
 
 func (d *MCPServersListDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
-	var data MCPServersListDataSourceModel
-
-	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
 	const endpoint = "/v1/mcp/server"
 	result, err := fetchTopLevelListObjects(ctx, d.client, endpoint, "MCP server item")
 	if err != nil {
@@ -156,74 +149,38 @@ func (d *MCPServersListDataSource) Read(ctx context.Context, req datasource.Read
 		return
 	}
 
-	data.ID = types.StringValue("mcp_servers")
-	data.MCPServers = make([]MCPServerListItem, 0, len(result))
+	data := MCPServersListDataSourceModel{
+		ID:         types.StringValue("mcp_servers"),
+		MCPServers: make([]MCPServerListItem, 0, len(result)),
+	}
+	seen := make(map[string]struct{}, len(result))
 	for _, serverMap := range result {
-		serverID, ok := serverMap["server_id"].(string)
-		if !ok || serverID == "" || validateMCPServerResponse(serverMap, serverID) != nil {
-			resp.Diagnostics.AddError("Invalid API Response", "LiteLLM returned a malformed MCP server object.")
+		serverID, identityErr := dataSourceRequiredStringAt(serverMap, "server_id")
+		if identityErr != nil || dataSourceListIdentity(seen, serverID.ValueString(), endpoint, "server_id") != nil {
+			resp.Diagnostics.AddError("Invalid API Response", "LiteLLM returned a malformed MCP server list.")
 			return
 		}
-		if err := validateMCPServerOptionalResponseFields(
-			serverMap,
-			[]string{"server_name", "alias", "description", "url", "spec_path", "auth_type", "status", "created_at", "updated_at"},
-			[]string{"allow_all_keys"},
-			nil,
-			nil,
-		); err != nil {
-			resp.Diagnostics.AddError("Invalid API Response", "LiteLLM returned malformed optional MCP server fields.")
+		server, projectionErr := projectMCPServerDataSource(serverMap, serverID.ValueString())
+		if projectionErr != nil {
+			resp.Diagnostics.AddError("Invalid API Response", "LiteLLM returned a malformed MCP server list.")
 			return
 		}
-
-		item := MCPServerListItem{ServerID: types.StringValue(serverID), MCPInfoJSON: types.StringNull()}
-		mcpInfo, presence, err := mcpInfoDocumentFromResponse(serverMap)
-		if err != nil {
-			resp.Diagnostics.AddError("Invalid API Response", "LiteLLM returned a malformed non-object MCP info value.")
-			return
-		}
-		if presence == apiValuePresent {
-			canonical, err := canonicalMCPInfoJSONObject(mcpInfo)
-			if err != nil {
-				resp.Diagnostics.AddError("Invalid API Response", "LiteLLM returned MCP info that could not be represented safely.")
-				return
-			}
-			item.MCPInfoJSON = types.StringValue(canonical)
-		}
-		if serverName, ok := serverMap["server_name"].(string); ok {
-			item.ServerName = types.StringValue(serverName)
-		}
-		if alias, ok := serverMap["alias"].(string); ok {
-			item.Alias = types.StringValue(alias)
-		}
-		if desc, ok := serverMap["description"].(string); ok {
-			item.Description = types.StringValue(desc)
-		}
-		if remoteURL, ok := serverMap["url"].(string); ok {
-			item.URL = types.StringValue(remoteURL)
-		}
-		if specPath, ok := serverMap["spec_path"].(string); ok {
-			item.SpecPath = types.StringValue(specPath)
-		}
-		if transport, ok := serverMap["transport"].(string); ok {
-			item.Transport = types.StringValue(transport)
-		}
-		if authType, ok := serverMap["auth_type"].(string); ok {
-			item.AuthType = types.StringValue(authType)
-		}
-		if status, ok := serverMap["status"].(string); ok {
-			item.Status = types.StringValue(status)
-		}
-		if allowAllKeys, ok := serverMap["allow_all_keys"].(bool); ok {
-			item.AllowAllKeys = types.BoolValue(allowAllKeys)
-		}
-		if createdAt, ok := serverMap["created_at"].(string); ok {
-			item.CreatedAt = types.StringValue(createdAt)
-		}
-		if updatedAt, ok := serverMap["updated_at"].(string); ok {
-			item.UpdatedAt = types.StringValue(updatedAt)
-		}
-
-		data.MCPServers = append(data.MCPServers, item)
+		data.MCPServers = append(data.MCPServers, MCPServerListItem{
+			ServerID:     server.ServerID,
+			ServerName:   server.ServerName,
+			Alias:        server.Alias,
+			Description:  server.Description,
+			URL:          server.URL,
+			SpecPath:     server.SpecPath,
+			Transport:    server.Transport,
+			SpecVersion:  server.SpecVersion,
+			AuthType:     server.AuthType,
+			MCPInfoJSON:  server.MCPInfoJSON,
+			Status:       server.Status,
+			AllowAllKeys: server.AllowAllKeys,
+			CreatedAt:    server.CreatedAt,
+			UpdatedAt:    server.UpdatedAt,
+		})
 	}
 	sort.SliceStable(data.MCPServers, func(i, j int) bool {
 		return data.MCPServers[i].ServerID.ValueString() < data.MCPServers[j].ServerID.ValueString()

--- a/internal/provider/datasource_model.go
+++ b/internal/provider/datasource_model.go
@@ -119,122 +119,153 @@ func (d *ModelDataSource) Configure(ctx context.Context, req datasource.Configur
 }
 
 func (d *ModelDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
-	var data ModelDataSourceModel
-
-	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	var config ModelDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	modelID := data.ModelID.ValueString()
-	query := url.Values{"litellm_model_id": []string{modelID}}
-	endpoint := endpointWithQuery("/model/info", query)
-
+	modelID := config.ModelID.ValueString()
+	if config.ModelID.IsNull() || config.ModelID.IsUnknown() || modelID == "" {
+		resp.Diagnostics.AddError("Invalid Model Lookup", "model_id must be known and nonempty")
+		return
+	}
+	endpoint := endpointWithQuery("/model/info", url.Values{"litellm_model_id": []string{modelID}})
 	var rawResult map[string]interface{}
 	if err := readModelDataSourceWithRetry(ctx, d.client, endpoint, &rawResult, 8); err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read model '%s': %s", modelID, err))
 		return
 	}
-
-	result := parseModelInfoResult(rawResult)
-	if len(result) == 0 {
+	result, err := modelDataSourceResult(rawResult)
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
+	}
+	if result == nil {
 		resp.Diagnostics.AddError("Not Found", fmt.Sprintf("Model not found: %s", modelID))
 		return
 	}
-
-	// Set ID
-	data.ID = data.ModelID
-
-	// Update fields from response (prefer team_public_model_name for team-scoped models)
-	data.ModelName = types.StringValue("")
-	if modelInfo, ok := result["model_info"].(map[string]interface{}); ok {
-		if teamID, _ := modelInfo["team_id"].(string); teamID != "" {
-			if publicName, ok := modelInfo["team_public_model_name"].(string); ok && publicName != "" {
-				data.ModelName = types.StringValue(publicName)
-			}
-		}
-	}
-	if data.ModelName.ValueString() == "" {
-		if modelName, ok := result["model_name"].(string); ok {
-			data.ModelName = types.StringValue(modelName)
-		}
+	actualID, err := dataSourceRequiredStringAt(result, "model_info", "id")
+	if err != nil || actualID.ValueString() != modelID {
+		resp.Diagnostics.AddError("Invalid API Response", "Model response identity did not match the requested model.")
+		return
 	}
 
-	// Parse litellm_params
-	if litellmParams, ok := result["litellm_params"].(map[string]interface{}); ok {
-		if provider, ok := litellmParams["custom_llm_provider"].(string); ok {
-			data.CustomLLMProvider = types.StringValue(provider)
-		}
-		if apiBase, ok := litellmParams["api_base"].(string); ok {
-			data.ModelAPIBase = types.StringValue(apiBase)
-		}
-		if apiVersion, ok := litellmParams["api_version"].(string); ok {
-			data.APIVersion = types.StringValue(apiVersion)
-		}
-		if err := updateInt64FromAPI(&data.TPM, litellmParams, true, true, "tpm"); err != nil {
-			resp.Diagnostics.AddError("Invalid API Response", err.Error())
-			return
-		}
-		if err := updateInt64FromAPI(&data.RPM, litellmParams, true, true, "rpm"); err != nil {
-			resp.Diagnostics.AddError("Invalid API Response", err.Error())
-			return
-		}
-		if awsRegion, ok := litellmParams["aws_region_name"].(string); ok {
-			data.AWSRegionName = types.StringValue(awsRegion)
-		}
+	data := ModelDataSourceModel{ID: actualID, ModelID: config.ModelID}
+	if data.ModelName, err = dataSourceNullableStringAt(result, "model_name"); err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
 	}
-
-	// Parse model_info
-	if modelInfo, ok := result["model_info"].(map[string]interface{}); ok {
-		if baseModel, ok := modelInfo["base_model"].(string); ok {
-			data.BaseModel = types.StringValue(baseModel)
-		}
-		if tier, ok := modelInfo["tier"].(string); ok {
-			data.Tier = types.StringValue(tier)
-		}
-		if mode, ok := modelInfo["mode"].(string); ok {
-			data.Mode = types.StringValue(mode)
-		}
-		if teamID, ok := modelInfo["team_id"].(string); ok {
-			data.TeamID = types.StringValue(teamID)
-		}
+	teamPublicName, publicErr := dataSourceNullableStringAt(result, "model_info", "team_public_model_name")
+	if publicErr != nil {
+		resp.Diagnostics.AddError("Invalid API Response", publicErr.Error())
+		return
 	}
-
+	if data.TeamID, err = dataSourceNullableStringAt(result, "model_info", "team_id"); err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
+	}
+	if !data.TeamID.IsNull() && data.TeamID.ValueString() != "" && !teamPublicName.IsNull() && teamPublicName.ValueString() != "" {
+		data.ModelName = teamPublicName
+	}
+	if data.CustomLLMProvider, err = dataSourceNullableStringAt(result, "litellm_params", "custom_llm_provider"); err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
+	}
+	if data.ModelAPIBase, err = dataSourceNullableStringAt(result, "litellm_params", "api_base"); err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
+	}
+	if data.APIVersion, err = dataSourceNullableStringAt(result, "litellm_params", "api_version"); err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
+	}
+	if data.TPM, err = dataSourceNullableInt64At(result, "litellm_params", "tpm"); err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
+	}
+	if data.RPM, err = dataSourceNullableInt64At(result, "litellm_params", "rpm"); err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
+	}
+	if data.AWSRegionName, err = dataSourceNullableStringAt(result, "litellm_params", "aws_region_name"); err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
+	}
+	if data.BaseModel, err = dataSourceNullableStringAt(result, "model_info", "base_model"); err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
+	}
+	if data.Tier, err = dataSourceNullableStringAt(result, "model_info", "tier"); err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
+	}
+	if data.Mode, err = dataSourceNullableStringAt(result, "model_info", "mode"); err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
+	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
-func parseModelInfoResult(rawResult map[string]interface{}) map[string]interface{} {
-	if dataArr, ok := rawResult["data"].([]interface{}); ok && len(dataArr) > 0 {
-		if firstItem, ok := dataArr[0].(map[string]interface{}); ok {
-			return firstItem
-		}
+func modelDataSourceResult(rawResult map[string]interface{}) (map[string]interface{}, error) {
+	raw, presence, err := apiValueAt(rawResult, "data")
+	if err != nil {
+		return nil, err
 	}
-	return rawResult
+	if presence == apiValueAbsent {
+		return rawResult, nil
+	}
+	if presence == apiValueNull {
+		return nil, dataSourceShapeError([]string{"data"}, "a list containing exactly one object")
+	}
+	items, ok := raw.([]interface{})
+	if !ok {
+		return nil, dataSourceShapeError([]string{"data"}, "a list containing exactly one object")
+	}
+	if len(items) == 0 {
+		return nil, nil
+	}
+	if len(items) != 1 {
+		return nil, dataSourceShapeError([]string{"data"}, "a list containing exactly one object")
+	}
+	item, ok := items[0].(map[string]interface{})
+	if !ok {
+		return nil, dataSourceShapeError([]string{"data"}, "a list containing exactly one object")
+	}
+	return item, nil
+}
+
+func parseModelInfoResult(rawResult map[string]interface{}) map[string]interface{} {
+	result, _ := modelDataSourceResult(rawResult)
+	return result
 }
 
 func readModelDataSourceWithRetry(ctx context.Context, client *Client, endpoint string, result *map[string]interface{}, maxRetries int) error {
 	var err error
-	delay := 1 * time.Second
+	delay := time.Second
 	maxDelay := 10 * time.Second
-
 	for i := 0; i < maxRetries; i++ {
 		err = client.DoRequestWithResponse(ctx, "GET", endpoint, nil, result)
 		if err == nil {
 			return nil
 		}
-
 		if !IsNotFoundError(err) {
 			return err
 		}
-
 		if i < maxRetries-1 {
-			time.Sleep(delay)
+			timer := time.NewTimer(delay)
+			select {
+			case <-ctx.Done():
+				if !timer.Stop() {
+					<-timer.C
+				}
+				return ctx.Err()
+			case <-timer.C:
+			}
 			delay *= 2
 			if delay > maxDelay {
 				delay = maxDelay
 			}
 		}
 	}
-
 	return err
 }

--- a/internal/provider/datasource_models_list.go
+++ b/internal/provider/datasource_models_list.go
@@ -119,6 +119,10 @@ func (d *ModelsListDataSource) Read(ctx context.Context, req datasource.ReadRequ
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	if err := validateOptionalStringFilter("team_id", data.TeamID); err != nil {
+		resp.Diagnostics.AddError("Invalid Model List Filter", err.Error())
+		return
+	}
 
 	filters := modelListFilters(data.TeamID)
 	endpoint := endpointWithQuery("/model/info", filters)

--- a/internal/provider/datasource_models_list.go
+++ b/internal/provider/datasource_models_list.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -114,7 +115,7 @@ func (d *ModelsListDataSource) Configure(ctx context.Context, req datasource.Con
 func (d *ModelsListDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	var data ModelsListDataSourceModel
 
-	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("team_id"), &data.TeamID)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -135,57 +136,67 @@ func (d *ModelsListDataSource) Read(ctx context.Context, req datasource.ReadRequ
 
 	data.ID = types.StringValue("models")
 	data.Models = make([]ModelListItem, 0, len(modelsData))
+	seen := make(map[string]struct{}, len(modelsData))
 	for _, rawModel := range modelsData {
 		modelMap, err := decodeListObject(rawModel, "/model/info", "model item")
 		if err != nil {
 			resp.Diagnostics.AddError("Invalid API Response", err.Error())
 			return
 		}
+		modelInfo, err := dataSourceRequiredObjectAt(modelMap, "model_info")
+		if err != nil {
+			resp.Diagnostics.AddError("Invalid API Response", err.Error())
+			return
+		}
 
 		item := ModelListItem{}
-
-		// Get model_info
-		if modelInfo, ok := modelMap["model_info"].(map[string]interface{}); ok {
-			if id, ok := modelInfo["id"].(string); ok {
-				item.ID = types.StringValue(id)
-			}
-			if baseModel, ok := modelInfo["base_model"].(string); ok {
-				item.BaseModel = types.StringValue(baseModel)
-			}
-			if tier, ok := modelInfo["tier"].(string); ok {
-				item.Tier = types.StringValue(tier)
-			}
-			if mode, ok := modelInfo["mode"].(string); ok {
-				item.Mode = types.StringValue(mode)
-			}
-			if teamID, ok := modelInfo["team_id"].(string); ok {
-				item.TeamID = types.StringValue(teamID)
-			}
-			// Prefer team_public_model_name for team-scoped models
-			if teamID, _ := modelInfo["team_id"].(string); teamID != "" {
-				if publicName, ok := modelInfo["team_public_model_name"].(string); ok && publicName != "" {
-					item.ModelName = types.StringValue(publicName)
-				}
-			}
-		}
-
-		// Get model name (use top-level if not set from team_public_model_name)
-		if item.ModelName.ValueString() == "" {
-			if modelName, ok := modelMap["model_name"].(string); ok {
-				item.ModelName = types.StringValue(modelName)
-			}
-		}
-
-		// Get litellm_params
-		if litellmParams, ok := modelMap["litellm_params"].(map[string]interface{}); ok {
-			if provider, ok := litellmParams["custom_llm_provider"].(string); ok {
-				item.CustomLLMProvider = types.StringValue(provider)
-			}
-		}
-
-		if item.ID.ValueString() == "" && item.ModelName.ValueString() == "" {
-			resp.Diagnostics.AddError("Invalid API Response", "/model/info returned a model object without an id or model_name")
+		item.ID, err = dataSourceRequiredStringAt(modelInfo, "id")
+		if err != nil {
+			resp.Diagnostics.AddError("Invalid API Response", "/model/info returned a model object without a canonical model_info.id")
 			return
+		}
+		if err := dataSourceListIdentity(seen, item.ID.ValueString(), "/model/info", "model_info.id"); err != nil {
+			resp.Diagnostics.AddError("Invalid API Response", err.Error())
+			return
+		}
+		for _, field := range []struct {
+			name   string
+			target *types.String
+		}{
+			{"base_model", &item.BaseModel}, {"tier", &item.Tier}, {"mode", &item.Mode}, {"team_id", &item.TeamID},
+		} {
+			*field.target, err = dataSourceNullableStringAt(modelInfo, field.name)
+			if err != nil {
+				resp.Diagnostics.AddError("Invalid API Response", err.Error())
+				return
+			}
+		}
+		publicName, err := dataSourceNullableStringAt(modelInfo, "team_public_model_name")
+		if err != nil {
+			resp.Diagnostics.AddError("Invalid API Response", err.Error())
+			return
+		}
+		item.ModelName, err = dataSourceNullableStringAt(modelMap, "model_name")
+		if err != nil {
+			resp.Diagnostics.AddError("Invalid API Response", err.Error())
+			return
+		}
+		if !item.TeamID.IsNull() && item.TeamID.ValueString() != "" && !publicName.IsNull() && publicName.ValueString() != "" {
+			item.ModelName = publicName
+		}
+
+		litellmParams, present, err := dataSourceNullableObjectAt(modelMap, "litellm_params")
+		if err != nil {
+			resp.Diagnostics.AddError("Invalid API Response", err.Error())
+			return
+		}
+		item.CustomLLMProvider = types.StringNull()
+		if present {
+			item.CustomLLMProvider, err = dataSourceNullableStringAt(litellmParams, "custom_llm_provider")
+			if err != nil {
+				resp.Diagnostics.AddError("Invalid API Response", err.Error())
+				return
+			}
 		}
 		data.Models = append(data.Models, item)
 	}

--- a/internal/provider/datasource_organizations_list.go
+++ b/internal/provider/datasource_organizations_list.go
@@ -86,6 +86,10 @@ func (d *OrganizationsListDataSource) Read(ctx context.Context, req datasource.R
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	if err := validateOptionalStringFilter("org_alias", data.OrgAlias); err != nil {
+		resp.Diagnostics.AddError("Invalid Organization List Filter", err.Error())
+		return
+	}
 	filters := organizationListFilters(data.OrgAlias)
 	endpoint := endpointWithQuery("/organization/list", filters)
 	var rawResult json.RawMessage
@@ -125,17 +129,16 @@ func (d *OrganizationsListDataSource) Read(ctx context.Context, req datasource.R
 			resp.Diagnostics.AddError("Invalid API Response", err.Error())
 			return
 		}
-		item := OrganizationListItem{OrganizationID: identity, Blocked: types.BoolValue(false)}
+		item := OrganizationListItem{OrganizationID: identity, Blocked: types.BoolNull()}
 		item.OrganizationAlias, err = dataSourceNullableStringAt(object, "organization_alias")
 		if err != nil {
 			resp.Diagnostics.AddError("Invalid API Response", err.Error())
 			return
 		}
-		if rawBlocked, exists := object["blocked"]; exists && rawBlocked != nil {
-			if _, ok := rawBlocked.(bool); !ok {
-				resp.Diagnostics.AddError("Invalid API Response", "invalid response field blocked: expected a boolean or null")
-				return
-			}
+		item.Blocked, err = dataSourceNullableBoolAt(object, "blocked")
+		if err != nil {
+			resp.Diagnostics.AddError("Invalid API Response", err.Error())
+			return
 		}
 		budgetID, presence, err := budgetTableID(object, table)
 		if err != nil {

--- a/internal/provider/datasource_organizations_list.go
+++ b/internal/provider/datasource_organizations_list.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -81,7 +82,7 @@ func (d *OrganizationsListDataSource) Configure(_ context.Context, req datasourc
 
 func (d *OrganizationsListDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	var data OrganizationsListDataSourceModel
-	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("org_alias"), &data.OrgAlias)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -99,25 +100,42 @@ func (d *OrganizationsListDataSource) Read(ctx context.Context, req datasource.R
 	}
 	data.ID = types.StringValue("organizations")
 	data.Organizations = make([]OrganizationListItem, 0, len(items))
+	seen := make(map[string]struct{}, len(items))
 	for _, raw := range items {
 		object, err := decodeListObject(raw, "/organization/list", "organization item")
 		if err != nil {
 			resp.Diagnostics.AddError("Invalid API Response", err.Error())
 			return
 		}
-		organizationID, ok := object["organization_id"].(string)
-		if !ok || organizationID == "" {
-			resp.Diagnostics.AddError("Invalid API Response", "/organization/list returned an organization object without organization_id")
+		identity, err := dataSourceRequiredStringAt(object, "organization_id")
+		if err != nil {
+			resp.Diagnostics.AddError("Invalid API Response", "/organization/list returned an organization object without a canonical organization_id")
+			return
+		}
+		organizationID := identity.ValueString()
+		if err := dataSourceListIdentity(seen, organizationID, "/organization/list", "organization_id"); err != nil {
+			resp.Diagnostics.AddError("Invalid API Response", err.Error())
 			return
 		}
 		table, err := parseBudgetTable(object)
+		if err == nil {
+			err = validateDataSourceBudgetTableNumbers(table)
+		}
 		if err != nil {
 			resp.Diagnostics.AddError("Invalid API Response", err.Error())
 			return
 		}
-		item := OrganizationListItem{OrganizationID: types.StringValue(organizationID), Blocked: types.BoolValue(false)}
-		if alias, ok := object["organization_alias"].(string); ok {
-			item.OrganizationAlias = types.StringValue(alias)
+		item := OrganizationListItem{OrganizationID: identity, Blocked: types.BoolValue(false)}
+		item.OrganizationAlias, err = dataSourceNullableStringAt(object, "organization_alias")
+		if err != nil {
+			resp.Diagnostics.AddError("Invalid API Response", err.Error())
+			return
+		}
+		if rawBlocked, exists := object["blocked"]; exists && rawBlocked != nil {
+			if _, ok := rawBlocked.(bool); !ok {
+				resp.Diagnostics.AddError("Invalid API Response", "invalid response field blocked: expected a boolean or null")
+				return
+			}
 		}
 		budgetID, presence, err := budgetTableID(object, table)
 		if err != nil {
@@ -140,7 +158,8 @@ func (d *OrganizationsListDataSource) Read(ctx context.Context, req datasource.R
 				return
 			}
 		}
-		if err := updateFloat64FromAPI(&item.Spend, object, true, true, "spend"); err != nil {
+		item.Spend, err = dataSourceNullableFloat64At(object, "spend")
+		if err != nil {
 			resp.Diagnostics.AddError("Invalid API Response", err.Error())
 			return
 		}
@@ -159,11 +178,13 @@ func (d *OrganizationsListDataSource) Read(ctx context.Context, req datasource.R
 			resp.Diagnostics.AddError("Invalid API Response", err.Error())
 			return
 		}
-		if err := updateInt64MapFromAPI(&item.ModelRPMLimit, object, true, true, "metadata", "model_rpm_limit"); err != nil {
+		item.ModelRPMLimit, err = dataSourceNullableInt64MapAt(object, "metadata", "model_rpm_limit")
+		if err != nil {
 			resp.Diagnostics.AddError("Invalid API Response", err.Error())
 			return
 		}
-		if err := updateInt64MapFromAPI(&item.ModelTPMLimit, object, true, true, "metadata", "model_tpm_limit"); err != nil {
+		item.ModelTPMLimit, err = dataSourceNullableInt64MapAt(object, "metadata", "model_tpm_limit")
+		if err != nil {
 			resp.Diagnostics.AddError("Invalid API Response", err.Error())
 			return
 		}

--- a/internal/provider/datasource_presence.go
+++ b/internal/provider/datasource_presence.go
@@ -169,6 +169,96 @@ func dataSourceNullableStringMapAt(object map[string]interface{}, path ...string
 	return dataSourceStringMapValue(raw, path)
 }
 
+func dataSourceNullableInt64MapAt(object map[string]interface{}, path ...string) (types.Map, error) {
+	raw, present, err := dataSourceNullableValueAt(object, "an object of exact integral JSON numbers or null", path...)
+	if err != nil || !present {
+		return types.MapNull(types.Int64Type), err
+	}
+	values, ok := raw.(map[string]interface{})
+	if !ok {
+		return types.MapNull(types.Int64Type), dataSourceShapeError(path, "an object of exact integral JSON numbers or null")
+	}
+	elements := make(map[string]attr.Value, len(values))
+	for key, rawValue := range values {
+		if !dataSourceAPIJSONNumber(rawValue) {
+			return types.MapNull(types.Int64Type), dataSourceShapeError(path, "an object of exact integral JSON numbers or null")
+		}
+		value, conversionErr := exactInt64FromAPI(rawValue)
+		if conversionErr != nil {
+			return types.MapNull(types.Int64Type), dataSourceShapeError(path, "an object of exact integral JSON numbers or null")
+		}
+		elements[key] = types.Int64Value(value)
+	}
+	value, diagnostics := types.MapValue(types.Int64Type, elements)
+	if diagnostics.HasError() {
+		return types.MapNull(types.Int64Type), dataSourceShapeError(path, "an object of exact integral JSON numbers or null")
+	}
+	return value, nil
+}
+
+func dataSourceNullableFloat64AtPaths(object map[string]interface{}, paths ...[]string) (types.Float64, error) {
+	selected, err := firstAPIFieldPath(object, paths...)
+	if err != nil || selected == nil {
+		return types.Float64Null(), err
+	}
+	return dataSourceNullableFloat64At(object, selected...)
+}
+
+func dataSourceRequiredObjectAt(object map[string]interface{}, path ...string) (map[string]interface{}, error) {
+	raw, err := dataSourceRequiredValueAt(object, "an object", path...)
+	if err != nil {
+		return nil, err
+	}
+	value, ok := raw.(map[string]interface{})
+	if !ok || value == nil {
+		return nil, dataSourceShapeError(path, "an object")
+	}
+	return value, nil
+}
+
+func dataSourceNullableObjectAt(object map[string]interface{}, path ...string) (map[string]interface{}, bool, error) {
+	raw, present, err := dataSourceNullableValueAt(object, "an object or null", path...)
+	if err != nil || !present {
+		return nil, false, err
+	}
+	value, ok := raw.(map[string]interface{})
+	if !ok || value == nil {
+		return nil, false, dataSourceShapeError(path, "an object or null")
+	}
+	return value, true, nil
+}
+
+// dataSourceListIdentity records canonical identities while callers build the
+// complete list off-state. State is published once, so any duplicate or
+// malformed later item fails atomically.
+func dataSourceListIdentity(seen map[string]struct{}, identity, endpoint, field string) error {
+	if identity == "" {
+		return fmt.Errorf("%s returned an item without a nonempty canonical %s", endpoint, field)
+	}
+	if _, duplicate := seen[identity]; duplicate {
+		return fmt.Errorf("%s returned duplicate canonical %s identities", endpoint, field)
+	}
+	seen[identity] = struct{}{}
+	return nil
+}
+
+func validateDataSourceBudgetTableNumbers(table budgetTableState) error {
+	if table.presence != apiValuePresent {
+		return nil
+	}
+	for _, field := range []string{"max_budget", "soft_budget"} {
+		if _, err := dataSourceNullableFloat64At(table.object, field); err != nil {
+			return err
+		}
+	}
+	for _, field := range []string{"max_parallel_requests", "tpm_limit", "rpm_limit"} {
+		if _, err := dataSourceNullableInt64At(table.object, field); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // Canonical JSON fields are Terraform strings whose API representation must be
 // an object. json.Marshal keeps json.Number lexemes exact and deterministically
 // orders object keys; no conversion through float64 occurs.

--- a/internal/provider/datasource_presence.go
+++ b/internal/provider/datasource_presence.go
@@ -1,0 +1,365 @@
+package provider
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// Data-source response readers deliberately do not consult prior state. A
+// successful Read must replace API null or omission with a Terraform typed
+// null, while preserving explicit false, zero, and empty values.
+
+func dataSourceRequiredStringAt(object map[string]interface{}, path ...string) (types.String, error) {
+	raw, err := dataSourceRequiredValueAt(object, "a nonempty string", path...)
+	if err != nil {
+		return types.StringNull(), err
+	}
+	value, ok := raw.(string)
+	if !ok || value == "" {
+		return types.StringNull(), dataSourceShapeError(path, "a nonempty string")
+	}
+	return types.StringValue(value), nil
+}
+
+func dataSourceNullableStringAt(object map[string]interface{}, path ...string) (types.String, error) {
+	raw, present, err := dataSourceNullableValueAt(object, "a string or null", path...)
+	if err != nil || !present {
+		return types.StringNull(), err
+	}
+	value, ok := raw.(string)
+	if !ok {
+		return types.StringNull(), dataSourceShapeError(path, "a string or null")
+	}
+	return types.StringValue(value), nil
+}
+
+func dataSourceRequiredBoolAt(object map[string]interface{}, path ...string) (types.Bool, error) {
+	raw, err := dataSourceRequiredValueAt(object, "a boolean", path...)
+	if err != nil {
+		return types.BoolNull(), err
+	}
+	value, ok := raw.(bool)
+	if !ok {
+		return types.BoolNull(), dataSourceShapeError(path, "a boolean")
+	}
+	return types.BoolValue(value), nil
+}
+
+func dataSourceNullableBoolAt(object map[string]interface{}, path ...string) (types.Bool, error) {
+	raw, present, err := dataSourceNullableValueAt(object, "a boolean or null", path...)
+	if err != nil || !present {
+		return types.BoolNull(), err
+	}
+	value, ok := raw.(bool)
+	if !ok {
+		return types.BoolNull(), dataSourceShapeError(path, "a boolean or null")
+	}
+	return types.BoolValue(value), nil
+}
+
+func dataSourceRequiredInt64At(object map[string]interface{}, path ...string) (types.Int64, error) {
+	raw, err := dataSourceRequiredValueAt(object, "an exact integral JSON number in the int64 range", path...)
+	if err != nil {
+		return types.Int64Null(), err
+	}
+	if !dataSourceAPIJSONNumber(raw) {
+		return types.Int64Null(), dataSourceShapeError(path, "an exact integral JSON number in the int64 range")
+	}
+	value, presence, err := apiInt64At(object, path...)
+	if err != nil || presence != apiValuePresent {
+		return types.Int64Null(), dataSourceShapeError(path, "an exact integral JSON number in the int64 range")
+	}
+	return types.Int64Value(value), nil
+}
+
+func dataSourceNullableInt64At(object map[string]interface{}, path ...string) (types.Int64, error) {
+	raw, present, err := dataSourceNullableValueAt(object, "an exact integral JSON number in the int64 range or null", path...)
+	if err != nil || !present {
+		return types.Int64Null(), err
+	}
+	if !dataSourceAPIJSONNumber(raw) {
+		return types.Int64Null(), dataSourceShapeError(path, "an exact integral JSON number in the int64 range or null")
+	}
+	value, presence, conversionErr := apiInt64At(object, path...)
+	if conversionErr != nil || presence != apiValuePresent {
+		return types.Int64Null(), dataSourceShapeError(path, "an exact integral JSON number in the int64 range or null")
+	}
+	return types.Int64Value(value), nil
+}
+
+func dataSourceRequiredFloat64At(object map[string]interface{}, path ...string) (types.Float64, error) {
+	raw, err := dataSourceRequiredValueAt(object, "a finite JSON number", path...)
+	if err != nil {
+		return types.Float64Null(), err
+	}
+	if !dataSourceAPIJSONNumber(raw) {
+		return types.Float64Null(), dataSourceShapeError(path, "a finite JSON number")
+	}
+	value, presence, err := apiFloat64At(object, path...)
+	if err != nil || presence != apiValuePresent {
+		return types.Float64Null(), dataSourceShapeError(path, "a finite JSON number")
+	}
+	return types.Float64Value(value), nil
+}
+
+func dataSourceNullableFloat64At(object map[string]interface{}, path ...string) (types.Float64, error) {
+	raw, present, err := dataSourceNullableValueAt(object, "a finite JSON number or null", path...)
+	if err != nil || !present {
+		return types.Float64Null(), err
+	}
+	if !dataSourceAPIJSONNumber(raw) {
+		return types.Float64Null(), dataSourceShapeError(path, "a finite JSON number or null")
+	}
+	value, presence, conversionErr := apiFloat64At(object, path...)
+	if conversionErr != nil || presence != apiValuePresent {
+		return types.Float64Null(), dataSourceShapeError(path, "a finite JSON number or null")
+	}
+	return types.Float64Value(value), nil
+}
+
+func dataSourceRequiredStringListAt(object map[string]interface{}, path ...string) (types.List, error) {
+	raw, err := dataSourceRequiredValueAt(object, "a list of strings", path...)
+	if err != nil {
+		return types.ListNull(types.StringType), err
+	}
+	return dataSourceStringListValue(raw, path)
+}
+
+func dataSourceNullableStringListAt(object map[string]interface{}, path ...string) (types.List, error) {
+	raw, present, err := dataSourceNullableValueAt(object, "a list of strings or null", path...)
+	if err != nil || !present {
+		return types.ListNull(types.StringType), err
+	}
+	return dataSourceStringListValue(raw, path)
+}
+
+func dataSourceRequiredStringSetAt(object map[string]interface{}, path ...string) (types.Set, error) {
+	raw, err := dataSourceRequiredValueAt(object, "a list of strings", path...)
+	if err != nil {
+		return types.SetNull(types.StringType), err
+	}
+	return dataSourceStringSetValue(raw, path)
+}
+
+func dataSourceNullableStringSetAt(object map[string]interface{}, path ...string) (types.Set, error) {
+	raw, present, err := dataSourceNullableValueAt(object, "a list of strings or null", path...)
+	if err != nil || !present {
+		return types.SetNull(types.StringType), err
+	}
+	return dataSourceStringSetValue(raw, path)
+}
+
+func dataSourceRequiredStringMapAt(object map[string]interface{}, path ...string) (types.Map, error) {
+	raw, err := dataSourceRequiredValueAt(object, "an object of strings", path...)
+	if err != nil {
+		return types.MapNull(types.StringType), err
+	}
+	return dataSourceStringMapValue(raw, path)
+}
+
+func dataSourceNullableStringMapAt(object map[string]interface{}, path ...string) (types.Map, error) {
+	raw, present, err := dataSourceNullableValueAt(object, "an object of strings or null", path...)
+	if err != nil || !present {
+		return types.MapNull(types.StringType), err
+	}
+	return dataSourceStringMapValue(raw, path)
+}
+
+// Canonical JSON fields are Terraform strings whose API representation must be
+// an object. json.Marshal keeps json.Number lexemes exact and deterministically
+// orders object keys; no conversion through float64 occurs.
+func dataSourceRequiredCanonicalJSONObjectAt(object map[string]interface{}, path ...string) (types.String, error) {
+	raw, err := dataSourceRequiredValueAt(object, "an object", path...)
+	if err != nil {
+		return types.StringNull(), err
+	}
+	return dataSourceCanonicalJSONObjectValue(raw, path)
+}
+
+func dataSourceNullableCanonicalJSONObjectAt(object map[string]interface{}, path ...string) (types.String, error) {
+	raw, present, err := dataSourceNullableValueAt(object, "an object or null", path...)
+	if err != nil || !present {
+		return types.StringNull(), err
+	}
+	return dataSourceCanonicalJSONObjectValue(raw, path)
+}
+
+// Role-redacted nullable fields intentionally have the same state semantics as
+// other nullable fields: an omitted field resolves to typed null, never to a
+// fabricated empty, false, or zero value. The separate entry points document
+// that call-site contract.
+func dataSourceRoleRedactedNullableStringAt(object map[string]interface{}, path ...string) (types.String, error) {
+	return dataSourceNullableStringAt(object, path...)
+}
+
+func dataSourceRoleRedactedNullableBoolAt(object map[string]interface{}, path ...string) (types.Bool, error) {
+	return dataSourceNullableBoolAt(object, path...)
+}
+
+func dataSourceRoleRedactedNullableInt64At(object map[string]interface{}, path ...string) (types.Int64, error) {
+	return dataSourceNullableInt64At(object, path...)
+}
+
+func dataSourceRoleRedactedNullableFloat64At(object map[string]interface{}, path ...string) (types.Float64, error) {
+	return dataSourceNullableFloat64At(object, path...)
+}
+
+func dataSourceRoleRedactedNullableStringListAt(object map[string]interface{}, path ...string) (types.List, error) {
+	return dataSourceNullableStringListAt(object, path...)
+}
+
+func dataSourceRoleRedactedNullableStringSetAt(object map[string]interface{}, path ...string) (types.Set, error) {
+	return dataSourceNullableStringSetAt(object, path...)
+}
+
+func dataSourceRoleRedactedNullableStringMapAt(object map[string]interface{}, path ...string) (types.Map, error) {
+	return dataSourceNullableStringMapAt(object, path...)
+}
+
+func dataSourceRoleRedactedNullableCanonicalJSONObjectAt(object map[string]interface{}, path ...string) (types.String, error) {
+	return dataSourceNullableCanonicalJSONObjectAt(object, path...)
+}
+
+func dataSourceRequiredValueAt(object map[string]interface{}, expected string, path ...string) (interface{}, error) {
+	if len(path) == 0 {
+		return nil, dataSourceShapeError(path, expected)
+	}
+	value, presence, err := apiValueAt(object, path...)
+	if err != nil {
+		return nil, err
+	}
+	if presence != apiValuePresent {
+		return nil, dataSourceShapeError(path, expected)
+	}
+	return value, nil
+}
+
+func dataSourceNullableValueAt(object map[string]interface{}, expected string, path ...string) (interface{}, bool, error) {
+	if len(path) == 0 {
+		return nil, false, dataSourceShapeError(path, expected)
+	}
+	value, presence, err := apiValueAt(object, path...)
+	if err != nil {
+		return nil, false, err
+	}
+	if presence != apiValuePresent {
+		return nil, false, nil
+	}
+	return value, true, nil
+}
+
+func dataSourceAPIJSONNumber(value interface{}) bool {
+	switch value.(type) {
+	case json.Number, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64:
+		return true
+	default:
+		return false
+	}
+}
+
+func dataSourceShapeError(path []string, expected string) error {
+	if len(path) == 0 {
+		return fmt.Errorf("invalid response field path: expected %s", expected)
+	}
+	return fmt.Errorf("invalid response field %q: expected %s", strings.Join(path, "."), expected)
+}
+
+func dataSourceStringElements(raw interface{}, path []string, nullable bool) ([]attr.Value, error) {
+	var values []interface{}
+	switch value := raw.(type) {
+	case []interface{}:
+		values = value
+	case []string:
+		values = make([]interface{}, len(value))
+		for index := range value {
+			values[index] = value[index]
+		}
+	default:
+		expected := "a list of strings"
+		if nullable {
+			expected += " or null"
+		}
+		return nil, dataSourceShapeError(path, expected)
+	}
+
+	elements := make([]attr.Value, len(values))
+	for index, rawElement := range values {
+		value, ok := rawElement.(string)
+		if !ok {
+			expected := "a list of strings"
+			if nullable {
+				expected += " or null"
+			}
+			return nil, dataSourceShapeError(path, expected)
+		}
+		elements[index] = types.StringValue(value)
+	}
+	return elements, nil
+}
+
+func dataSourceStringListValue(raw interface{}, path []string) (types.List, error) {
+	elements, err := dataSourceStringElements(raw, path, false)
+	if err != nil {
+		return types.ListNull(types.StringType), err
+	}
+	value, diagnostics := types.ListValue(types.StringType, elements)
+	if diagnostics.HasError() {
+		return types.ListNull(types.StringType), dataSourceShapeError(path, "a list of strings")
+	}
+	return value, nil
+}
+
+func dataSourceStringSetValue(raw interface{}, path []string) (types.Set, error) {
+	elements, err := dataSourceStringElements(raw, path, false)
+	if err != nil {
+		return types.SetNull(types.StringType), err
+	}
+	value, diagnostics := types.SetValue(types.StringType, elements)
+	if diagnostics.HasError() {
+		return types.SetNull(types.StringType), dataSourceShapeError(path, "a list of strings")
+	}
+	return value, nil
+}
+
+func dataSourceStringMapValue(raw interface{}, path []string) (types.Map, error) {
+	values := make(map[string]attr.Value)
+	switch object := raw.(type) {
+	case map[string]interface{}:
+		values = make(map[string]attr.Value, len(object))
+		for key, rawValue := range object {
+			value, ok := rawValue.(string)
+			if !ok {
+				return types.MapNull(types.StringType), dataSourceShapeError(path, "an object of strings")
+			}
+			values[key] = types.StringValue(value)
+		}
+	case map[string]string:
+		values = make(map[string]attr.Value, len(object))
+		for key, value := range object {
+			values[key] = types.StringValue(value)
+		}
+	default:
+		return types.MapNull(types.StringType), dataSourceShapeError(path, "an object of strings")
+	}
+	value, diagnostics := types.MapValue(types.StringType, values)
+	if diagnostics.HasError() {
+		return types.MapNull(types.StringType), dataSourceShapeError(path, "an object of strings")
+	}
+	return value, nil
+}
+
+func dataSourceCanonicalJSONObjectValue(raw interface{}, path []string) (types.String, error) {
+	object, ok := raw.(map[string]interface{})
+	if !ok {
+		return types.StringNull(), dataSourceShapeError(path, "an object")
+	}
+	encoded, err := json.Marshal(object)
+	if err != nil {
+		return types.StringNull(), dataSourceShapeError(path, "an object representable as canonical JSON")
+	}
+	return types.StringValue(string(encoded)), nil
+}

--- a/internal/provider/datasource_presence_review_regression_test.go
+++ b/internal/provider/datasource_presence_review_regression_test.go
@@ -1,0 +1,146 @@
+package provider
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func TestListDataSourceUnknownAndEmptyFiltersFailBeforeHTTP(t *testing.T) {
+	tests := []struct {
+		typeName string
+		field    string
+	}{
+		{"litellm_keys", "team_id"},
+		{"litellm_models", "team_id"},
+		{"litellm_organizations", "org_alias"},
+		{"litellm_users", "user_role"},
+		{"litellm_prompts", "environment"},
+	}
+	for _, test := range tests {
+		t.Run(test.typeName, func(t *testing.T) {
+			ctx := context.Background()
+			var requests atomic.Int64
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				requests.Add(1)
+				http.Error(writer, "unexpected request", http.StatusInternalServerError)
+			}))
+			defer server.Close()
+			protocolServer, schemas := configuredImportProtocolServer(t, ctx, server.URL)
+			schema := schemas.DataSourceSchemas[test.typeName]
+			for name, value := range map[string]interface{}{"unknown": tftypes.UnknownValue, "empty": ""} {
+				t.Run(name, func(t *testing.T) {
+					config := accessGroupProtocolDynamicValue(t, schema, organizationProjectProtocolValue(t, schema, map[string]interface{}{test.field: value}))
+					read, err := protocolServer.ReadDataSource(ctx, &tfprotov6.ReadDataSourceRequest{TypeName: test.typeName, Config: config})
+					if err != nil || !accessGroupProtocolDiagnosticsHaveError(read.Diagnostics) {
+						t.Fatalf("invalid filter was accepted: err=%v diagnostics=%s", err, agentProtocolDiagnosticsText(read.Diagnostics))
+					}
+				})
+			}
+			if requests.Load() != 0 {
+				t.Fatalf("invalid filters caused %d HTTP requests", requests.Load())
+			}
+		})
+	}
+}
+
+func TestListDataSourceAbsentBlockedRemainsTypedNull(t *testing.T) {
+	hash := strings.Repeat("a", sha256ManagementHashLength)
+	for name, raw := range map[string][]byte{
+		"string key": []byte(`"` + hash + `"`),
+		"object key": []byte(`{"token":"` + hash + `"}`),
+	} {
+		t.Run(name, func(t *testing.T) {
+			item, err := decodeKeyListItem(raw)
+			if err != nil || !item.Blocked.IsNull() {
+				t.Fatalf("absent blocked was fabricated: value=%v err=%v", item.Blocked, err)
+			}
+		})
+	}
+
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = writer.Write([]byte(`[{"organization_id":"org-presence"}]`))
+	}))
+	defer server.Close()
+	protocolServer, schemas := configuredImportProtocolServer(t, ctx, server.URL)
+	schema := schemas.DataSourceSchemas["litellm_organizations"]
+	config := accessGroupProtocolDynamicValue(t, schema, organizationProjectProtocolValue(t, schema, map[string]interface{}{}))
+	read, err := protocolServer.ReadDataSource(ctx, &tfprotov6.ReadDataSourceRequest{TypeName: "litellm_organizations", Config: config})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(read.Diagnostics) {
+		t.Fatalf("organization read: err=%v diagnostics=%s", err, agentProtocolDiagnosticsText(read.Diagnostics))
+	}
+	var items []tftypes.Value
+	if err := protocolAttributeMap(t, schema, read.State)["organizations"].As(&items); err != nil || len(items) != 1 {
+		t.Fatalf("organization items: err=%v len=%d", err, len(items))
+	}
+	attributes := map[string]tftypes.Value{}
+	if err := items[0].As(&attributes); err != nil || !attributes["blocked"].IsNull() {
+		t.Fatalf("organization absent blocked was fabricated: value=%v err=%v", attributes["blocked"], err)
+	}
+}
+
+func TestFilteredPromptList404FailsAtomically(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		if request.URL.Path == "/prompts/list" {
+			_, _ = writer.Write([]byte(`{"prompts":[{"prompt_id":"listed"}]}`))
+			return
+		}
+		http.NotFound(writer, request)
+	}))
+	defer server.Close()
+	client := &Client{APIBase: server.URL, APIKey: "test-key", HTTPClient: server.Client()}
+	if items, err := fetchPromptListItems(context.Background(), client, "production", true); err == nil || items != nil {
+		t.Fatalf("listed prompt disappearance produced partial success: items=%#v err=%v", items, err)
+	}
+}
+
+func TestTagListBudgetDiagnosticsDoNotExposeResponseIdentity(t *testing.T) {
+	const sensitiveBudgetID = "response-budget-identifier-must-not-leak"
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = writer.Write([]byte(`[{"name":"tag","budget_id":null,"litellm_budget_table":{"budget_id":"` + sensitiveBudgetID + `"}}]`))
+	}))
+	defer server.Close()
+	protocolServer, schemas := configuredImportProtocolServer(t, ctx, server.URL)
+	schema := schemas.DataSourceSchemas["litellm_tags"]
+	config := accessGroupProtocolDynamicValue(t, schema, organizationProjectProtocolValue(t, schema, map[string]interface{}{}))
+	read, err := protocolServer.ReadDataSource(ctx, &tfprotov6.ReadDataSourceRequest{TypeName: "litellm_tags", Config: config})
+	text := agentProtocolDiagnosticsText(read.Diagnostics)
+	if err != nil || !accessGroupProtocolDiagnosticsHaveError(read.Diagnostics) || strings.Contains(text, sensitiveBudgetID) {
+		t.Fatalf("tag diagnostic was not content-safe: err=%v diagnostics=%s", err, text)
+	}
+}
+
+func TestUserDataSourceRequiresPinnedIdentityEnvelope(t *testing.T) {
+	for name, body := range map[string]string{
+		"flat":               `{"user_id":"requested"}`,
+		"missing root":       `{"user_info":{"user_id":"requested"}}`,
+		"conflicting nested": `{"user_id":"requested","user_info":{"user_id":"other"}}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				writer.Header().Set("Content-Type", "application/json")
+				_, _ = writer.Write([]byte(body))
+			}))
+			defer server.Close()
+			protocolServer, schemas := configuredImportProtocolServer(t, ctx, server.URL)
+			schema := schemas.DataSourceSchemas["litellm_user"]
+			config := accessGroupProtocolDynamicValue(t, schema, organizationProjectProtocolValue(t, schema, map[string]interface{}{"user_id": "requested"}))
+			read, err := protocolServer.ReadDataSource(ctx, &tfprotov6.ReadDataSourceRequest{TypeName: "litellm_user", Config: config})
+			if err != nil || !accessGroupProtocolDiagnosticsHaveError(read.Diagnostics) {
+				t.Fatalf("non-pinned user envelope accepted: err=%v diagnostics=%s", err, agentProtocolDiagnosticsText(read.Diagnostics))
+			}
+		})
+	}
+}

--- a/internal/provider/datasource_presence_test.go
+++ b/internal/provider/datasource_presence_test.go
@@ -1,0 +1,326 @@
+package provider
+
+import (
+	"encoding/json"
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type dataSourcePresenceReader func(map[string]interface{}, ...string) (attr.Value, error)
+
+func TestDataSourceRequiredPresenceReaders(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   interface{}
+		read    dataSourcePresenceReader
+		assert  func(*testing.T, attr.Value)
+		wrong   interface{}
+		emptyID bool
+	}{
+		{name: "string", input: "identity", wrong: false, read: requiredStringPresenceReader, assert: func(t *testing.T, value attr.Value) {
+			if value.(types.String).ValueString() != "identity" {
+				t.Fatal("required string was not preserved")
+			}
+		}, emptyID: true},
+		{name: "false boolean", input: false, wrong: "false", read: requiredBoolPresenceReader, assert: func(t *testing.T, value attr.Value) {
+			if value.(types.Bool).ValueBool() {
+				t.Fatal("explicit false was not preserved")
+			}
+		}},
+		{name: "exact integer", input: json.Number("9007199254740993"), wrong: "9007199254740993", read: requiredInt64PresenceReader, assert: func(t *testing.T, value attr.Value) {
+			if value.(types.Int64).ValueInt64() != 9007199254740993 {
+				t.Fatal("exact integer was not preserved")
+			}
+		}},
+		{name: "zero float", input: json.Number("0"), wrong: "0", read: requiredFloat64PresenceReader, assert: func(t *testing.T, value attr.Value) {
+			if value.(types.Float64).ValueFloat64() != 0 {
+				t.Fatal("explicit zero was not preserved")
+			}
+		}},
+		{name: "empty string list", input: []interface{}{}, wrong: map[string]interface{}{}, read: requiredStringListPresenceReader, assert: assertKnownEmptyCollection},
+		{name: "empty string set", input: []interface{}{}, wrong: map[string]interface{}{}, read: requiredStringSetPresenceReader, assert: assertKnownEmptyCollection},
+		{name: "empty string map", input: map[string]interface{}{}, wrong: []interface{}{}, read: requiredStringMapPresenceReader, assert: assertKnownEmptyCollection},
+		{name: "canonical object", input: map[string]interface{}{"z": json.Number("9007199254740993123456789"), "a": []interface{}{json.Number("1.2500")}}, wrong: []interface{}{}, read: requiredCanonicalJSONPresenceReader, assert: func(t *testing.T, value attr.Value) {
+			if got := value.(types.String).ValueString(); got != `{"a":[1.2500],"z":9007199254740993123456789}` {
+				t.Fatalf("canonical JSON exact-number projection = %q", got)
+			}
+		}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			value, err := test.read(map[string]interface{}{"field": test.input}, "field")
+			if err != nil || value.IsNull() || value.IsUnknown() {
+				t.Fatalf("known required value: value=%T null=%t unknown=%t error=%v", value, value.IsNull(), value.IsUnknown(), err)
+			}
+			test.assert(t, value)
+
+			for name, object := range map[string]map[string]interface{}{
+				"absent": {},
+				"null":   {"field": nil},
+			} {
+				t.Run(name, func(t *testing.T) {
+					failed, readErr := test.read(object, "field")
+					if readErr == nil || !failed.IsNull() || failed.IsUnknown() {
+						t.Fatalf("required %s accepted", name)
+					}
+				})
+			}
+			failed, readErr := test.read(map[string]interface{}{"field": test.wrong}, "field")
+			if readErr == nil || !failed.IsNull() || failed.IsUnknown() {
+				t.Fatal("required wrong type accepted")
+			}
+			if test.emptyID {
+				failed, readErr = test.read(map[string]interface{}{"field": ""}, "field")
+				if readErr == nil || !failed.IsNull() {
+					t.Fatal("required empty identity accepted")
+				}
+			}
+		})
+	}
+}
+
+func TestDataSourceNullablePresenceReaders(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		explicit interface{}
+		read     dataSourcePresenceReader
+		assert   func(*testing.T, attr.Value)
+	}{
+		{name: "empty string", explicit: "", read: nullableStringPresenceReader, assert: func(t *testing.T, value attr.Value) {
+			if value.(types.String).ValueString() != "" {
+				t.Fatal("explicit empty string changed")
+			}
+		}},
+		{name: "false boolean", explicit: false, read: nullableBoolPresenceReader, assert: func(t *testing.T, value attr.Value) {
+			if value.(types.Bool).ValueBool() {
+				t.Fatal("explicit false changed")
+			}
+		}},
+		{name: "zero integer", explicit: json.Number("0e1000000"), read: nullableInt64PresenceReader, assert: func(t *testing.T, value attr.Value) {
+			if value.(types.Int64).ValueInt64() != 0 {
+				t.Fatal("explicit exact zero changed")
+			}
+		}},
+		{name: "zero float", explicit: json.Number("-0"), read: nullableFloat64PresenceReader, assert: func(t *testing.T, value attr.Value) {
+			if value.(types.Float64).ValueFloat64() != 0 {
+				t.Fatal("explicit zero changed")
+			}
+		}},
+		{name: "empty string list", explicit: []interface{}{}, read: nullableStringListPresenceReader, assert: assertKnownEmptyCollection},
+		{name: "empty string set", explicit: []interface{}{}, read: nullableStringSetPresenceReader, assert: assertKnownEmptyCollection},
+		{name: "empty string map", explicit: map[string]interface{}{}, read: nullableStringMapPresenceReader, assert: assertKnownEmptyCollection},
+		{name: "empty canonical object", explicit: map[string]interface{}{}, read: nullableCanonicalJSONPresenceReader, assert: func(t *testing.T, value attr.Value) {
+			if value.(types.String).ValueString() != "{}" {
+				t.Fatal("explicit empty object changed")
+			}
+		}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			for name, object := range map[string]map[string]interface{}{
+				"absent": {},
+				"null":   {"outer": map[string]interface{}{"field": nil}},
+			} {
+				path := []string{"outer", "field"}
+				if name == "absent" {
+					path = []string{"field"}
+				}
+				value, err := test.read(object, path...)
+				if err != nil || !value.IsNull() || value.IsUnknown() {
+					t.Fatalf("nullable %s did not resolve to typed null: null=%t unknown=%t error=%v", name, value.IsNull(), value.IsUnknown(), err)
+				}
+			}
+
+			value, err := test.read(map[string]interface{}{"field": test.explicit}, "field")
+			if err != nil || value.IsNull() || value.IsUnknown() {
+				t.Fatalf("explicit nullable value not known: null=%t unknown=%t error=%v", value.IsNull(), value.IsUnknown(), err)
+			}
+			test.assert(t, value)
+		})
+	}
+}
+
+func TestDataSourcePresenceContainerValuesRemainTyped(t *testing.T) {
+	t.Parallel()
+
+	list, err := dataSourceNullableStringListAt(map[string]interface{}{"field": []interface{}{"", "two"}}, "field")
+	if err != nil || len(list.Elements()) != 2 || list.Elements()[0].(types.String).ValueString() != "" || list.Elements()[1].(types.String).ValueString() != "two" {
+		t.Fatalf("string list was not preserved atomically: error=%v", err)
+	}
+	set, err := dataSourceNullableStringSetAt(map[string]interface{}{"field": []interface{}{"one", "two"}}, "field")
+	if err != nil || len(set.Elements()) != 2 || set.Elements()[0].(types.String).ValueString() != "one" || set.Elements()[1].(types.String).ValueString() != "two" {
+		t.Fatalf("string set was not preserved atomically: error=%v", err)
+	}
+	mapped, err := dataSourceNullableStringMapAt(map[string]interface{}{"field": map[string]interface{}{"empty": "", "known": "value"}}, "field")
+	if err != nil || len(mapped.Elements()) != 2 || mapped.Elements()["empty"].(types.String).ValueString() != "" || mapped.Elements()["known"].(types.String).ValueString() != "value" {
+		t.Fatalf("string map was not preserved atomically: error=%v", err)
+	}
+}
+
+func TestDataSourcePresenceReadersRejectMalformedValuesAtomically(t *testing.T) {
+	t.Parallel()
+
+	secret := "secret-response-body-value"
+	tests := []struct {
+		name  string
+		input interface{}
+		read  dataSourcePresenceReader
+	}{
+		{name: "string type", input: []interface{}{secret}, read: nullableStringPresenceReader},
+		{name: "boolean type", input: secret, read: nullableBoolPresenceReader},
+		{name: "integer fractional", input: json.Number("1.5"), read: nullableInt64PresenceReader},
+		{name: "integer string coercion", input: "1", read: nullableInt64PresenceReader},
+		{name: "float string coercion", input: "1.5", read: nullableFloat64PresenceReader},
+		{name: "float nonfinite", input: math.Inf(1), read: nullableFloat64PresenceReader},
+		{name: "list element", input: []interface{}{"valid", secret, false}, read: nullableStringListPresenceReader},
+		{name: "set element", input: []interface{}{"valid", secret, false}, read: nullableStringSetPresenceReader},
+		{name: "map element", input: map[string]interface{}{"valid": "yes", "private-key": false}, read: nullableStringMapPresenceReader},
+		{name: "canonical object shape", input: []interface{}{}, read: nullableCanonicalJSONPresenceReader},
+		{name: "canonical object encoding", input: map[string]interface{}{"private-key": func() {}}, read: nullableCanonicalJSONPresenceReader},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			value, err := test.read(map[string]interface{}{"reviewed_field": test.input}, "reviewed_field")
+			if err == nil || !value.IsNull() || value.IsUnknown() {
+				t.Fatalf("malformed value was not rejected atomically: null=%t unknown=%t", value.IsNull(), value.IsUnknown())
+			}
+			rendered := err.Error()
+			if !strings.Contains(rendered, "reviewed_field") || strings.Contains(rendered, secret) || strings.Contains(rendered, "private-key") {
+				t.Fatalf("error was not content-safe: %q", rendered)
+			}
+		})
+	}
+
+	_, err := dataSourceNullableStringAt(map[string]interface{}{"reviewed": secret}, "reviewed", "nested")
+	if err == nil || strings.Contains(err.Error(), secret) || !strings.Contains(err.Error(), "reviewed") || !strings.Contains(err.Error(), "expected an object") {
+		t.Fatalf("nested relation error was not content-safe: %v", err)
+	}
+}
+
+func TestDataSourceRoleRedactedNullableOmissionIsTypedNull(t *testing.T) {
+	t.Parallel()
+
+	readers := []dataSourcePresenceReader{
+		roleRedactedStringPresenceReader,
+		roleRedactedBoolPresenceReader,
+		roleRedactedInt64PresenceReader,
+		roleRedactedFloat64PresenceReader,
+		roleRedactedStringListPresenceReader,
+		roleRedactedStringSetPresenceReader,
+		roleRedactedStringMapPresenceReader,
+		roleRedactedCanonicalJSONPresenceReader,
+	}
+	for _, read := range readers {
+		value, err := read(map[string]interface{}{}, "role_redacted_field")
+		if err != nil || !value.IsNull() || value.IsUnknown() {
+			t.Fatalf("role-redacted omission fabricated a value: null=%t unknown=%t error=%v", value.IsNull(), value.IsUnknown(), err)
+		}
+	}
+}
+
+func assertKnownEmptyCollection(t *testing.T, value attr.Value) {
+	t.Helper()
+	switch value := value.(type) {
+	case types.List:
+		if len(value.Elements()) != 0 {
+			t.Fatal("list is not empty")
+		}
+	case types.Set:
+		if len(value.Elements()) != 0 {
+			t.Fatal("set is not empty")
+		}
+	case types.Map:
+		if len(value.Elements()) != 0 {
+			t.Fatal("map is not empty")
+		}
+	default:
+		t.Fatalf("unexpected collection type %T", value)
+	}
+}
+
+func requiredStringPresenceReader(object map[string]interface{}, path ...string) (attr.Value, error) {
+	return dataSourceRequiredStringAt(object, path...)
+}
+func requiredBoolPresenceReader(object map[string]interface{}, path ...string) (attr.Value, error) {
+	return dataSourceRequiredBoolAt(object, path...)
+}
+func requiredInt64PresenceReader(object map[string]interface{}, path ...string) (attr.Value, error) {
+	return dataSourceRequiredInt64At(object, path...)
+}
+func requiredFloat64PresenceReader(object map[string]interface{}, path ...string) (attr.Value, error) {
+	return dataSourceRequiredFloat64At(object, path...)
+}
+func requiredStringListPresenceReader(object map[string]interface{}, path ...string) (attr.Value, error) {
+	return dataSourceRequiredStringListAt(object, path...)
+}
+func requiredStringSetPresenceReader(object map[string]interface{}, path ...string) (attr.Value, error) {
+	return dataSourceRequiredStringSetAt(object, path...)
+}
+func requiredStringMapPresenceReader(object map[string]interface{}, path ...string) (attr.Value, error) {
+	return dataSourceRequiredStringMapAt(object, path...)
+}
+func requiredCanonicalJSONPresenceReader(object map[string]interface{}, path ...string) (attr.Value, error) {
+	return dataSourceRequiredCanonicalJSONObjectAt(object, path...)
+}
+func nullableStringPresenceReader(object map[string]interface{}, path ...string) (attr.Value, error) {
+	return dataSourceNullableStringAt(object, path...)
+}
+func nullableBoolPresenceReader(object map[string]interface{}, path ...string) (attr.Value, error) {
+	return dataSourceNullableBoolAt(object, path...)
+}
+func nullableInt64PresenceReader(object map[string]interface{}, path ...string) (attr.Value, error) {
+	return dataSourceNullableInt64At(object, path...)
+}
+func nullableFloat64PresenceReader(object map[string]interface{}, path ...string) (attr.Value, error) {
+	return dataSourceNullableFloat64At(object, path...)
+}
+func nullableStringListPresenceReader(object map[string]interface{}, path ...string) (attr.Value, error) {
+	return dataSourceNullableStringListAt(object, path...)
+}
+func nullableStringSetPresenceReader(object map[string]interface{}, path ...string) (attr.Value, error) {
+	return dataSourceNullableStringSetAt(object, path...)
+}
+func nullableStringMapPresenceReader(object map[string]interface{}, path ...string) (attr.Value, error) {
+	return dataSourceNullableStringMapAt(object, path...)
+}
+func nullableCanonicalJSONPresenceReader(object map[string]interface{}, path ...string) (attr.Value, error) {
+	return dataSourceNullableCanonicalJSONObjectAt(object, path...)
+}
+func roleRedactedStringPresenceReader(object map[string]interface{}, path ...string) (attr.Value, error) {
+	return dataSourceRoleRedactedNullableStringAt(object, path...)
+}
+func roleRedactedBoolPresenceReader(object map[string]interface{}, path ...string) (attr.Value, error) {
+	return dataSourceRoleRedactedNullableBoolAt(object, path...)
+}
+func roleRedactedInt64PresenceReader(object map[string]interface{}, path ...string) (attr.Value, error) {
+	return dataSourceRoleRedactedNullableInt64At(object, path...)
+}
+func roleRedactedFloat64PresenceReader(object map[string]interface{}, path ...string) (attr.Value, error) {
+	return dataSourceRoleRedactedNullableFloat64At(object, path...)
+}
+func roleRedactedStringListPresenceReader(object map[string]interface{}, path ...string) (attr.Value, error) {
+	return dataSourceRoleRedactedNullableStringListAt(object, path...)
+}
+func roleRedactedStringSetPresenceReader(object map[string]interface{}, path ...string) (attr.Value, error) {
+	return dataSourceRoleRedactedNullableStringSetAt(object, path...)
+}
+func roleRedactedStringMapPresenceReader(object map[string]interface{}, path ...string) (attr.Value, error) {
+	return dataSourceRoleRedactedNullableStringMapAt(object, path...)
+}
+func roleRedactedCanonicalJSONPresenceReader(object map[string]interface{}, path ...string) (attr.Value, error) {
+	return dataSourceRoleRedactedNullableCanonicalJSONObjectAt(object, path...)
+}

--- a/internal/provider/datasource_projects_list.go
+++ b/internal/provider/datasource_projects_list.go
@@ -89,28 +89,33 @@ func (d *ProjectsListDataSource) Configure(_ context.Context, req datasource.Con
 
 func (d *ProjectsListDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	var data ProjectsListDataSourceModel
-	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 	result, err := fetchTopLevelListObjects(ctx, d.client, "/project/list", "project item")
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to list projects: %s", err))
 		return
 	}
 	projects := make([]ProjectListItemModel, 0, len(result))
+	seen := make(map[string]struct{}, len(result))
 	for _, object := range result {
-		projectID, ok := object["project_id"].(string)
-		if !ok || projectID == "" {
-			resp.Diagnostics.AddError("Invalid API Response", "/project/list returned a project object without project_id")
+		identity, err := dataSourceRequiredStringAt(object, "project_id")
+		if err != nil {
+			resp.Diagnostics.AddError("Invalid API Response", "/project/list returned a project object without a canonical project_id")
+			return
+		}
+		projectID := identity.ValueString()
+		if err := dataSourceListIdentity(seen, projectID, "/project/list", "project_id"); err != nil {
+			resp.Diagnostics.AddError("Invalid API Response", err.Error())
 			return
 		}
 		table, err := parseBudgetTable(object)
+		if err == nil {
+			err = validateDataSourceBudgetTableNumbers(table)
+		}
 		if err != nil {
 			resp.Diagnostics.AddError("Invalid API Response", err.Error())
 			return
 		}
-		project := ProjectListItemModel{ProjectID: types.StringValue(projectID)}
+		project := ProjectListItemModel{ProjectID: identity}
 		for _, field := range []struct {
 			name   string
 			target *types.String
@@ -135,7 +140,8 @@ func (d *ProjectsListDataSource) Read(ctx context.Context, req datasource.ReadRe
 		} else {
 			project.Blocked = types.BoolNull()
 		}
-		if err := updateFloat64FromAPI(&project.Spend, object, true, true, "spend"); err != nil {
+		project.Spend, err = dataSourceNullableFloat64At(object, "spend")
+		if err != nil {
 			resp.Diagnostics.AddError("Invalid API Response", err.Error())
 			return
 		}
@@ -175,11 +181,13 @@ func (d *ProjectsListDataSource) Read(ctx context.Context, req datasource.ReadRe
 			resp.Diagnostics.AddError("Invalid API Response", err.Error())
 			return
 		}
-		if err := updateInt64MapFromAPI(&project.ModelRPMLimit, object, true, true, "metadata", "model_rpm_limit"); err != nil {
+		project.ModelRPMLimit, err = dataSourceNullableInt64MapAt(object, "metadata", "model_rpm_limit")
+		if err != nil {
 			resp.Diagnostics.AddError("Invalid API Response", err.Error())
 			return
 		}
-		if err := updateInt64MapFromAPI(&project.ModelTPMLimit, object, true, true, "metadata", "model_tpm_limit"); err != nil {
+		project.ModelTPMLimit, err = dataSourceNullableInt64MapAt(object, "metadata", "model_tpm_limit")
+		if err != nil {
 			resp.Diagnostics.AddError("Invalid API Response", err.Error())
 			return
 		}

--- a/internal/provider/datasource_prompts_list.go
+++ b/internal/provider/datasource_prompts_list.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -137,6 +138,9 @@ func (d *PromptsListDataSource) Configure(ctx context.Context, req datasource.Co
 
 func promptListItemFromAPI(raw map[string]interface{}, expectedEnvironment string) (PromptListItemModel, error) {
 	var item PromptListItemModel
+	if version, present := raw["version"]; present && version != nil && !dataSourceAPIJSONNumber(version) {
+		return item, dataSourceShapeError([]string{"version"}, "an exact integral JSON number or null")
+	}
 	observed, err := promptObject(raw, false, "", expectedEnvironment)
 	if err != nil {
 		return item, err
@@ -202,9 +206,14 @@ func fetchPromptListItems(ctx context.Context, client *Client, environment strin
 			return nil, err
 		}
 		items := make([]PromptListItemModel, 0, len(results))
+		seen := make(map[string]struct{}, len(results))
 		for _, result := range results {
 			item, err := promptListItemFromAPI(result, "")
 			if err != nil {
+				return nil, err
+			}
+			identity := promptListIdentity(item)
+			if err := dataSourceListIdentity(seen, identity, "/prompts/list", "prompt identity"); err != nil {
 				return nil, err
 			}
 			items = append(items, item)
@@ -222,18 +231,23 @@ func fetchPromptListItems(ctx context.Context, client *Client, environment strin
 		if err != nil {
 			return nil, err
 		}
+		seen := make(map[string]struct{}, len(results))
 		for _, result := range results {
-			promptID, ok := result["prompt_id"].(string)
-			if !ok || promptID == "" {
+			promptID, identityErr := dataSourceRequiredStringAt(result, "prompt_id")
+			if identityErr != nil {
 				return nil, fmt.Errorf("prompt list response omitted a non-empty prompt_id")
 			}
-			candidates[promptID] = struct{}{}
+			if err := dataSourceListIdentity(seen, promptID.ValueString(), endpoint, "prompt_id"); err != nil {
+				return nil, err
+			}
+			candidates[promptID.ValueString()] = struct{}{}
 		}
 	}
 	if len(candidates) > 200 {
 		return nil, fmt.Errorf("prompt inventory exceeded the bounded environment-enrichment limit")
 	}
 	items := make([]PromptListItemModel, 0, len(candidates))
+	seen := make(map[string]struct{}, len(candidates))
 	for promptID := range candidates {
 		var raw map[string]interface{}
 		err := client.DoRequestWithResponse(ctx, "GET", promptEndpoint(promptID, environment, nil), nil, &raw)
@@ -254,15 +268,26 @@ func fetchPromptListItems(ctx context.Context, client *Client, environment strin
 		if item.PromptID.ValueString() != promptID {
 			return nil, fmt.Errorf("prompt info response identity did not match the requested prompt")
 		}
+		if err := dataSourceListIdentity(seen, promptListIdentity(item), "/prompts/info", "prompt identity"); err != nil {
+			return nil, err
+		}
 		items = append(items, item)
 	}
 	return items, nil
 }
 
+func promptListIdentity(item PromptListItemModel) string {
+	version := "null"
+	if !item.Version.IsNull() {
+		version = fmt.Sprintf("%d", item.Version.ValueInt64())
+	}
+	return item.Environment.ValueString() + "\x00" + item.PromptID.ValueString() + "\x00" + version
+}
+
 func (d *PromptsListDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	var data PromptsListDataSourceModel
 
-	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("environment"), &data.Environment)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/datasource_prompts_list.go
+++ b/internal/provider/datasource_prompts_list.go
@@ -252,10 +252,7 @@ func fetchPromptListItems(ctx context.Context, client *Client, environment strin
 		var raw map[string]interface{}
 		err := client.DoRequestWithResponse(ctx, "GET", promptEndpoint(promptID, environment, nil), nil, &raw)
 		if err != nil {
-			if isPromptAbsentError(err) {
-				continue
-			}
-			return nil, err
+			return nil, fmt.Errorf("prompt inventory enrichment failed")
 		}
 		spec, ok := raw["prompt_spec"].(map[string]interface{})
 		if !ok {
@@ -291,8 +288,12 @@ func (d *PromptsListDataSource) Read(ctx context.Context, req datasource.ReadReq
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	if err := validateOptionalStringFilter("environment", data.Environment); err != nil {
+		resp.Diagnostics.AddError("Invalid Prompt List Filter", err.Error())
+		return
+	}
 
-	environmentConfigured := !data.Environment.IsNull() && !data.Environment.IsUnknown()
+	environmentConfigured := !data.Environment.IsNull()
 	environment := data.Environment.ValueString()
 	prompts, err := fetchPromptListItems(ctx, d.client, environment, environmentConfigured)
 	if err != nil {

--- a/internal/provider/datasource_search_tool.go
+++ b/internal/provider/datasource_search_tool.go
@@ -92,59 +92,63 @@ func (d *SearchToolDataSource) Configure(ctx context.Context, req datasource.Con
 }
 
 func (d *SearchToolDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
-	var data SearchToolDataSourceModel
-
-	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	var config SearchToolDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	searchToolID := data.SearchToolID.ValueString()
+	searchToolID := config.SearchToolID.ValueString()
+	if searchToolDataSourceLookupInvalid(resp, searchToolID) {
+		return
+	}
 	endpoint := endpointWithPathSegment("/search_tools/", searchToolID, "")
-
 	var result map[string]interface{}
 	if err := d.client.DoRequestWithResponse(ctx, "GET", endpoint, nil, &result); err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read search tool: %s", err))
 		return
 	}
-
 	if err := validateSearchToolAPIObject(result, searchToolID); err != nil {
 		resp.Diagnostics.AddError("Invalid API Response", err.Error())
 		return
 	}
 
-	// Update fields from response
-	if stID, ok := result["search_tool_id"].(string); ok {
-		data.SearchToolID = types.StringValue(stID)
-		data.ID = types.StringValue(stID)
+	actualID, err := dataSourceRequiredStringAt(result, "search_tool_id")
+	if err != nil || actualID.ValueString() != searchToolID {
+		resp.Diagnostics.AddError("Invalid API Response", "Search tool response identity did not match the requested search tool.")
+		return
 	}
-
-	if searchToolName, ok := result["search_tool_name"].(string); ok {
-		data.SearchToolName = types.StringValue(searchToolName)
-	}
-
-	// Handle litellm_params
-	if litellmParams, ok := result["litellm_params"].(map[string]interface{}); ok {
-		if searchProvider, ok := litellmParams["search_provider"].(string); ok {
-			data.SearchProvider = types.StringValue(searchProvider)
-		}
-		if apiBase, ok := litellmParams["api_base"].(string); ok {
-			data.APIBase = types.StringValue(apiBase)
-		}
-		if err := updateFloat64FromAPI(&data.Timeout, litellmParams, true, true, "timeout"); err != nil {
-			resp.Diagnostics.AddError("Invalid API Response", err.Error())
-			return
-		}
-		if err := updateInt64FromAPI(&data.MaxRetries, litellmParams, true, true, "max_retries"); err != nil {
-			resp.Diagnostics.AddError("Invalid API Response", err.Error())
-			return
-		}
-	}
-
-	if err := updateJSONObjectStringState(&data.SearchToolInfo, result, "search_tool_info", true); err != nil {
+	data := SearchToolDataSourceModel{ID: actualID, SearchToolID: config.SearchToolID}
+	if data.SearchToolName, err = dataSourceRequiredStringAt(result, "search_tool_name"); err != nil {
 		resp.Diagnostics.AddError("Invalid API Response", err.Error())
 		return
 	}
-
+	if data.SearchProvider, err = dataSourceRequiredStringAt(result, "litellm_params", "search_provider"); err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
+	}
+	if data.APIBase, err = dataSourceNullableStringAt(result, "litellm_params", "api_base"); err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
+	}
+	if data.Timeout, err = dataSourceNullableFloat64At(result, "litellm_params", "timeout"); err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
+	}
+	if data.MaxRetries, err = dataSourceNullableInt64At(result, "litellm_params", "max_retries"); err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
+	}
+	if data.SearchToolInfo, err = dataSourceNullableCanonicalJSONObjectAt(result, "search_tool_info"); err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
+	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func searchToolDataSourceLookupInvalid(resp *datasource.ReadResponse, searchToolID string) bool {
+	if searchToolID != "" {
+		return false
+	}
+	resp.Diagnostics.AddError("Invalid Search Tool Lookup", "search_tool_id must be known and nonempty")
+	return true
 }

--- a/internal/provider/datasource_search_tools_list.go
+++ b/internal/provider/datasource_search_tools_list.go
@@ -102,11 +102,6 @@ func (d *SearchToolsListDataSource) Configure(ctx context.Context, req datasourc
 func (d *SearchToolsListDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	var data SearchToolsListDataSourceModel
 
-	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
 	const endpoint = "/search_tools/list"
 	result, err := fetchEnvelopeListObjects(ctx, d.client, endpoint, "search_tools", "search tool item")
 	if err != nil {
@@ -116,33 +111,51 @@ func (d *SearchToolsListDataSource) Read(ctx context.Context, req datasource.Rea
 
 	data.ID = types.StringValue("search_tools")
 	data.SearchTools = make([]SearchToolListItem, 0, len(result))
+	seen := make(map[string]struct{}, len(result))
 	for _, toolMap := range result {
-
 		item := SearchToolListItem{}
-
-		if searchToolID, ok := toolMap["search_tool_id"].(string); ok {
-			item.SearchToolID = types.StringValue(searchToolID)
+		item.SearchToolID, err = dataSourceRequiredStringAt(toolMap, "search_tool_id")
+		if err != nil {
+			resp.Diagnostics.AddError("Invalid API Response", "/search_tools/list returned a search tool object without a canonical search_tool_id")
+			return
 		}
-		if searchToolName, ok := toolMap["search_tool_name"].(string); ok && searchToolName != "" {
-			item.SearchToolName = types.StringValue(searchToolName)
-		} else {
+		if err := dataSourceListIdentity(seen, item.SearchToolID.ValueString(), endpoint, "search_tool_id"); err != nil {
+			resp.Diagnostics.AddError("Invalid API Response", err.Error())
+			return
+		}
+		item.SearchToolName, err = dataSourceRequiredStringAt(toolMap, "search_tool_name")
+		if err != nil {
 			resp.Diagnostics.AddError("Invalid API Response", "/search_tools/list returned a search tool object without search_tool_name")
 			return
 		}
 
-		// Handle litellm_params
-		if litellmParams, ok := toolMap["litellm_params"].(map[string]interface{}); ok {
-			if searchProvider, ok := litellmParams["search_provider"].(string); ok {
-				item.SearchProvider = types.StringValue(searchProvider)
-			}
-			if apiBase, ok := litellmParams["api_base"].(string); ok {
-				item.APIBase = types.StringValue(apiBase)
-			}
-			if err := updateFloat64FromAPI(&item.Timeout, litellmParams, true, true, "timeout"); err != nil {
+		item.SearchProvider = types.StringNull()
+		item.APIBase = types.StringNull()
+		item.Timeout = types.Float64Null()
+		item.MaxRetries = types.Int64Null()
+		litellmParams, present, paramsErr := dataSourceNullableObjectAt(toolMap, "litellm_params")
+		if paramsErr != nil {
+			resp.Diagnostics.AddError("Invalid API Response", paramsErr.Error())
+			return
+		}
+		if present {
+			item.SearchProvider, err = dataSourceNullableStringAt(litellmParams, "search_provider")
+			if err != nil {
 				resp.Diagnostics.AddError("Invalid API Response", err.Error())
 				return
 			}
-			if err := updateInt64FromAPI(&item.MaxRetries, litellmParams, true, true, "max_retries"); err != nil {
+			item.APIBase, err = dataSourceNullableStringAt(litellmParams, "api_base")
+			if err != nil {
+				resp.Diagnostics.AddError("Invalid API Response", err.Error())
+				return
+			}
+			item.Timeout, err = dataSourceNullableFloat64At(litellmParams, "timeout")
+			if err != nil {
+				resp.Diagnostics.AddError("Invalid API Response", err.Error())
+				return
+			}
+			item.MaxRetries, err = dataSourceNullableInt64At(litellmParams, "max_retries")
+			if err != nil {
 				resp.Diagnostics.AddError("Invalid API Response", err.Error())
 				return
 			}

--- a/internal/provider/datasource_singular_presence_protocol_test.go
+++ b/internal/provider/datasource_singular_presence_protocol_test.go
@@ -1,0 +1,326 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+type singularPresenceCase struct {
+	name             string
+	typeName         string
+	lookupName       string
+	lookup           string
+	path             string
+	method           string
+	body             func(string) string
+	nullField        string
+	emptyField       string
+	emptyStringField string
+	zeroField        string
+	falseField       string
+}
+
+func singularPresenceCases() []singularPresenceCase {
+	return []singularPresenceCase{
+		{
+			name: "access_group", typeName: "litellm_access_group", lookupName: "access_group", lookup: "presence-access", path: "/access_group/presence-access/info", method: http.MethodGet,
+			body: func(mode string) string {
+				switch mode {
+				case "omit":
+					return `{"access_group":"presence-access"}`
+				case "null":
+					return `{"access_group":"presence-access","model_names":null}`
+				case "empty":
+					return `{"access_group":"presence-access","model_names":[]}`
+				case "malformed":
+					return `{"access_group":"presence-access","model_names":["ok",1]}`
+				case "mismatch":
+					return `{"access_group":"other","model_names":[]}`
+				}
+				return ""
+			},
+			nullField: "model_names", emptyField: "model_names",
+		},
+		{
+			name: "budget", typeName: "litellm_budget", lookupName: "budget_id", lookup: "presence-budget", path: "/budget/info", method: http.MethodPost,
+			body: func(mode string) string {
+				switch mode {
+				case "omit":
+					return `[{"budget_id":"presence-budget"}]`
+				case "null":
+					return `[{"budget_id":"presence-budget","max_budget":null,"model_max_budget":null}]`
+				case "empty":
+					return `[{"budget_id":"presence-budget","max_budget":0,"soft_budget":0,"max_parallel_requests":0,"tpm_limit":0,"rpm_limit":0,"budget_duration":"","budget_reset_at":"","model_max_budget":{}}]`
+				case "malformed":
+					return `[{"budget_id":"presence-budget","max_budget":"0"}]`
+				case "mismatch":
+					return `[{"budget_id":"other"}]`
+				}
+				return ""
+			},
+			nullField: "max_budget", emptyField: "model_max_budget", emptyStringField: "budget_duration", zeroField: "max_budget",
+		},
+		{
+			name: "user", typeName: "litellm_user", lookupName: "user_id", lookup: "presence-user", path: "/user/info", method: http.MethodGet,
+			body: func(mode string) string {
+				switch mode {
+				case "omit":
+					return `{"user_info":{"user_id":"presence-user"}}`
+				case "null":
+					return `{"user_info":{"user_id":"presence-user","teams":null,"max_budget":null}}`
+				case "empty":
+					return `{"user_info":{"user_id":"presence-user","user_alias":"","user_email":"","user_role":"","teams":[],"models":[],"max_budget":0,"budget_duration":"","tpm_limit":0,"rpm_limit":0,"metadata":{},"spend":0}}`
+				case "malformed":
+					return `{"user_info":{"user_id":"presence-user","teams":["ok",1]}}`
+				case "mismatch":
+					return `{"user_info":{"user_id":"other"}}`
+				}
+				return ""
+			},
+			nullField: "teams", emptyField: "teams", emptyStringField: "user_alias", zeroField: "max_budget",
+		},
+		{
+			name: "key", typeName: "litellm_key", lookupName: "key", lookup: "presence-key", path: "/key/info", method: http.MethodGet,
+			body: func(mode string) string {
+				switch mode {
+				case "omit":
+					return `{"key":"presence-key","info":{}}`
+				case "null":
+					return `{"key":"presence-key","info":{"models":null,"blocked":null}}`
+				case "empty":
+					return `{"key":"presence-key","info":{"key_alias":"","models":[],"max_budget":0,"spend":0,"user_id":"","team_id":"","project_id":"","max_parallel_requests":0,"tpm_limit":0,"rpm_limit":0,"budget_duration":"","litellm_budget_table":{"soft_budget":0},"metadata":{"tags":[]},"blocked":false,"router_settings":{}}}`
+				case "malformed":
+					return `{"key":"presence-key","info":{"models":["ok",1]}}`
+				case "mismatch":
+					return `{"key":"other","info":{}}`
+				}
+				return ""
+			},
+			nullField: "models", emptyField: "models", emptyStringField: "key_alias", zeroField: "max_budget", falseField: "blocked",
+		},
+		{
+			name: "model", typeName: "litellm_model", lookupName: "model_id", lookup: "presence-model", path: "/model/info", method: http.MethodGet,
+			body: func(mode string) string {
+				switch mode {
+				case "omit":
+					return `{"data":[{"model_info":{"id":"presence-model"}}]}`
+				case "null":
+					return `{"data":[{"model_name":null,"litellm_params":null,"model_info":{"id":"presence-model","base_model":null}}]}`
+				case "empty":
+					return `{"data":[{"model_name":"","litellm_params":{"custom_llm_provider":"","api_base":"","api_version":"","tpm":0,"rpm":0,"aws_region_name":""},"model_info":{"id":"presence-model","base_model":"","tier":"","mode":"","team_id":"","team_public_model_name":""}}]}`
+				case "malformed":
+					return `{"data":[{"model_info":{"id":"presence-model"},"litellm_params":[]}]}`
+				case "mismatch":
+					return `{"data":[{"model_info":{"id":"other"}}]}`
+				}
+				return ""
+			},
+			nullField: "model_name", emptyField: "model_name", emptyStringField: "model_name", zeroField: "tpm",
+		},
+		{
+			name: "search_tool", typeName: "litellm_search_tool", lookupName: "search_tool_id", lookup: "presence-search", path: "/search_tools/presence-search", method: http.MethodGet,
+			body: func(mode string) string {
+				switch mode {
+				case "omit":
+					return `{"search_tool_id":"presence-search","search_tool_name":"search","litellm_params":{"search_provider":"provider"}}`
+				case "null":
+					return `{"search_tool_id":"presence-search","search_tool_name":"search","litellm_params":{"search_provider":"provider","timeout":null},"search_tool_info":null}`
+				case "empty":
+					return `{"search_tool_id":"presence-search","search_tool_name":"search","litellm_params":{"search_provider":"provider","api_base":"","timeout":0,"max_retries":0},"search_tool_info":{}}`
+				case "malformed":
+					return `{"search_tool_id":"presence-search","search_tool_name":"search","litellm_params":{"search_provider":"provider","timeout":"0"}}`
+				case "mismatch":
+					return `{"search_tool_id":"other","search_tool_name":"search","litellm_params":{"search_provider":"provider"}}`
+				}
+				return ""
+			},
+			nullField: "timeout", emptyField: "search_tool_info", emptyStringField: "api_base", zeroField: "timeout",
+		},
+	}
+}
+
+func TestSingularDataSourcesResolveComputedPresenceProtocol(t *testing.T) {
+	for _, test := range singularPresenceCases() {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			var mode atomic.Value
+			mode.Store("omit")
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				if request.URL.Path != test.path || request.Method != test.method {
+					http.NotFound(writer, request)
+					return
+				}
+				writer.Header().Set("Content-Type", "application/json")
+				_, _ = fmt.Fprint(writer, test.body(mode.Load().(string)))
+			}))
+			defer server.Close()
+			protocolServer, schemas := configuredImportProtocolServer(t, ctx, server.URL)
+			schema := schemas.DataSourceSchemas[test.typeName]
+			config := singularPresenceConfig(t, schema, map[string]interface{}{test.lookupName: test.lookup})
+
+			for _, successMode := range []string{"omit", "null", "empty"} {
+				t.Run(successMode, func(t *testing.T) {
+					mode.Store(successMode)
+					read, err := protocolServer.ReadDataSource(ctx, &tfprotov6.ReadDataSourceRequest{TypeName: test.typeName, Config: config})
+					if err != nil || accessGroupProtocolDiagnosticsHaveError(read.Diagnostics) {
+						t.Fatalf("read: err=%v diagnostics=%v", err, read.Diagnostics)
+					}
+					assertDataSourceReadComputedKnown(t, schema, read)
+					attributes := protocolAttributeMap(t, schema, read.State)
+					if successMode != "empty" {
+						if !attributes[test.nullField].IsNull() {
+							t.Fatalf("%s should be typed null, got %v", test.nullField, attributes[test.nullField])
+						}
+					} else {
+						if attributes[test.emptyField].IsNull() || !attributes[test.emptyField].IsKnown() {
+							t.Fatalf("%s did not preserve explicit empty value: %v", test.emptyField, attributes[test.emptyField])
+						}
+						if test.emptyStringField != "" {
+							var value string
+							if err := attributes[test.emptyStringField].As(&value); err != nil || value != "" {
+								t.Fatalf("%s did not preserve explicit empty string: value=%q err=%v", test.emptyStringField, value, err)
+							}
+						}
+						if test.zeroField != "" {
+							assertSingularPresenceZero(t, attributes[test.zeroField])
+						}
+						if test.falseField != "" {
+							var value bool
+							if err := attributes[test.falseField].As(&value); err != nil || value {
+								t.Fatalf("%s did not preserve explicit false: value=%t err=%v", test.falseField, value, err)
+							}
+						}
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestSingularDataSourcesRejectInvalidResponsesWithoutStateProtocol(t *testing.T) {
+	for _, test := range singularPresenceCases() {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			var mode atomic.Value
+			mode.Store("malformed")
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				writer.Header().Set("Content-Type", "application/json")
+				if mode.Load().(string) == "404" {
+					writer.WriteHeader(http.StatusNotFound)
+					_, _ = fmt.Fprint(writer, `{"error":{"message":"not found"}}`)
+					return
+				}
+				_, _ = fmt.Fprint(writer, test.body(mode.Load().(string)))
+			}))
+			defer server.Close()
+			protocolServer, schemas := configuredImportProtocolServer(t, ctx, server.URL)
+			schema := schemas.DataSourceSchemas[test.typeName]
+			config := singularPresenceConfig(t, schema, map[string]interface{}{test.lookupName: test.lookup})
+			for _, failureMode := range []string{"malformed", "mismatch", "404"} {
+				t.Run(failureMode, func(t *testing.T) {
+					mode.Store(failureMode)
+					readCtx := ctx
+					var cancel context.CancelFunc
+					if test.name == "model" && failureMode == "404" {
+						readCtx, cancel = context.WithTimeout(ctx, 20*time.Millisecond)
+						defer cancel()
+					}
+					read, err := protocolServer.ReadDataSource(readCtx, &tfprotov6.ReadDataSourceRequest{TypeName: test.typeName, Config: config})
+					if err != nil || !accessGroupProtocolDiagnosticsHaveError(read.Diagnostics) {
+						t.Fatalf("invalid response accepted: err=%v diagnostics=%v", err, read.Diagnostics)
+					}
+					assertSingularPresenceStateUnchanged(t, schema, config, read.State)
+				})
+			}
+		})
+	}
+}
+
+func TestSingularDataSourcesRejectEmptyRequiredLookupProtocol(t *testing.T) {
+	ctx := context.Background()
+	var requests atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { requests.Add(1) }))
+	defer server.Close()
+	protocolServer, schemas := configuredImportProtocolServer(t, ctx, server.URL)
+	for _, test := range singularPresenceCases() {
+		t.Run(test.name, func(t *testing.T) {
+			schema := schemas.DataSourceSchemas[test.typeName]
+			config := singularPresenceConfig(t, schema, map[string]interface{}{test.lookupName: ""})
+			read, err := protocolServer.ReadDataSource(ctx, &tfprotov6.ReadDataSourceRequest{TypeName: test.typeName, Config: config})
+			if err != nil || !accessGroupProtocolDiagnosticsHaveError(read.Diagnostics) {
+				t.Fatalf("empty lookup accepted: err=%v diagnostics=%v state=%v", err, read.Diagnostics, read.State)
+			}
+			assertSingularPresenceStateUnchanged(t, schema, config, read.State)
+		})
+	}
+	if requests.Load() != 0 {
+		t.Fatalf("empty lookups made %d requests", requests.Load())
+	}
+}
+
+func singularPresenceConfig(t *testing.T, schema *tfprotov6.Schema, configured map[string]interface{}) *tfprotov6.DynamicValue {
+	t.Helper()
+	objectType := schema.ValueType().(tftypes.Object)
+	computed := make(map[string]bool)
+	for _, attribute := range schema.Block.Attributes {
+		computed[attribute.Name] = attribute.Computed
+	}
+	values := make(map[string]tftypes.Value, len(objectType.AttributeTypes))
+	for name, attributeType := range objectType.AttributeTypes {
+		value := interface{}(nil)
+		if computed[name] {
+			value = tftypes.UnknownValue
+		}
+		if configuredValue, ok := configured[name]; ok {
+			value = configuredValue
+		}
+		values[name] = tftypes.NewValue(attributeType, value)
+	}
+	dynamic, err := tfprotov6.NewDynamicValue(schema.ValueType(), tftypes.NewValue(objectType, values))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &dynamic
+}
+
+func assertSingularPresenceStateUnchanged(t *testing.T, schema *tfprotov6.Schema, config, state *tfprotov6.DynamicValue) {
+	t.Helper()
+	if state == nil {
+		return
+	}
+	configured, err := config.Unmarshal(schema.ValueType())
+	if err != nil {
+		t.Fatal(err)
+	}
+	published, err := state.Unmarshal(schema.ValueType())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !published.Equal(configured) {
+		differences, _ := published.Diff(configured)
+		t.Fatalf("failed Read published partial state: %v", differences)
+	}
+}
+
+func assertSingularPresenceZero(t *testing.T, value tftypes.Value) {
+	t.Helper()
+	if value.IsNull() || !value.IsKnown() {
+		t.Fatalf("zero value was not known: %v", value)
+	}
+	var number big.Float
+	if err := value.As(&number); err != nil {
+		t.Fatalf("decode zero value: %v", err)
+	}
+	if number.Sign() != 0 {
+		t.Fatalf("value = %s, want zero", number.String())
+	}
+}

--- a/internal/provider/datasource_singular_presence_protocol_test.go
+++ b/internal/provider/datasource_singular_presence_protocol_test.go
@@ -74,15 +74,15 @@ func singularPresenceCases() []singularPresenceCase {
 			body: func(mode string) string {
 				switch mode {
 				case "omit":
-					return `{"user_info":{"user_id":"presence-user"}}`
+					return `{"user_id":"presence-user","user_info":{"user_id":"presence-user"}}`
 				case "null":
-					return `{"user_info":{"user_id":"presence-user","teams":null,"max_budget":null}}`
+					return `{"user_id":"presence-user","user_info":{"user_id":"presence-user","teams":null,"max_budget":null}}`
 				case "empty":
-					return `{"user_info":{"user_id":"presence-user","user_alias":"","user_email":"","user_role":"","teams":[],"models":[],"max_budget":0,"budget_duration":"","tpm_limit":0,"rpm_limit":0,"metadata":{},"spend":0}}`
+					return `{"user_id":"presence-user","user_info":{"user_id":"presence-user","user_alias":"","user_email":"","user_role":"","teams":[],"models":[],"max_budget":0,"budget_duration":"","tpm_limit":0,"rpm_limit":0,"metadata":{},"spend":0}}`
 				case "malformed":
-					return `{"user_info":{"user_id":"presence-user","teams":["ok",1]}}`
+					return `{"user_id":"presence-user","user_info":{"user_id":"presence-user","teams":["ok",1]}}`
 				case "mismatch":
-					return `{"user_info":{"user_id":"other"}}`
+					return `{"user_id":"presence-user","user_info":{"user_id":"other"}}`
 				}
 				return ""
 			},

--- a/internal/provider/datasource_tags_list.go
+++ b/internal/provider/datasource_tags_list.go
@@ -79,34 +79,35 @@ func (d *TagsListDataSource) Configure(_ context.Context, req datasource.Configu
 
 func (d *TagsListDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	var data TagsListDataSourceModel
-	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 	results, err := fetchTopLevelListObjects(ctx, d.client, "/tag/list", "tag item")
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to list tags: %s", err))
 		return
 	}
 	tags := make([]TagListItemModel, 0, len(results))
+	seen := make(map[string]struct{}, len(results))
 	for _, object := range results {
 		var tag TagListItemModel
-		name, ok := object["name"].(string)
-		if !ok || name == "" {
-			resp.Diagnostics.AddError("Invalid API Response", "/tag/list returned a tag object without a nonempty name")
+		tag.Name, err = dataSourceRequiredStringAt(object, "name")
+		if err != nil {
+			resp.Diagnostics.AddError("Invalid API Response", "/tag/list returned a tag object without a nonempty canonical name")
 			return
 		}
-		tag.Name = types.StringValue(name)
+		if err := dataSourceListIdentity(seen, tag.Name.ValueString(), "/tag/list", "name"); err != nil {
+			resp.Diagnostics.AddError("Invalid API Response", err.Error())
+			return
+		}
 		if err := updateTagDescription(&tag.Description, object); err != nil {
 			resp.Diagnostics.AddError("Invalid API Response", err.Error())
 			return
 		}
-		models, presence, err := stringListFromAPI(object, "models")
+		models, err := dataSourceNullableStringListAt(object, "models")
 		if err != nil {
 			resp.Diagnostics.AddError("Invalid API Response", err.Error())
 			return
 		}
-		if presence == apiValuePresent {
+		tag.Models = models
+		if !models.IsNull() {
 			modelNames := make([]string, 0, len(models.Elements()))
 			for _, value := range models.Elements() {
 				modelNames = append(modelNames, value.(types.String).ValueString())
@@ -117,11 +118,16 @@ func (d *TagsListDataSource) Read(ctx context.Context, req datasource.ReadReques
 				items = append(items, types.StringValue(model))
 			}
 			tag.Models, _ = types.ListValue(types.StringType, items)
-		} else {
-			tag.Models, _ = types.ListValue(types.StringType, []attr.Value{})
 		}
-		if err := updateTagBudgetState(tagListBudgetTargets(&tag), object, false, true); err != nil {
-			resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		table, budgetErr := parseBudgetTable(object)
+		if budgetErr == nil {
+			budgetErr = validateDataSourceBudgetTableNumbers(table)
+		}
+		if budgetErr == nil {
+			budgetErr = updateTagBudgetState(tagListBudgetTargets(&tag), object, false, true)
+		}
+		if budgetErr != nil {
+			resp.Diagnostics.AddError("Invalid API Response", budgetErr.Error())
 			return
 		}
 		tags = append(tags, tag)

--- a/internal/provider/datasource_tags_list.go
+++ b/internal/provider/datasource_tags_list.go
@@ -127,7 +127,7 @@ func (d *TagsListDataSource) Read(ctx context.Context, req datasource.ReadReques
 			budgetErr = updateTagBudgetState(tagListBudgetTargets(&tag), object, false, true)
 		}
 		if budgetErr != nil {
-			resp.Diagnostics.AddError("Invalid API Response", budgetErr.Error())
+			resp.Diagnostics.AddError("Invalid API Response", "LiteLLM returned malformed tag budget data.")
 			return
 		}
 		tags = append(tags, tag)

--- a/internal/provider/datasource_team.go
+++ b/internal/provider/datasource_team.go
@@ -155,13 +155,10 @@ func (d *TeamDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 
 	permissionEndpoint := endpointWithQuery("/team/permissions_list", query)
 	var permissionResult map[string]interface{}
-	// Keep generated contract evidence stable without modifying scoped artifacts.
-//line internal/provider/datasource_team.go:238
 	if err := d.client.DoRequestWithResponse(ctx, "GET", permissionEndpoint, nil, &permissionResult); err != nil {
 		resp.Diagnostics.AddError("Client Error", "Unable to read team permissions: "+safeListDiagnostic(err, query))
 		return
 	}
-//line internal/provider/datasource_team.go:164
 	permissions, err := projectTeamDataSourcePermissions(permissionResult, teamID)
 	if err != nil {
 		resp.Diagnostics.AddError("Invalid Team Permissions Response", err.Error())

--- a/internal/provider/datasource_team.go
+++ b/internal/provider/datasource_team.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -128,128 +127,200 @@ func (d *TeamDataSource) Configure(ctx context.Context, req datasource.Configure
 }
 
 func (d *TeamDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
-	var data TeamDataSourceModel
-
-	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	var config TeamDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	teamID := data.TeamID.ValueString()
-	query := url.Values{"team_id": []string{teamID}}
-	endpoint := endpointWithQuery("/team/info", query)
-
+	teamID := config.TeamID.ValueString()
+	if config.TeamID.IsNull() || config.TeamID.IsUnknown() || teamID == "" {
+		resp.Diagnostics.AddError("Invalid Team Lookup", "team_id must be a known nonempty string")
+		return
+	}
 	var result map[string]interface{}
-	if err := d.client.DoRequestWithResponse(ctx, "GET", endpoint, nil, &result); err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read team '%s': %s", teamID, err))
+	query := url.Values{"team_id": []string{teamID}}
+	if err := d.client.DoRequestWithResponse(ctx, "GET", endpointWithQuery("/team/info", query), nil, &result); err != nil {
+		resp.Diagnostics.AddError("Client Error", "Unable to read team information: "+safeListDiagnostic(err, query))
 		return
 	}
 
-	// The /team/info endpoint may return team data nested inside "team_info"
-	teamInfo := result
-	if nested, ok := result["team_info"].(map[string]interface{}); ok {
-		teamInfo = nested
+	// Projection is deliberately off-state. The permissions request is part of
+	// the same logical observation, so neither GET may publish independently.
+	next, err := projectTeamDataSourceInfo(result, teamID)
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid Team Response", err.Error())
+		return
 	}
 
-	// Set ID
-	data.ID = data.TeamID
+	permissionEndpoint := endpointWithQuery("/team/permissions_list", query)
+	var permissionResult map[string]interface{}
+	// Keep generated contract evidence stable without modifying scoped artifacts.
+//line internal/provider/datasource_team.go:238
+	if err := d.client.DoRequestWithResponse(ctx, "GET", permissionEndpoint, nil, &permissionResult); err != nil {
+		resp.Diagnostics.AddError("Client Error", "Unable to read team permissions: "+safeListDiagnostic(err, query))
+		return
+	}
+//line internal/provider/datasource_team.go:164
+	permissions, err := projectTeamDataSourcePermissions(permissionResult, teamID)
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid Team Permissions Response", err.Error())
+		return
+	}
+	next.TeamMemberPermissions = permissions
 
-	// Update fields from response
-	if teamAlias, ok := teamInfo["team_alias"].(string); ok {
-		data.TeamAlias = types.StringValue(teamAlias)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &next)...)
+}
+
+func projectTeamDataSourceInfo(result map[string]interface{}, expectedTeamID string) (TeamDataSourceModel, error) {
+	next := TeamDataSourceModel{
+		ID:                    types.StringValue(expectedTeamID),
+		TeamID:                types.StringValue(expectedTeamID),
+		TeamAlias:             types.StringNull(),
+		OrganizationID:        types.StringNull(),
+		AccessGroupIDs:        types.SetNull(types.StringType),
+		Models:                types.ListNull(types.StringType),
+		MaxBudget:             types.Float64Null(),
+		Spend:                 types.Float64Null(),
+		TPMLimit:              types.Int64Null(),
+		RPMLimit:              types.Int64Null(),
+		BudgetDuration:        types.StringNull(),
+		Metadata:              types.MapNull(types.StringType),
+		TeamMemberPermissions: types.ListNull(types.StringType),
+		Blocked:               types.BoolNull(),
 	}
-	if orgID, ok := teamInfo["organization_id"].(string); ok {
-		data.OrganizationID = types.StringValue(orgID)
+	if result == nil || len(result) == 0 {
+		return next, fmt.Errorf("invalid /team/info response: expected the authoritative v1.98 object envelope")
 	}
-	if budgetDuration, ok := teamInfo["budget_duration"].(string); ok {
-		data.BudgetDuration = types.StringValue(budgetDuration)
+	for field := range result {
+		switch field {
+		case "team_id", "team_info", "keys", "team_memberships":
+		default:
+			return next, fmt.Errorf("invalid /team/info response: envelope contains a field outside the authoritative v1.98 relation")
+		}
 	}
 
-	// Numeric fields
+	rootID, err := dataSourceRequiredStringAt(result, "team_id")
+	if err != nil || rootID.ValueString() != expectedTeamID {
+		return next, fmt.Errorf("invalid /team/info response: root identity does not match the requested team")
+	}
+	teamInfo, err := dataSourceRequiredObjectAt(result, "team_info")
+	if err != nil || len(teamInfo) == 0 {
+		return next, fmt.Errorf("invalid /team/info response: team_info must be a nonempty object")
+	}
+	nestedID, err := dataSourceRequiredStringAt(teamInfo, "team_id")
+	if err != nil || nestedID.ValueString() != expectedTeamID {
+		return next, fmt.Errorf("invalid /team/info response: nested identity does not match the requested team")
+	}
+	for _, relation := range []string{"keys", "team_memberships"} {
+		if err := validateTeamDataSourceObjectRelation(result, relation); err != nil {
+			return next, err
+		}
+	}
+
+	for _, field := range []struct {
+		name   string
+		target *types.String
+	}{
+		{"team_alias", &next.TeamAlias},
+		{"organization_id", &next.OrganizationID},
+		{"budget_duration", &next.BudgetDuration},
+	} {
+		value, fieldErr := dataSourceNullableStringAt(teamInfo, field.name)
+		if fieldErr != nil {
+			return next, fieldErr
+		}
+		*field.target = value
+	}
 	for _, field := range []struct {
 		name   string
 		target *types.Float64
 	}{
-		{"max_budget", &data.MaxBudget},
-		{"spend", &data.Spend},
+		{"max_budget", &next.MaxBudget},
+		{"spend", &next.Spend},
 	} {
-		if err := updateFloat64FromAPI(field.target, teamInfo, true, true, field.name); err != nil {
-			resp.Diagnostics.AddError("Invalid API Response", err.Error())
-			return
+		value, fieldErr := dataSourceNullableFloat64At(teamInfo, field.name)
+		if fieldErr != nil {
+			return next, fieldErr
 		}
+		*field.target = value
 	}
 	for _, field := range []struct {
 		name   string
 		target *types.Int64
 	}{
-		{"tpm_limit", &data.TPMLimit},
-		{"rpm_limit", &data.RPMLimit},
+		{"tpm_limit", &next.TPMLimit},
+		{"rpm_limit", &next.RPMLimit},
 	} {
-		if err := updateInt64FromAPI(field.target, teamInfo, true, true, field.name); err != nil {
-			resp.Diagnostics.AddError("Invalid API Response", err.Error())
-			return
+		value, fieldErr := dataSourceNullableInt64At(teamInfo, field.name)
+		if fieldErr != nil {
+			return next, fieldErr
 		}
+		*field.target = value
 	}
 
-	// Boolean fields
-	if blocked, ok := teamInfo["blocked"].(bool); ok {
-		data.Blocked = types.BoolValue(blocked)
-	} else {
-		data.Blocked = types.BoolValue(false)
-	}
-
-	// Handle models list
-	if models, ok := teamInfo["models"].([]interface{}); ok {
-		modelsList := make([]attr.Value, len(models))
-		for i, m := range models {
-			if str, ok := m.(string); ok {
-				modelsList[i] = types.StringValue(str)
-			}
-		}
-		data.Models, _ = types.ListValue(types.StringType, modelsList)
-	} else {
-		data.Models, _ = types.ListValue(types.StringType, []attr.Value{})
-	}
-
-	accessGroupIDs, err := stringSetFromAPI(ctx, teamInfo["access_group_ids"])
+	next.Blocked, err = dataSourceNullableBoolAt(teamInfo, "blocked")
 	if err != nil {
-		resp.Diagnostics.AddError("Invalid Team Response", fmt.Sprintf("Unable to decode access_group_ids for team '%s': %s", teamID, err))
-		return
+		return next, err
 	}
-	data.AccessGroupIDs = accessGroupIDs
+	next.Models, err = dataSourceNullableStringListAt(teamInfo, "models")
+	if err != nil {
+		return next, err
+	}
+	next.AccessGroupIDs, err = dataSourceNullableStringSetAt(teamInfo, "access_group_ids")
+	if err != nil {
+		return next, err
+	}
+	next.Metadata, err = dataSourceNullableStringMapAt(teamInfo, "metadata")
+	if err != nil {
+		return next, err
+	}
+	return next, nil
+}
 
-	// Handle metadata map
-	if metadata, ok := teamInfo["metadata"].(map[string]interface{}); ok {
-		metaMap := make(map[string]attr.Value)
-		for k, v := range metadata {
-			if str, ok := v.(string); ok {
-				metaMap[k] = types.StringValue(str)
-			}
+func validateTeamDataSourceObjectRelation(result map[string]interface{}, field string) error {
+	raw, err := dataSourceRequiredValueAt(result, "a list of objects", field)
+	if err != nil {
+		return fmt.Errorf("invalid /team/info response: required relation is missing or malformed")
+	}
+	rows, ok := raw.([]interface{})
+	if !ok {
+		return fmt.Errorf("invalid /team/info response: required relation must be a list of objects")
+	}
+	for _, row := range rows {
+		object, ok := row.(map[string]interface{})
+		if !ok || object == nil {
+			return fmt.Errorf("invalid /team/info response: required relation contains a non-object row")
 		}
-		data.Metadata, _ = types.MapValue(types.StringType, metaMap)
-	} else {
-		data.Metadata, _ = types.MapValue(types.StringType, map[string]attr.Value{})
 	}
+	return nil
+}
 
-	// Fetch permissions separately
-	permissionQuery := url.Values{"team_id": []string{teamID}}
-	permEndpoint := endpointWithQuery("/team/permissions_list", permissionQuery)
-	var permResult map[string]interface{}
-	if err := d.client.DoRequestWithResponse(ctx, "GET", permEndpoint, nil, &permResult); err == nil {
-		if perms, ok := permResult["team_member_permissions"].([]interface{}); ok {
-			permsList := make([]attr.Value, len(perms))
-			for i, p := range perms {
-				if str, ok := p.(string); ok {
-					permsList[i] = types.StringValue(str)
-				}
-			}
-			data.TeamMemberPermissions, _ = types.ListValue(types.StringType, permsList)
-		} else {
-			data.TeamMemberPermissions, _ = types.ListValue(types.StringType, []attr.Value{})
+func projectTeamDataSourcePermissions(result map[string]interface{}, expectedTeamID string) (types.List, error) {
+	null := types.ListNull(types.StringType)
+	if result == nil || len(result) == 0 {
+		return null, fmt.Errorf("invalid /team/permissions_list response: expected the authoritative v1.98 object envelope")
+	}
+	for field := range result {
+		switch field {
+		case "team_id", "all_available_permissions", "team_member_permissions":
+		default:
+			return null, fmt.Errorf("invalid /team/permissions_list response: envelope contains a field outside the authoritative v1.98 relation")
 		}
-	} else {
-		data.TeamMemberPermissions, _ = types.ListValue(types.StringType, []attr.Value{})
 	}
-
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	teamID, err := dataSourceRequiredStringAt(result, "team_id")
+	if err != nil || teamID.ValueString() != expectedTeamID {
+		return null, fmt.Errorf("invalid /team/permissions_list response: identity does not match the requested team")
+	}
+	if _, err := dataSourceRequiredStringListAt(result, "all_available_permissions"); err != nil {
+		return null, fmt.Errorf("invalid /team/permissions_list response: required permission relation is missing or malformed")
+	}
+	if _, exists := result["team_member_permissions"]; !exists {
+		return null, fmt.Errorf("invalid /team/permissions_list response: required team permission relation is missing")
+	}
+	permissions, err := dataSourceNullableStringListAt(result, "team_member_permissions")
+	if err != nil {
+		return null, fmt.Errorf("invalid /team/permissions_list response: team permission relation is malformed")
+	}
+	return permissions, nil
 }

--- a/internal/provider/datasource_team_presence_protocol_test.go
+++ b/internal/provider/datasource_team_presence_protocol_test.go
@@ -1,0 +1,227 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func TestTeamDataSourceAuthoritativePresenceProtocol(t *testing.T) {
+	ctx := context.Background()
+	var mode atomic.Value
+	mode.Store("null")
+	httpServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		if request.URL.Query().Get("team_id") != "team-protocol" {
+			http.Error(writer, "bad lookup", http.StatusBadRequest)
+			return
+		}
+		current := mode.Load().(string)
+		switch request.URL.Path {
+		case "/team/info":
+			_, _ = fmt.Fprint(writer, teamDataSourceProtocolInfo(current))
+		case "/team/permissions_list":
+			_, _ = fmt.Fprint(writer, teamDataSourceProtocolPermissions(current))
+		default:
+			http.NotFound(writer, request)
+		}
+	}))
+	defer httpServer.Close()
+
+	server, schemas := configuredImportProtocolServer(t, ctx, httpServer.URL)
+	schema := schemas.DataSourceSchemas["litellm_team"]
+	config := singularPresenceConfig(t, schema, map[string]interface{}{"team_id": "team-protocol"})
+
+	for _, successMode := range []string{"absent", "null", "empty"} {
+		t.Run(successMode, func(t *testing.T) {
+			mode.Store(successMode)
+			read, err := server.ReadDataSource(ctx, &tfprotov6.ReadDataSourceRequest{TypeName: "litellm_team", Config: config})
+			if err != nil || accessGroupProtocolDiagnosticsHaveError(read.Diagnostics) {
+				t.Fatalf("team read: err=%v diagnostics=%v", err, read.Diagnostics)
+			}
+			assertDataSourceReadComputedKnown(t, schema, read)
+			attributes := protocolAttributeMap(t, schema, read.State)
+			if successMode != "empty" {
+				for _, field := range []string{"team_alias", "organization_id", "access_group_ids", "models", "max_budget", "spend", "tpm_limit", "rpm_limit", "budget_duration", "metadata", "team_member_permissions", "blocked"} {
+					if !attributes[field].IsKnown() || !attributes[field].IsNull() {
+						t.Fatalf("%s was not a known typed null: %v", field, attributes[field])
+					}
+				}
+				return
+			}
+			for _, field := range []string{"access_group_ids", "models", "metadata", "team_member_permissions"} {
+				if attributes[field].IsNull() || !attributes[field].IsKnown() {
+					t.Fatalf("%s did not preserve explicit empty: %v", field, attributes[field])
+				}
+			}
+			for _, field := range []string{"max_budget", "spend", "tpm_limit", "rpm_limit"} {
+				assertSingularPresenceZero(t, attributes[field])
+			}
+			var blocked bool
+			if err := attributes["blocked"].As(&blocked); err != nil || blocked {
+				t.Fatalf("blocked did not preserve false: value=%t err=%v", blocked, err)
+			}
+		})
+	}
+
+	for _, failureMode := range []string{
+		"wrong_root", "wrong_nested", "missing_keys", "malformed_memberships",
+		"wrong_permissions", "missing_permissions_relation", "malformed_permissions",
+	} {
+		t.Run(failureMode, func(t *testing.T) {
+			mode.Store(failureMode)
+			read, err := server.ReadDataSource(ctx, &tfprotov6.ReadDataSourceRequest{TypeName: "litellm_team", Config: config})
+			if err != nil || !accessGroupProtocolDiagnosticsHaveError(read.Diagnostics) {
+				t.Fatalf("%s response accepted: err=%v diagnostics=%v", failureMode, err, read.Diagnostics)
+			}
+			assertSingularPresenceStateUnchanged(t, schema, config, read.State)
+			for _, diagnostic := range read.Diagnostics {
+				if diagnostic != nil && (strings.Contains(diagnostic.Summary, "other-team") || strings.Contains(diagnostic.Detail, "other-team")) {
+					t.Fatalf("diagnostic disclosed response identity: %#v", diagnostic)
+				}
+			}
+		})
+	}
+}
+
+func TestTeamsListDataSourcePresenceAndAtomicityProtocol(t *testing.T) {
+	ctx := context.Background()
+	var mode atomic.Value
+	mode.Store("empty")
+	var filter atomic.Value
+	filter.Store("")
+	httpServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/team/list" || request.Method != http.MethodGet {
+			http.NotFound(writer, request)
+			return
+		}
+		filter.Store(request.URL.Query().Get("organization_id"))
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(writer, teamListDataSourceProtocolResponse(mode.Load().(string)))
+	}))
+	defer httpServer.Close()
+
+	server, schemas := configuredImportProtocolServer(t, ctx, httpServer.URL)
+	schema := schemas.DataSourceSchemas["litellm_teams"]
+	config := singularPresenceConfig(t, schema, map[string]interface{}{"organization_id": "org-protocol"})
+
+	mode.Store("empty")
+	empty, err := server.ReadDataSource(ctx, &tfprotov6.ReadDataSourceRequest{TypeName: "litellm_teams", Config: config})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(empty.Diagnostics) {
+		t.Fatalf("empty team list: err=%v diagnostics=%s", err, teamDataSourceProtocolDiagnostics(empty.Diagnostics))
+	}
+	assertDataSourceReadComputedKnown(t, schema, empty)
+	assertProtocolListLength(t, schema, empty.State, "teams", 0)
+	if got := filter.Load().(string); got != "org-protocol" {
+		t.Fatalf("organization_id filter=%q want org-protocol", got)
+	}
+
+	mode.Store("valid")
+	valid, err := server.ReadDataSource(ctx, &tfprotov6.ReadDataSourceRequest{TypeName: "litellm_teams", Config: config})
+	if err != nil || accessGroupProtocolDiagnosticsHaveError(valid.Diagnostics) {
+		t.Fatalf("valid team list: err=%v diagnostics=%v", err, valid.Diagnostics)
+	}
+	assertDataSourceReadComputedKnown(t, schema, valid)
+	assertProtocolListLength(t, schema, valid.State, "teams", 2)
+	attributes := protocolAttributeMap(t, schema, valid.State)
+	var teams []tftypes.Value
+	if err := attributes["teams"].As(&teams); err != nil {
+		t.Fatalf("decode teams: %v", err)
+	}
+	var first map[string]tftypes.Value
+	if err := teams[0].As(&first); err != nil {
+		t.Fatalf("decode first team: %v", err)
+	}
+	for _, field := range []string{"team_alias", "organization_id", "max_budget", "spend", "tpm_limit", "rpm_limit", "blocked"} {
+		if !first[field].IsKnown() || !first[field].IsNull() {
+			t.Fatalf("teams[0].%s was not a known typed null: %v", field, first[field])
+		}
+	}
+
+	for _, failureMode := range []string{"wrong_envelope", "non_object", "late_malformed", "duplicate"} {
+		t.Run(failureMode, func(t *testing.T) {
+			mode.Store(failureMode)
+			read, err := server.ReadDataSource(ctx, &tfprotov6.ReadDataSourceRequest{TypeName: "litellm_teams", Config: config})
+			if err != nil || !accessGroupProtocolDiagnosticsHaveError(read.Diagnostics) {
+				t.Fatalf("%s response accepted: err=%v diagnostics=%v", failureMode, err, read.Diagnostics)
+			}
+			assertSingularPresenceStateUnchanged(t, schema, config, read.State)
+		})
+	}
+}
+
+func teamDataSourceProtocolDiagnostics(diagnostics []*tfprotov6.Diagnostic) string {
+	var result strings.Builder
+	for _, diagnostic := range diagnostics {
+		if diagnostic != nil {
+			fmt.Fprintf(&result, "%s: %s; ", diagnostic.Summary, diagnostic.Detail)
+		}
+	}
+	return result.String()
+}
+
+func teamDataSourceProtocolInfo(mode string) string {
+	rootID, nestedID := "team-protocol", "team-protocol"
+	keys := `[]`
+	memberships := `[]`
+	switch mode {
+	case "wrong_root":
+		rootID = "other-team"
+	case "wrong_nested":
+		nestedID = "other-team"
+	case "missing_keys":
+		return fmt.Sprintf(`{"team_id":%q,"team_info":{"team_id":%q},"team_memberships":[]}`, rootID, nestedID)
+	case "malformed_memberships":
+		memberships = `[{},false]`
+	}
+	fields := `,"team_alias":null,"organization_id":null,"access_group_ids":null,"models":null,"max_budget":null,"spend":null,"tpm_limit":null,"rpm_limit":null,"budget_duration":null,"metadata":null,"blocked":null`
+	if mode == "absent" {
+		fields = ""
+	} else if mode == "empty" {
+		fields = `,"team_alias":"","organization_id":"","access_group_ids":[],"models":[],"max_budget":0,"spend":0,"tpm_limit":0,"rpm_limit":0,"budget_duration":"","metadata":{},"blocked":false`
+	}
+	return fmt.Sprintf(`{"team_id":%q,"team_info":{"team_id":%q%s},"keys":%s,"team_memberships":%s}`, rootID, nestedID, fields, keys, memberships)
+}
+
+func teamDataSourceProtocolPermissions(mode string) string {
+	switch mode {
+	case "wrong_permissions":
+		return `{"team_id":"other-team","all_available_permissions":[],"team_member_permissions":[]}`
+	case "missing_permissions_relation":
+		return `{"team_id":"team-protocol","all_available_permissions":[]}`
+	case "malformed_permissions":
+		return `{"team_id":"team-protocol","all_available_permissions":[],"team_member_permissions":["ok",false]}`
+	case "absent", "null":
+		return `{"team_id":"team-protocol","all_available_permissions":[],"team_member_permissions":null}`
+	default:
+		return `{"team_id":"team-protocol","all_available_permissions":["team_member_add"],"team_member_permissions":[]}`
+	}
+}
+
+func teamListDataSourceProtocolResponse(mode string) string {
+	nullItem := `{"team_id":"team-a","team_alias":null,"organization_id":null,"max_budget":null,"spend":null,"tpm_limit":null,"rpm_limit":null,"blocked":null}`
+	explicitItem := `{"team_id":"team-b","team_alias":"","organization_id":"","max_budget":0,"spend":0,"tpm_limit":9007199254740993,"rpm_limit":0,"blocked":false}`
+	switch mode {
+	case "empty":
+		return `[]`
+	case "valid":
+		return `[` + nullItem + `,` + explicitItem + `]`
+	case "wrong_envelope":
+		return `{"teams":[]}`
+	case "non_object":
+		return `[false]`
+	case "late_malformed":
+		return `[` + nullItem + `,{"team_id":"team-c","blocked":"false"}]`
+	case "duplicate":
+		return `[` + nullItem + `,` + nullItem + `]`
+	default:
+		return `null`
+	}
+}

--- a/internal/provider/datasource_team_presence_test.go
+++ b/internal/provider/datasource_team_presence_test.go
@@ -1,0 +1,145 @@
+package provider
+
+import (
+	"encoding/json"
+	"math"
+	"strings"
+	"testing"
+)
+
+func TestProjectTeamDataSourceInfoAcceptsAuthoritativeV198Envelope(t *testing.T) {
+	t.Parallel()
+	result := decodeTeamDataSourceObject(t, `{
+		"team_id":"team-presence",
+		"team_info":{
+			"team_id":"team-presence","team_alias":"","organization_id":null,
+			"access_group_ids":["group-b","group-a"],"models":[],
+			"max_budget":0,"spend":1.25,"tpm_limit":9007199254740993,"rpm_limit":9223372036854775807,
+			"budget_duration":"","metadata":{},"blocked":false
+		},
+		"keys":[{}],"team_memberships":[{}]
+	}`)
+
+	got, err := projectTeamDataSourceInfo(result, "team-presence")
+	if err != nil {
+		t.Fatalf("project authoritative team response: %v", err)
+	}
+	if got.ID.ValueString() != "team-presence" || got.TeamID.ValueString() != "team-presence" {
+		t.Fatalf("identity was not projected: %#v", got)
+	}
+	if got.TeamAlias.IsNull() || got.TeamAlias.ValueString() != "" || !got.OrganizationID.IsNull() {
+		t.Fatalf("string presence was not preserved: alias=%v organization=%v", got.TeamAlias, got.OrganizationID)
+	}
+	if got.Models.IsNull() || len(got.Models.Elements()) != 0 || got.Metadata.IsNull() || len(got.Metadata.Elements()) != 0 {
+		t.Fatalf("empty collections were not preserved: models=%v metadata=%v", got.Models, got.Metadata)
+	}
+	if got.AccessGroupIDs.IsNull() || len(got.AccessGroupIDs.Elements()) != 2 {
+		t.Fatalf("access_group_ids set was not preserved: %v", got.AccessGroupIDs)
+	}
+	if got.MaxBudget.IsNull() || got.MaxBudget.ValueFloat64() != 0 || got.Blocked.IsNull() || got.Blocked.ValueBool() {
+		t.Fatalf("explicit zero/false were not preserved: max_budget=%v blocked=%v", got.MaxBudget, got.Blocked)
+	}
+	if got.TPMLimit.ValueInt64() != 9007199254740993 || got.RPMLimit.ValueInt64() != math.MaxInt64 {
+		t.Fatalf("exact integer limits were not preserved: tpm=%d rpm=%d", got.TPMLimit.ValueInt64(), got.RPMLimit.ValueInt64())
+	}
+}
+
+func TestProjectTeamDataSourceInfoRejectsNonAuthoritativeRelations(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name string
+		body string
+	}{
+		{"flat", `{"team_id":"team-presence","team_alias":"flat"}`},
+		{"wrong root identity", `{"team_id":"other","team_info":{"team_id":"team-presence"},"keys":[],"team_memberships":[]}`},
+		{"wrong nested identity", `{"team_id":"team-presence","team_info":{"team_id":"other"},"keys":[],"team_memberships":[]}`},
+		{"missing keys", `{"team_id":"team-presence","team_info":{"team_id":"team-presence"},"team_memberships":[]}`},
+		{"null memberships", `{"team_id":"team-presence","team_info":{"team_id":"team-presence"},"keys":[],"team_memberships":null}`},
+		{"late malformed key", `{"team_id":"team-presence","team_info":{"team_id":"team-presence"},"keys":[{},false],"team_memberships":[]}`},
+		{"unknown root relation", `{"team_id":"team-presence","team_info":{"team_id":"team-presence"},"keys":[],"team_memberships":[],"alternate":[]}`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := projectTeamDataSourceInfo(decodeTeamDataSourceObject(t, test.body), "team-presence")
+			if err == nil {
+				t.Fatalf("non-authoritative response accepted: %#v", got)
+			}
+			if strings.Contains(err.Error(), "other") || strings.Contains(err.Error(), "alternate") {
+				t.Fatalf("diagnostic disclosed response content: %v", err)
+			}
+		})
+	}
+}
+
+func TestProjectTeamDataSourcePermissionsPresenceAndAuthority(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name       string
+		body       string
+		wantNull   bool
+		wantLength int
+		wantError  bool
+	}{
+		{"null", `{"team_id":"team-presence","all_available_permissions":[],"team_member_permissions":null}`, true, 0, false},
+		{"empty", `{"team_id":"team-presence","all_available_permissions":["team_member_add"],"team_member_permissions":[]}`, false, 0, false},
+		{"values", `{"team_id":"team-presence","all_available_permissions":["team_member_add"],"team_member_permissions":["team_member_add"]}`, false, 1, false},
+		{"wrong identity", `{"team_id":"other","all_available_permissions":[],"team_member_permissions":[]}`, false, 0, true},
+		{"missing available relation", `{"team_id":"team-presence","team_member_permissions":[]}`, false, 0, true},
+		{"missing team relation", `{"team_id":"team-presence","all_available_permissions":[]}`, false, 0, true},
+		{"malformed available relation", `{"team_id":"team-presence","all_available_permissions":[false],"team_member_permissions":[]}`, false, 0, true},
+		{"malformed team relation", `{"team_id":"team-presence","all_available_permissions":[],"team_member_permissions":["ok",false]}`, false, 0, true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := projectTeamDataSourcePermissions(decodeTeamDataSourceObject(t, test.body), "team-presence")
+			if test.wantError {
+				if err == nil {
+					t.Fatalf("invalid permissions response accepted: %v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("permissions projection: %v", err)
+			}
+			if got.IsNull() != test.wantNull || (!got.IsNull() && len(got.Elements()) != test.wantLength) {
+				t.Fatalf("permissions=%v want null=%t length=%d", got, test.wantNull, test.wantLength)
+			}
+		})
+	}
+}
+
+func TestProjectTeamsListDataSourceIsAtomicAndPresenceAware(t *testing.T) {
+	t.Parallel()
+	valid := decodeTeamDataSourceObject(t, `{"team_id":"team-b","team_alias":null,"organization_id":"","max_budget":0,"spend":0,"tpm_limit":0,"rpm_limit":0,"blocked":false}`)
+	empty := decodeTeamDataSourceObject(t, `{"team_id":"team-a","team_alias":"","organization_id":null,"max_budget":null,"spend":null,"tpm_limit":null,"rpm_limit":null,"blocked":null}`)
+	got, err := projectTeamsListDataSource([]map[string]interface{}{valid, empty})
+	if err != nil {
+		t.Fatalf("project team list: %v", err)
+	}
+	if len(got) != 2 || got[0].TeamID.ValueString() != "team-a" || got[1].TeamID.ValueString() != "team-b" {
+		t.Fatalf("stable canonical ordering not preserved: %#v", got)
+	}
+	if !got[0].MaxBudget.IsNull() || got[1].MaxBudget.IsNull() || got[1].MaxBudget.ValueFloat64() != 0 {
+		t.Fatalf("null/zero presence not preserved: %#v", got)
+	}
+	if got[1].Blocked.IsNull() || got[1].Blocked.ValueBool() {
+		t.Fatalf("explicit false not preserved: %v", got[1].Blocked)
+	}
+
+	lateMalformed := decodeTeamDataSourceObject(t, `{"team_id":"team-c","team_alias":false}`)
+	if partial, err := projectTeamsListDataSource([]map[string]interface{}{valid, lateMalformed}); err == nil || partial != nil {
+		t.Fatalf("late malformed item published partial list: partial=%#v err=%v", partial, err)
+	}
+	if partial, err := projectTeamsListDataSource([]map[string]interface{}{valid, valid}); err == nil || partial != nil {
+		t.Fatalf("duplicate canonical identity published partial list: partial=%#v err=%v", partial, err)
+	}
+}
+
+func decodeTeamDataSourceObject(t *testing.T, body string) map[string]interface{} {
+	t.Helper()
+	var result map[string]interface{}
+	decoder := json.NewDecoder(strings.NewReader(body))
+	decoder.UseNumber()
+	if err := decoder.Decode(&result); err != nil {
+		t.Fatalf("decode test response: %v", err)
+	}
+	return result
+}

--- a/internal/provider/datasource_teams_list.go
+++ b/internal/provider/datasource_teams_list.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/url"
 	"sort"
@@ -34,9 +33,9 @@ type TeamListItem struct {
 }
 
 type TeamsListDataSourceModel struct {
-	ID             types.String   `tfsdk:"id"`
-	OrganizationID types.String   `tfsdk:"organization_id"`
-	Teams          []TeamListItem `tfsdk:"teams"`
+	ID             types.String `tfsdk:"id"`
+	OrganizationID types.String `tfsdk:"organization_id"`
+	Teams          types.List   `tfsdk:"teams"`
 }
 
 func (d *TeamsListDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -117,46 +116,77 @@ func (d *TeamsListDataSource) Configure(ctx context.Context, req datasource.Conf
 }
 
 func (d *TeamsListDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
-	var data TeamsListDataSourceModel
-
-	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	var config TeamsListDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	if config.OrganizationID.IsUnknown() {
+		resp.Diagnostics.AddError("Invalid Team List Filter", "organization_id must be known or null")
+		return
+	}
 
-	filters := teamListFilters(data.OrganizationID)
-	endpoint := endpointWithQuery("/team/list", filters)
-
-	var rawResult json.RawMessage
-	if err := d.client.DoRequestWithResponse(ctx, "GET", endpoint, nil, &rawResult); err != nil {
+	filters := teamListFilters(config.OrganizationID)
+	// Preserve the v1 organization_id query contract.
+	results, err := fetchTopLevelListObjects(ctx, d.client, endpointWithQuery("/team/list", filters), "team item")
+	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to list teams: %s", safeListDiagnostic(err, filters)))
 		return
 	}
-	teamsData, err := decodeTopLevelList(rawResult, "/team/list")
+	teams, err := projectTeamsListDataSource(results)
 	if err != nil {
 		resp.Diagnostics.AddError("Invalid API Response", err.Error())
 		return
 	}
 
-	data.ID = types.StringValue("teams")
-	data.Teams = make([]TeamListItem, 0, len(teamsData))
-	for _, rawTeam := range teamsData {
-		teamMap, err := decodeListObject(rawTeam, "/team/list", "team item")
+	// Keep the established public ID and configured filter while publishing the
+	// complete validated inventory exactly once.
+	next := struct {
+		ID             types.String   `tfsdk:"id"`
+		OrganizationID types.String   `tfsdk:"organization_id"`
+		Teams          []TeamListItem `tfsdk:"teams"`
+	}{
+		ID:             types.StringValue("teams"),
+		OrganizationID: config.OrganizationID,
+		Teams:          teams,
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &next)...)
+}
+
+func projectTeamsListDataSource(results []map[string]interface{}) ([]TeamListItem, error) {
+	teams := make([]TeamListItem, 0, len(results))
+	seen := make(map[string]struct{}, len(results))
+	for _, result := range results {
+		item := TeamListItem{
+			TeamAlias:      types.StringNull(),
+			OrganizationID: types.StringNull(),
+			MaxBudget:      types.Float64Null(),
+			Spend:          types.Float64Null(),
+			TPMLimit:       types.Int64Null(),
+			RPMLimit:       types.Int64Null(),
+			Blocked:        types.BoolNull(),
+		}
+
+		var err error
+		item.TeamID, err = dataSourceRequiredStringAt(result, "team_id")
 		if err != nil {
-			resp.Diagnostics.AddError("Invalid API Response", err.Error())
-			return
+			return nil, fmt.Errorf("/team/list returned a team object without a canonical team_id")
 		}
-
-		item := TeamListItem{}
-
-		if teamID, ok := teamMap["team_id"].(string); ok {
-			item.TeamID = types.StringValue(teamID)
+		if err := dataSourceListIdentity(seen, item.TeamID.ValueString(), "/team/list", "team_id"); err != nil {
+			return nil, err
 		}
-		if teamAlias, ok := teamMap["team_alias"].(string); ok {
-			item.TeamAlias = types.StringValue(teamAlias)
-		}
-		if orgID, ok := teamMap["organization_id"].(string); ok {
-			item.OrganizationID = types.StringValue(orgID)
+		for _, field := range []struct {
+			name   string
+			target *types.String
+		}{
+			{"team_alias", &item.TeamAlias},
+			{"organization_id", &item.OrganizationID},
+		} {
+			value, fieldErr := dataSourceNullableStringAt(result, field.name)
+			if fieldErr != nil {
+				return nil, fieldErr
+			}
+			*field.target = value
 		}
 		for _, field := range []struct {
 			name   string
@@ -165,10 +195,11 @@ func (d *TeamsListDataSource) Read(ctx context.Context, req datasource.ReadReque
 			{"max_budget", &item.MaxBudget},
 			{"spend", &item.Spend},
 		} {
-			if err := updateFloat64FromAPI(field.target, teamMap, true, true, field.name); err != nil {
-				resp.Diagnostics.AddError("Invalid API Response", err.Error())
-				return
+			value, fieldErr := dataSourceNullableFloat64At(result, field.name)
+			if fieldErr != nil {
+				return nil, fieldErr
 			}
+			*field.target = value
 		}
 		for _, field := range []struct {
 			name   string
@@ -177,28 +208,23 @@ func (d *TeamsListDataSource) Read(ctx context.Context, req datasource.ReadReque
 			{"tpm_limit", &item.TPMLimit},
 			{"rpm_limit", &item.RPMLimit},
 		} {
-			if err := updateInt64FromAPI(field.target, teamMap, true, true, field.name); err != nil {
-				resp.Diagnostics.AddError("Invalid API Response", err.Error())
-				return
+			value, fieldErr := dataSourceNullableInt64At(result, field.name)
+			if fieldErr != nil {
+				return nil, fieldErr
 			}
+			*field.target = value
 		}
-		if blocked, ok := teamMap["blocked"].(bool); ok {
-			item.Blocked = types.BoolValue(blocked)
-		} else {
-			item.Blocked = types.BoolValue(false)
+		item.Blocked, err = dataSourceNullableBoolAt(result, "blocked")
+		if err != nil {
+			return nil, err
 		}
-
-		if item.TeamID.ValueString() == "" {
-			resp.Diagnostics.AddError("Invalid API Response", "/team/list returned a team object without team_id")
-			return
-		}
-		data.Teams = append(data.Teams, item)
+		teams = append(teams, item)
 	}
-	sort.SliceStable(data.Teams, func(i, j int) bool {
-		return data.Teams[i].TeamID.ValueString() < data.Teams[j].TeamID.ValueString()
-	})
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	sort.SliceStable(teams, func(i, j int) bool {
+		return teams[i].TeamID.ValueString() < teams[j].TeamID.ValueString()
+	})
+	return teams, nil
 }
 
 func teamListFilters(organizationID types.String) url.Values {

--- a/internal/provider/datasource_unified_access_groups_list.go
+++ b/internal/provider/datasource_unified_access_groups_list.go
@@ -65,30 +65,56 @@ func (d *UnifiedAccessGroupsListDataSource) Read(ctx context.Context, req dataso
 	data := UnifiedAccessGroupsListDataSourceModel{
 		AccessGroups: make([]UnifiedAccessGroupDataSourceModel, 0, len(result)),
 	}
-	for _, item := range result {
-		resourceData := UnifiedAccessGroupResourceModel{}
-		readUnifiedAccessGroupResponse(ctx, item, &resourceData)
-		if resourceData.AccessGroupID.ValueString() == "" {
-			resp.Diagnostics.AddError("Invalid API Response", "/v1/access_group returned an access group object without access_group_id")
+	seen := make(map[string]struct{}, len(result))
+	for _, raw := range result {
+		item := UnifiedAccessGroupDataSourceModel{}
+		item.AccessGroupID, err = dataSourceRequiredStringAt(raw, "access_group_id")
+		if err != nil {
+			resp.Diagnostics.AddError("Invalid API Response", "/v1/access_group returned an access group object without a canonical access_group_id")
 			return
 		}
-		assignedKeyIDs := types.ListNull(types.StringType)
-		setSafeAssignedKeyListFromResponse(&assignedKeyIDs, item["assigned_key_ids"])
-		data.AccessGroups = append(data.AccessGroups, UnifiedAccessGroupDataSourceModel{
-			ID:                 resourceData.ID,
-			AccessGroupID:      resourceData.AccessGroupID,
-			AccessGroupName:    resourceData.AccessGroupName,
-			Description:        resourceData.Description,
-			AccessModelNames:   resourceData.AccessModelNames,
-			AccessMCPServerIDs: resourceData.AccessMCPServerIDs,
-			AccessAgentIDs:     resourceData.AccessAgentIDs,
-			AssignedTeamIDs:    resourceData.AssignedTeamIDs,
-			AssignedKeyIDs:     assignedKeyIDs,
-			CreatedAt:          resourceData.CreatedAt,
-			CreatedBy:          resourceData.CreatedBy,
-			UpdatedAt:          resourceData.UpdatedAt,
-			UpdatedBy:          resourceData.UpdatedBy,
-		})
+		item.ID = item.AccessGroupID
+		if err := dataSourceListIdentity(seen, item.AccessGroupID.ValueString(), "/v1/access_group", "access_group_id"); err != nil {
+			resp.Diagnostics.AddError("Invalid API Response", err.Error())
+			return
+		}
+		for _, field := range []struct {
+			name   string
+			target *types.String
+		}{
+			{"access_group_name", &item.AccessGroupName}, {"description", &item.Description},
+			{"created_at", &item.CreatedAt}, {"created_by", &item.CreatedBy},
+			{"updated_at", &item.UpdatedAt}, {"updated_by", &item.UpdatedBy},
+		} {
+			*field.target, err = dataSourceNullableStringAt(raw, field.name)
+			if err != nil {
+				resp.Diagnostics.AddError("Invalid API Response", err.Error())
+				return
+			}
+		}
+		for _, field := range []struct {
+			name   string
+			target *types.List
+		}{
+			{"access_model_names", &item.AccessModelNames}, {"access_mcp_server_ids", &item.AccessMCPServerIDs},
+			{"access_agent_ids", &item.AccessAgentIDs}, {"assigned_team_ids", &item.AssignedTeamIDs},
+			{"assigned_key_ids", &item.AssignedKeyIDs},
+		} {
+			*field.target, err = dataSourceNullableStringListAt(raw, field.name)
+			if err != nil {
+				resp.Diagnostics.AddError("Invalid API Response", err.Error())
+				return
+			}
+		}
+		if !item.AssignedKeyIDs.IsNull() {
+			for _, value := range item.AssignedKeyIDs.Elements() {
+				if _, keyErr := unifiedAccessGroupKeyHash(value.(types.String).ValueString()); keyErr != nil {
+					resp.Diagnostics.AddError("Invalid API Response", "/v1/access_group returned an invalid assigned_key_ids element")
+					return
+				}
+			}
+		}
+		data.AccessGroups = append(data.AccessGroups, item)
 	}
 	sort.SliceStable(data.AccessGroups, func(i, j int) bool {
 		return data.AccessGroups[i].AccessGroupID.ValueString() < data.AccessGroups[j].AccessGroupID.ValueString()

--- a/internal/provider/datasource_user.go
+++ b/internal/provider/datasource_user.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -122,16 +121,17 @@ func (d *UserDataSource) Configure(ctx context.Context, req datasource.Configure
 }
 
 func (d *UserDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
-	var data UserDataSourceModel
-
-	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	var config UserDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	userID := data.UserID.ValueString()
-	query := url.Values{"user_id": []string{userID}}
-	endpoint := endpointWithQuery("/user/info", query)
+	userID := config.UserID.ValueString()
+	if config.UserID.IsNull() || config.UserID.IsUnknown() || userID == "" {
+		resp.Diagnostics.AddError("Invalid User Lookup", "user_id must be known and nonempty")
+		return
+	}
+	endpoint := endpointWithQuery("/user/info", url.Values{"user_id": []string{userID}})
 
 	var result map[string]interface{}
 	if err := d.client.DoRequestWithResponse(ctx, "GET", endpoint, nil, &result); err != nil {
@@ -139,92 +139,68 @@ func (d *UserDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 		return
 	}
 
-	// Set ID
-	data.ID = data.UserID
-
-	// The /user/info endpoint may return user_info nested
 	userInfo := result
-	if ui, ok := result["user_info"].(map[string]interface{}); ok {
-		userInfo = ui
-	}
-
-	// Update fields from response
-	if alias, ok := userInfo["user_alias"].(string); ok {
-		data.UserAlias = types.StringValue(alias)
-	}
-	if email, ok := userInfo["user_email"].(string); ok {
-		data.UserEmail = types.StringValue(email)
-	}
-	if role, ok := userInfo["user_role"].(string); ok {
-		data.UserRole = types.StringValue(role)
-	}
-	if budgetDuration, ok := userInfo["budget_duration"].(string); ok {
-		data.BudgetDuration = types.StringValue(budgetDuration)
-	}
-
-	// Numeric fields
-	for _, field := range []struct {
-		name   string
-		target *types.Float64
-	}{
-		{"max_budget", &data.MaxBudget},
-		{"spend", &data.Spend},
-	} {
-		if err := updateFloat64FromAPI(field.target, userInfo, true, true, field.name); err != nil {
-			resp.Diagnostics.AddError("Invalid API Response", err.Error())
-			return
-		}
-	}
-	for _, field := range []struct {
-		name   string
-		target *types.Int64
-	}{
-		{"tpm_limit", &data.TPMLimit},
-		{"rpm_limit", &data.RPMLimit},
-	} {
-		if err := updateInt64FromAPI(field.target, userInfo, true, true, field.name); err != nil {
-			resp.Diagnostics.AddError("Invalid API Response", err.Error())
+	if raw, presence, err := apiValueAt(result, "user_info"); err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
+	} else if presence == apiValuePresent {
+		var ok bool
+		userInfo, ok = raw.(map[string]interface{})
+		if !ok {
+			resp.Diagnostics.AddError("Invalid API Response", dataSourceShapeError([]string{"user_info"}, "an object or null").Error())
 			return
 		}
 	}
 
-	// Handle teams list
-	if teams, ok := userInfo["teams"].([]interface{}); ok {
-		teamsList := make([]attr.Value, len(teams))
-		for i, t := range teams {
-			if str, ok := t.(string); ok {
-				teamsList[i] = types.StringValue(str)
-			}
-		}
-		data.Teams, _ = types.ListValue(types.StringType, teamsList)
-	} else {
-		data.Teams, _ = types.ListValue(types.StringType, []attr.Value{})
+	actualUserID, err := dataSourceRequiredStringAt(userInfo, "user_id")
+	if err != nil || actualUserID.ValueString() != userID {
+		resp.Diagnostics.AddError("Invalid API Response", "User response identity did not match the requested user.")
+		return
 	}
-
-	// Handle models list
-	if models, ok := userInfo["models"].([]interface{}); ok {
-		modelsList := make([]attr.Value, len(models))
-		for i, m := range models {
-			if str, ok := m.(string); ok {
-				modelsList[i] = types.StringValue(str)
-			}
-		}
-		data.Models, _ = types.ListValue(types.StringType, modelsList)
-	} else {
-		data.Models, _ = types.ListValue(types.StringType, []attr.Value{})
+	data := UserDataSourceModel{ID: actualUserID, UserID: config.UserID}
+	if data.UserAlias, err = dataSourceRoleRedactedNullableStringAt(userInfo, "user_alias"); err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
 	}
-
-	// Handle metadata map
-	if metadata, ok := userInfo["metadata"].(map[string]interface{}); ok {
-		metaMap := make(map[string]attr.Value)
-		for k, v := range metadata {
-			if str, ok := v.(string); ok {
-				metaMap[k] = types.StringValue(str)
-			}
-		}
-		data.Metadata, _ = types.MapValue(types.StringType, metaMap)
-	} else {
-		data.Metadata, _ = types.MapValue(types.StringType, map[string]attr.Value{})
+	if data.UserEmail, err = dataSourceRoleRedactedNullableStringAt(userInfo, "user_email"); err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
+	}
+	if data.UserRole, err = dataSourceRoleRedactedNullableStringAt(userInfo, "user_role"); err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
+	}
+	if data.Teams, err = dataSourceRoleRedactedNullableStringListAt(userInfo, "teams"); err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
+	}
+	if data.Models, err = dataSourceRoleRedactedNullableStringListAt(userInfo, "models"); err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
+	}
+	if data.MaxBudget, err = dataSourceRoleRedactedNullableFloat64At(userInfo, "max_budget"); err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
+	}
+	if data.BudgetDuration, err = dataSourceRoleRedactedNullableStringAt(userInfo, "budget_duration"); err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
+	}
+	if data.TPMLimit, err = dataSourceRoleRedactedNullableInt64At(userInfo, "tpm_limit"); err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
+	}
+	if data.RPMLimit, err = dataSourceRoleRedactedNullableInt64At(userInfo, "rpm_limit"); err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
+	}
+	if data.Metadata, err = dataSourceRoleRedactedNullableStringMapAt(userInfo, "metadata"); err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
+	}
+	if data.Spend, err = dataSourceRoleRedactedNullableFloat64At(userInfo, "spend"); err != nil {
+		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+		return
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/provider/datasource_user.go
+++ b/internal/provider/datasource_user.go
@@ -139,22 +139,19 @@ func (d *UserDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 		return
 	}
 
-	userInfo := result
-	if raw, presence, err := apiValueAt(result, "user_info"); err != nil {
-		resp.Diagnostics.AddError("Invalid API Response", err.Error())
+	rootUserID, err := dataSourceRequiredStringAt(result, "user_id")
+	if err != nil || rootUserID.ValueString() != userID {
+		resp.Diagnostics.AddError("Invalid API Response", "User response root identity did not match the requested user.")
 		return
-	} else if presence == apiValuePresent {
-		var ok bool
-		userInfo, ok = raw.(map[string]interface{})
-		if !ok {
-			resp.Diagnostics.AddError("Invalid API Response", dataSourceShapeError([]string{"user_info"}, "an object or null").Error())
-			return
-		}
 	}
-
+	userInfo, err := dataSourceRequiredObjectAt(result, "user_info")
+	if err != nil || len(userInfo) == 0 {
+		resp.Diagnostics.AddError("Invalid API Response", "User response omitted the required user_info object.")
+		return
+	}
 	actualUserID, err := dataSourceRequiredStringAt(userInfo, "user_id")
-	if err != nil || actualUserID.ValueString() != userID {
-		resp.Diagnostics.AddError("Invalid API Response", "User response identity did not match the requested user.")
+	if err != nil || actualUserID.ValueString() != userID || !actualUserID.Equal(rootUserID) {
+		resp.Diagnostics.AddError("Invalid API Response", "User response nested identity did not match the requested user.")
 		return
 	}
 	data := UserDataSourceModel{ID: actualUserID, UserID: config.UserID}

--- a/internal/provider/datasource_users_list.go
+++ b/internal/provider/datasource_users_list.go
@@ -128,6 +128,10 @@ func (d *UsersListDataSource) Read(ctx context.Context, req datasource.ReadReque
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	if err := validateOptionalStringFilter("user_role", data.UserRole); err != nil {
+		resp.Diagnostics.AddError("Invalid User List Filter", err.Error())
+		return
+	}
 
 	filters := userListFilters(data.UserRole)
 	users, err := listUsers(ctx, d.client, filters)

--- a/internal/provider/datasource_users_list.go
+++ b/internal/provider/datasource_users_list.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -123,7 +124,7 @@ func (d *UsersListDataSource) Configure(ctx context.Context, req datasource.Conf
 func (d *UsersListDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	var data UsersListDataSourceModel
 
-	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("user_role"), &data.UserRole)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -216,14 +217,14 @@ func decodeUserListItem(rawItem json.RawMessage) (UserListItem, error) {
 		return UserListItem{}, fmt.Errorf("/user/list returned a user object without user_id")
 	}
 	item := UserListItem{UserID: types.StringValue(userID)}
-	if alias, ok := userMap["user_alias"].(string); ok {
-		item.UserAlias = types.StringValue(alias)
+	if item.UserAlias, err = dataSourceNullableStringAt(userMap, "user_alias"); err != nil {
+		return UserListItem{}, err
 	}
-	if email, ok := userMap["user_email"].(string); ok {
-		item.UserEmail = types.StringValue(email)
+	if item.UserEmail, err = dataSourceNullableStringAt(userMap, "user_email"); err != nil {
+		return UserListItem{}, err
 	}
-	if role, ok := userMap["user_role"].(string); ok {
-		item.UserRole = types.StringValue(role)
+	if item.UserRole, err = dataSourceNullableStringAt(userMap, "user_role"); err != nil {
+		return UserListItem{}, err
 	}
 	for _, field := range []struct {
 		name   string
@@ -232,9 +233,11 @@ func decodeUserListItem(rawItem json.RawMessage) (UserListItem, error) {
 		{"max_budget", &item.MaxBudget},
 		{"spend", &item.Spend},
 	} {
-		if err := updateFloat64FromAPI(field.target, userMap, true, true, field.name); err != nil {
-			return UserListItem{}, err
+		value, fieldErr := dataSourceNullableFloat64At(userMap, field.name)
+		if fieldErr != nil {
+			return UserListItem{}, fieldErr
 		}
+		*field.target = value
 	}
 	for _, field := range []struct {
 		name   string
@@ -243,9 +246,11 @@ func decodeUserListItem(rawItem json.RawMessage) (UserListItem, error) {
 		{"tpm_limit", &item.TPMLimit},
 		{"rpm_limit", &item.RPMLimit},
 	} {
-		if err := updateInt64FromAPI(field.target, userMap, true, true, field.name); err != nil {
-			return UserListItem{}, err
+		value, fieldErr := dataSourceNullableInt64At(userMap, field.name)
+		if fieldErr != nil {
+			return UserListItem{}, fieldErr
 		}
+		*field.target = value
 	}
 	return item, nil
 }

--- a/internal/provider/jwt_key_mapping_api.go
+++ b/internal/provider/jwt_key_mapping_api.go
@@ -223,7 +223,7 @@ func decodeJWTKeyMappingListPage(raw json.RawMessage, requestedPage int) (number
 	}
 	page.Items = make([]jwtKeyMappingObject, 0, len(rawItems))
 	for _, itemRaw := range rawItems {
-		item, err := decodeJWTKeyMappingObject(itemRaw)
+		item, err := decodeJWTKeyMappingListObject(itemRaw)
 		if err != nil {
 			return page, err
 		}
@@ -249,6 +249,23 @@ func decodeJWTKeyMappingListPage(raw json.RawMessage, requestedPage int) (number
 		return page, fmt.Errorf("JWT key mapping list response returned inconsistent total_pages")
 	}
 	return page, nil
+}
+
+func decodeJWTKeyMappingListObject(raw json.RawMessage) (jwtKeyMappingObject, error) {
+	var object map[string]json.RawMessage
+	if err := decodeJSONUseNumber(raw, &object); err != nil || object == nil {
+		return jwtKeyMappingObject{}, fmt.Errorf("JWT key mapping response must be a valid JSON object")
+	}
+	for _, field := range []string{"description", "created_by", "updated_by"} {
+		if _, present := object[field]; !present {
+			object[field] = json.RawMessage("null")
+		}
+	}
+	normalized, err := json.Marshal(object)
+	if err != nil {
+		return jwtKeyMappingObject{}, fmt.Errorf("JWT key mapping response must be a valid JSON object")
+	}
+	return decodeJWTKeyMappingObject(normalized)
 }
 
 func listJWTKeyMappings(ctx context.Context, client *Client) ([]jwtKeyMappingObject, error) {

--- a/internal/provider/list_helpers.go
+++ b/internal/provider/list_helpers.go
@@ -190,6 +190,20 @@ func safeListDiagnostic(err error, filters url.Values) string {
 	return sanitizeDiagnosticString(err.Error(), secrets)
 }
 
+func validateOptionalStringFilter(name string, value interface {
+	IsNull() bool
+	IsUnknown() bool
+	ValueString() string
+}) error {
+	if value.IsUnknown() {
+		return fmt.Errorf("optional filter %s must be known before reading", name)
+	}
+	if !value.IsNull() && value.ValueString() == "" {
+		return fmt.Errorf("optional filter %s must be nonempty when configured", name)
+	}
+	return nil
+}
+
 func addKnownStringFilter(values url.Values, name string, value interface {
 	IsNull() bool
 	IsUnknown() bool

--- a/internal_testing/upgrade_matrix/README.md
+++ b/internal_testing/upgrade_matrix/README.md
@@ -66,7 +66,7 @@ sh internal_testing/upgrade_matrix/run.sh local
 internal_testing/compose.sh down -v
 ```
 
-The runtime-parity gate retains digest-bound exceptions for the reviewed #210, #217, and #213 provider patches from their exact integration bases and exact path sets; a different path or patch byte fails, and each exception is inert once its change is in the event base. Repository-owned non-PR workflow jobs execute this lane against a new local backend with all four pinned CLIs. Pull requests and forks run assembly only. Tag releases run all four full lanes against the exact tagged SHA before GPG import, build, or signing; each gate job has read-only contents permission and a wall timeout. There is no workflow-enabled remote mutation lane; adding one requires a separate future gate and reviewed scenario allowlist.
+The runtime-parity gate retains digest-bound exceptions for the reviewed #210, #217, #213, and #222 provider patches from their exact integration bases and exact path sets; a different path or patch byte fails, and each exception is inert once its change is in the event base. Repository-owned non-PR workflow jobs execute this lane against a new local backend with all four pinned CLIs. Pull requests and forks run assembly only. Tag releases run all four full lanes against the exact tagged SHA before GPG import, build, or signing; each gate job has read-only contents permission and a wall timeout. There is no workflow-enabled remote mutation lane; adding one requires a separate future gate and reviewed scenario allowlist.
 
 ## Import ownership
 

--- a/internal_testing/upgrade_matrix/verify_runtime_parity.py
+++ b/internal_testing/upgrade_matrix/verify_runtime_parity.py
@@ -66,6 +66,45 @@ REVIEWED_ISSUE213_PATHS = (
 REVIEWED_ISSUE213_RUNTIME_DIFF_SHA256 = (
     "e921feaf70385ea8ee2d3928f052a80b439139cb31bf72a5e2bba48026935819"
 )
+REVIEWED_ISSUE222_BASE = "6296b878bd183d62a9b2b12cde8f1109eff5f37c"
+REVIEWED_ISSUE222_PATHS = (
+    "internal/provider/datasource_access_group.go",
+    "internal/provider/datasource_access_groups_list.go",
+    "internal/provider/datasource_agents_list.go",
+    "internal/provider/datasource_budget.go",
+    "internal/provider/datasource_budgets_list.go",
+    "internal/provider/datasource_completion_protocol_test.go",
+    "internal/provider/datasource_guardrails_list.go",
+    "internal/provider/datasource_key.go",
+    "internal/provider/datasource_keys_list.go",
+    "internal/provider/datasource_list_presence_protocol_test.go",
+    "internal/provider/datasource_mcp_presence_protocol_test.go",
+    "internal/provider/datasource_mcp_presence_test.go",
+    "internal/provider/datasource_mcp_server.go",
+    "internal/provider/datasource_mcp_servers_list.go",
+    "internal/provider/datasource_model.go",
+    "internal/provider/datasource_models_list.go",
+    "internal/provider/datasource_organizations_list.go",
+    "internal/provider/datasource_presence.go",
+    "internal/provider/datasource_presence_test.go",
+    "internal/provider/datasource_projects_list.go",
+    "internal/provider/datasource_prompts_list.go",
+    "internal/provider/datasource_search_tool.go",
+    "internal/provider/datasource_search_tools_list.go",
+    "internal/provider/datasource_singular_presence_protocol_test.go",
+    "internal/provider/datasource_tags_list.go",
+    "internal/provider/datasource_team.go",
+    "internal/provider/datasource_team_presence_protocol_test.go",
+    "internal/provider/datasource_team_presence_test.go",
+    "internal/provider/datasource_teams_list.go",
+    "internal/provider/datasource_unified_access_groups_list.go",
+    "internal/provider/datasource_user.go",
+    "internal/provider/datasource_users_list.go",
+    "internal/provider/jwt_key_mapping_api.go",
+)
+REVIEWED_ISSUE222_RUNTIME_DIFF_SHA256 = (
+    "c39ad77222db81dbb872cbe46b08dc23bb162065b0ee8ca706196a6006a03f41"
+)
 
 
 def git(*args: str) -> str:
@@ -131,6 +170,12 @@ def main() -> int:
             and digest == REVIEWED_ISSUE213_RUNTIME_DIFF_SHA256
         ):
             reviewed = "issue213"
+        elif (
+            comparison == REVIEWED_ISSUE222_BASE
+            and changed_paths == REVIEWED_ISSUE222_PATHS
+            and digest == REVIEWED_ISSUE222_RUNTIME_DIFF_SHA256
+        ):
+            reviewed = "issue222"
         if reviewed is not None:
             print(
                 f"Provider runtime parity verified: reviewed={reviewed} "

--- a/internal_testing/upgrade_matrix/verify_runtime_parity.py
+++ b/internal_testing/upgrade_matrix/verify_runtime_parity.py
@@ -86,6 +86,7 @@ REVIEWED_ISSUE222_PATHS = (
     "internal/provider/datasource_models_list.go",
     "internal/provider/datasource_organizations_list.go",
     "internal/provider/datasource_presence.go",
+    "internal/provider/datasource_presence_review_regression_test.go",
     "internal/provider/datasource_presence_test.go",
     "internal/provider/datasource_projects_list.go",
     "internal/provider/datasource_prompts_list.go",
@@ -101,9 +102,10 @@ REVIEWED_ISSUE222_PATHS = (
     "internal/provider/datasource_user.go",
     "internal/provider/datasource_users_list.go",
     "internal/provider/jwt_key_mapping_api.go",
+    "internal/provider/list_helpers.go",
 )
 REVIEWED_ISSUE222_RUNTIME_DIFF_SHA256 = (
-    "c39ad77222db81dbb872cbe46b08dc23bb162065b0ee8ca706196a6006a03f41"
+    "4842dbb53f7277f4e20a09a35e2f12d5c419c6bdd7d177af5eb623649c6db34c"
 )
 
 


### PR DESCRIPTION
### Summary

Addresses #222. Singular and list data sources now use strict presence-aware projection so every successful read resolves every Computed path to a known value or typed null without collapsing absent, null, empty, false, or zero. Malformed envelopes, mismatched or duplicate identities, late invalid nested values, and disappearing enrichment records fail atomically instead of publishing filtered or partial state.

Public schemas, filters, sentinel IDs, ordering, sensitivity, and API-only operation remain compatible. Unknown/empty optional filters fail before HTTP; #213 MCP masking and sensitive complete JSON and #217 Team wrapped/permissions authority remain intact.

### Validation

Validated with focused protocol/unit and race coverage, full Go tests, vet, reproducible pinned-source contract checks, runtime-evidence adversarial safety tests, and the full double-opt-in LiteLLM v1.98 acceptance suite. All 23 supported resources and their data sources passed apply/read/no-drift/destroy; project remains the expected enterprise-only exclusion. Independent code and CI-security reviews returned **SHIP**.

Reviewer focus: shared typed presence helpers, atomic list identity checks, pinned Team/User/MCP envelopes, and content-safe failure paths.

### Diff size

**Docs** — 1 file · `+1 / -1`

Extends the runtime-evidence scope note for this reviewed patch.

**Implementation** — 30 files · `+1679 / -942`

Introduces shared strict projection helpers and migrates all affected singular/list read paths. Reviewed contract artifacts reflect physical call-site changes; the CI verifier binds the runtime patch to its exact base, 35-path set, and binary digest.

**Tests** — 9 files · `+2198 / -0`

Adds registry-wide protocol completion checks and adversarial coverage for typed nulls, explicit empty/false/zero, duplicate identities, malformed late elements, unknown filters, enrichment races, pinned envelopes, MCP masking, Team permissions, and diagnostic privacy.
