### PR TITLE
fix: retry authoritative JWT mapping reads

### DIFF
--- a/internal/provider/jwt_key_mapping_api.go
+++ b/internal/provider/jwt_key_mapping_api.go
@@ -179,7 +179,7 @@ func readJWTKeyMappingWithConnection(ctx context.Context, client *Client, id str
 	if fresh {
 		err = client.doFreshRequestWithResponse(ctx, http.MethodGet, jwtKeyMappingInfoEndpoint(id), nil, &raw)
 	} else {
-		err = client.DoRequestWithResponse(ctx, http.MethodGet, jwtKeyMappingInfoEndpoint(id), nil, &raw)
+		err = client.DoReadWithResponse(ctx, http.MethodGet, jwtKeyMappingInfoEndpoint(id), nil, &raw)
 	}
 	if err != nil {
 		return jwtKeyMappingObject{}, err

--- a/internal/provider/jwt_key_mapping_safe_read_protocol_test.go
+++ b/internal/provider/jwt_key_mapping_safe_read_protocol_test.go
@@ -1,0 +1,205 @@
+package provider
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+)
+
+func jwtMappingProtocolPriorState(t *testing.T, schema *tfprotov6.Schema) *tfprotov6.DynamicValue {
+	t.Helper()
+	return jwtMappingProtocolValue(t, schema, map[string]interface{}{
+		"id":              jwtMappingID1,
+		"jwt_claim_name":  "sub",
+		"jwt_claim_value": "prior-claim-secret",
+		"key_wo_version":  "prior-version",
+		"description":     "prior-description-secret",
+		"is_active":       false,
+		"created_at":      "2026-08-26T00:00:00Z",
+		"updated_at":      "2026-08-26T00:01:00Z",
+		"created_by":      "prior-creator-secret",
+		"updated_by":      "prior-updater-secret",
+	})
+}
+
+func assertJWTMappingProtocolStateEqual(t *testing.T, schema *tfprotov6.Schema, want, got *tfprotov6.DynamicValue) {
+	t.Helper()
+	wantValue, err := want.Unmarshal(schema.ValueType())
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotValue, err := got.Unmarshal(schema.ValueType())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !wantValue.Equal(gotValue) {
+		differences, _ := gotValue.Diff(wantValue)
+		t.Fatalf("state changed: %v", differences)
+	}
+}
+
+func TestJWTKeyMappingResourceSafeReadProtocolSequences(t *testing.T) {
+	ctx := context.Background()
+	var mu sync.Mutex
+	mode := "success"
+	attempt := 0
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		mu.Lock()
+		currentMode := mode
+		attempt++
+		currentAttempt := attempt
+		mu.Unlock()
+		writer.Header().Set("Content-Type", "application/json")
+		if request.Method != http.MethodGet || request.URL.RequestURI() != jwtKeyMappingInfoEndpoint(jwtMappingID1) {
+			http.Error(writer, `{"detail":"unexpected route"}`, http.StatusBadRequest)
+			return
+		}
+		switch currentMode {
+		case "transient-success":
+			if currentAttempt == 1 {
+				writer.Header().Set("Retry-After", "0")
+				http.Error(writer, `{"detail":"temporary-response-secret"}`, http.StatusServiceUnavailable)
+				return
+			}
+			_ = json.NewEncoder(writer).Encode(jwtMappingJSON(jwtMappingID1, "refreshed-claim-secret", "refreshed-description-secret", true))
+		case "exhaustion":
+			writer.Header().Set("Retry-After", "0")
+			http.Error(writer, `{"detail":"body-secret 404 not found"}`, http.StatusBadGateway)
+		case "terminal-4xx":
+			http.Error(writer, `{"detail":"404 not found body-secret"}`, http.StatusBadRequest)
+		case "malformed":
+			_, _ = writer.Write([]byte(`{"id":`))
+		case "mismatch":
+			_ = json.NewEncoder(writer).Encode(jwtMappingJSON(jwtMappingID2, "wrong-claim-secret", nil, true))
+		case "404":
+			http.Error(writer, `{"detail":"missing body-secret"}`, http.StatusNotFound)
+		default:
+			_ = json.NewEncoder(writer).Encode(jwtMappingJSON(jwtMappingID1, "refreshed-claim-secret", nil, true))
+		}
+	}))
+	defer server.Close()
+
+	protocolServer, schemas := configuredImportProtocolServer(t, ctx, server.URL)
+	schema := schemas.ResourceSchemas["litellm_jwt_key_mapping"]
+	prior := jwtMappingProtocolPriorState(t, schema)
+	private, err := json.Marshal(map[string][]byte{jwtKeyMappingDescriptionOwnedPrivateKey: []byte("true")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	read := func(readMode string) (*tfprotov6.ReadResourceResponse, int) {
+		t.Helper()
+		mu.Lock()
+		mode = readMode
+		attempt = 0
+		mu.Unlock()
+		response, readErr := protocolServer.ReadResource(ctx, &tfprotov6.ReadResourceRequest{TypeName: "litellm_jwt_key_mapping", CurrentState: prior, Private: private})
+		if readErr != nil {
+			t.Fatalf("mode=%s err=%v", readMode, readErr)
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		return response, attempt
+	}
+
+	t.Run("transient then 200 refreshes state", func(t *testing.T) {
+		response, calls := read("transient-success")
+		if accessGroupProtocolDiagnosticsHaveError(response.Diagnostics) || calls != 2 {
+			t.Fatalf("calls=%d diagnostics=%s", calls, agentProtocolDiagnosticsText(response.Diagnostics))
+		}
+		attributes := protocolAttributeMap(t, schema, response.NewState)
+		var claimValue string
+		if err := attributes["jwt_claim_value"].As(&claimValue); err != nil || claimValue != "refreshed-claim-secret" {
+			t.Fatalf("claim=%q err=%v", claimValue, err)
+		}
+		if !bytes.Equal(response.Private, private) {
+			t.Fatalf("private changed: got=%s want=%s", response.Private, private)
+		}
+	})
+
+	for _, failureMode := range []string{"exhaustion", "terminal-4xx", "malformed", "mismatch"} {
+		failureMode := failureMode
+		t.Run(failureMode+" retains public and private state", func(t *testing.T) {
+			response, calls := read(failureMode)
+			wantCalls := 1
+			if failureMode == "exhaustion" {
+				wantCalls = defaultSafeReadRetryPolicy.maxAttempts
+			}
+			text := agentProtocolDiagnosticsText(response.Diagnostics)
+			if !accessGroupProtocolDiagnosticsHaveError(response.Diagnostics) || calls != wantCalls {
+				t.Fatalf("calls=%d want=%d diagnostics=%s", calls, wantCalls, text)
+			}
+			assertJWTMappingProtocolStateEqual(t, schema, prior, response.NewState)
+			if !bytes.Equal(response.Private, private) {
+				t.Fatalf("private changed: got=%s want=%s", response.Private, private)
+			}
+			for _, forbidden := range []string{server.URL, jwtMappingID1, "prior-claim-secret", "prior-description-secret", "body-secret", "wrong-claim-secret", "jwt/key/mapping", "id="} {
+				if strings.Contains(text, forbidden) {
+					t.Fatalf("diagnostic exposed %q: %s", forbidden, text)
+				}
+			}
+		})
+	}
+
+	t.Run("complete exact 404 removes resource after one attempt", func(t *testing.T) {
+		response, calls := read("404")
+		if accessGroupProtocolDiagnosticsHaveError(response.Diagnostics) || calls != 1 {
+			t.Fatalf("calls=%d diagnostics=%s", calls, agentProtocolDiagnosticsText(response.Diagnostics))
+		}
+		value, err := response.NewState.Unmarshal(schema.ValueType())
+		if err != nil || !value.IsNull() {
+			t.Fatalf("state=%v err=%v", value, err)
+		}
+	})
+}
+
+func TestJWTKeyMappingDataSourceSafeReadFailurePublishesNoPartialStateProtocol(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		status int
+		body   string
+		calls  int
+	}{
+		{name: "complete exact 404", status: http.StatusNotFound, body: `{"detail":"missing secret"}`, calls: 1},
+		{name: "malformed JSON", status: http.StatusOK, body: `{"id":`, calls: 1},
+		{name: "identity mismatch", status: http.StatusOK, body: `{"id":"22222222-2222-4222-8222-222222222222","jwt_claim_name":"sub","jwt_claim_value":"wrong-claim-secret","description":null,"is_active":true,"created_at":"2026-08-26T00:00:00Z","updated_at":"2026-08-26T00:01:00Z","created_by":null,"updated_by":null}`, calls: 1},
+		{name: "retry exhaustion", status: http.StatusServiceUnavailable, body: `{"detail":"404 not found body-secret"}`, calls: defaultSafeReadRetryPolicy.maxAttempts},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			var calls atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				calls.Add(1)
+				writer.Header().Set("Content-Type", "application/json")
+				if test.status == http.StatusServiceUnavailable {
+					writer.Header().Set("Retry-After", "0")
+				}
+				writer.WriteHeader(test.status)
+				_, _ = writer.Write([]byte(test.body))
+			}))
+			defer server.Close()
+			protocolServer, schemas := configuredImportProtocolServer(t, ctx, server.URL)
+			schema := schemas.DataSourceSchemas["litellm_jwt_key_mapping"]
+			config := singularPresenceConfig(t, schema, map[string]interface{}{"id": jwtMappingID1})
+			response, err := protocolServer.ReadDataSource(ctx, &tfprotov6.ReadDataSourceRequest{TypeName: "litellm_jwt_key_mapping", Config: config})
+			text := agentProtocolDiagnosticsText(response.Diagnostics)
+			if err != nil || !accessGroupProtocolDiagnosticsHaveError(response.Diagnostics) || calls.Load() != int32(test.calls) {
+				t.Fatalf("err=%v calls=%d want=%d diagnostics=%s", err, calls.Load(), test.calls, text)
+			}
+			assertSingularPresenceStateUnchanged(t, schema, config, response.State)
+			for _, forbidden := range []string{server.URL, jwtMappingID1, "missing secret", "body-secret", "wrong-claim-secret", "jwt/key/mapping", "id="} {
+				if strings.Contains(text, forbidden) {
+					t.Fatalf("diagnostic exposed %q: %s", forbidden, text)
+				}
+			}
+		})
+	}
+}

--- a/internal/provider/jwt_key_mapping_safe_read_test.go
+++ b/internal/provider/jwt_key_mapping_safe_read_test.go
@@ -1,0 +1,377 @@
+package provider
+
+import (
+	"bytes"
+	"context"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func readJWTKeyMappingWithTestPolicy(ctx context.Context, client *Client, id string, policy safeReadRetryPolicy, hooks safeReadRetryHooks) (jwtKeyMappingObject, error) {
+	var raw json.RawMessage
+	if err := client.doReadWithResponsePolicy(ctx, http.MethodGet, jwtKeyMappingInfoEndpoint(id), nil, &raw, policy, hooks); err != nil {
+		return jwtKeyMappingObject{}, err
+	}
+	mapping, err := decodeJWTKeyMappingObject(raw)
+	if err != nil {
+		return jwtKeyMappingObject{}, err
+	}
+	if mapping.ID != id {
+		return jwtKeyMappingObject{}, errors.New("JWT key mapping response identity did not match the requested UUID")
+	}
+	return mapping, nil
+}
+
+func jwtMappingTestResponse(request *http.Request, status int, body []byte, headers http.Header) *http.Response {
+	if headers == nil {
+		headers = make(http.Header)
+	}
+	return &http.Response{
+		StatusCode:    status,
+		Header:        headers,
+		Body:          io.NopCloser(bytes.NewReader(body)),
+		ContentLength: int64(len(body)),
+		Request:       request,
+	}
+}
+
+func jwtMappingTestBody(t *testing.T, id string) []byte {
+	t.Helper()
+	body, err := json.Marshal(jwtMappingJSON(id, "claim-secret", nil, true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return body
+}
+
+func TestJWTKeyMappingOrdinaryReadUsesBoundedRetryTransport(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	body := jwtMappingTestBody(t, jwtMappingID1)
+	client := testRetryClient(func(request *http.Request) (*http.Response, error) {
+		if request.Method != http.MethodGet || request.URL.RequestURI() != jwtKeyMappingInfoEndpoint(jwtMappingID1) {
+			t.Fatalf("request=%s %s", request.Method, request.URL.RequestURI())
+		}
+		if calls.Add(1) == 1 {
+			return jwtMappingTestResponse(request, http.StatusServiceUnavailable, []byte(`{"detail":"temporary"}`), nil), nil
+		}
+		return jwtMappingTestResponse(request, http.StatusOK, body, nil), nil
+	})
+	mapping, err := readJWTKeyMapping(context.Background(), client, jwtMappingID1)
+	if err != nil || mapping.ID != jwtMappingID1 || calls.Load() != 2 {
+		t.Fatalf("mapping=%#v calls=%d err=%v", mapping, calls.Load(), err)
+	}
+}
+
+func TestJWTKeyMappingSafeReadStatusAndBodySequences(t *testing.T) {
+	t.Parallel()
+
+	policy := testReadPolicy(4)
+	body := jwtMappingTestBody(t, jwtMappingID1)
+
+	t.Run("complete exact 404 is terminal", func(t *testing.T) {
+		t.Parallel()
+		var calls atomic.Int32
+		client := testRetryClient(func(request *http.Request) (*http.Response, error) {
+			calls.Add(1)
+			return jwtMappingTestResponse(request, http.StatusNotFound, []byte(`{"detail":"missing"}`), nil), nil
+		})
+		_, err := readJWTKeyMapping(context.Background(), client, jwtMappingID1)
+		if !IsAPIErrorStatus(err, http.StatusNotFound) || calls.Load() != 1 {
+			t.Fatalf("calls=%d classification=%#v err=%v", calls.Load(), ClassifyHTTPFailure(err), err)
+		}
+	})
+
+	t.Run("misleading terminal body is not classification input", func(t *testing.T) {
+		t.Parallel()
+		var calls atomic.Int32
+		client := testRetryClient(func(request *http.Request) (*http.Response, error) {
+			calls.Add(1)
+			return jwtMappingTestResponse(request, http.StatusBadRequest, []byte(`{"detail":"404 not found; retry 503 timeout"}`), nil), nil
+		})
+		_, err := readJWTKeyMapping(context.Background(), client, jwtMappingID1)
+		if !IsAPIErrorStatus(err, http.StatusBadRequest) || IsAPIErrorStatus(err, http.StatusNotFound) || calls.Load() != 1 {
+			t.Fatalf("calls=%d classification=%#v err=%v", calls.Load(), ClassifyHTTPFailure(err), err)
+		}
+	})
+
+	t.Run("incomplete 404 retries then succeeds", func(t *testing.T) {
+		t.Parallel()
+		var calls atomic.Int32
+		client := testRetryClient(func(request *http.Request) (*http.Response, error) {
+			if calls.Add(1) == 1 {
+				response := jwtMappingTestResponse(request, http.StatusNotFound, nil, nil)
+				response.Body = failingReadCloser{err: io.ErrUnexpectedEOF}
+				response.ContentLength = -1
+				return response, nil
+			}
+			return jwtMappingTestResponse(request, http.StatusOK, body, nil), nil
+		})
+		mapping, err := readJWTKeyMappingWithTestPolicy(context.Background(), client, jwtMappingID1, policy, noWaitRetryHooks())
+		if err != nil || mapping.ID != jwtMappingID1 || calls.Load() != 2 {
+			t.Fatalf("mapping=%#v calls=%d err=%v", mapping, calls.Load(), err)
+		}
+	})
+
+	t.Run("retry exhaustion is bounded", func(t *testing.T) {
+		t.Parallel()
+		var calls atomic.Int32
+		client := testRetryClient(func(request *http.Request) (*http.Response, error) {
+			calls.Add(1)
+			return jwtMappingTestResponse(request, http.StatusBadGateway, []byte(`{"detail":"still unavailable"}`), nil), nil
+		})
+		_, err := readJWTKeyMappingWithTestPolicy(context.Background(), client, jwtMappingID1, policy, noWaitRetryHooks())
+		if !IsAPIErrorStatus(err, http.StatusBadGateway) || calls.Load() != int32(policy.maxAttempts) {
+			t.Fatalf("calls=%d classification=%#v err=%v", calls.Load(), ClassifyHTTPFailure(err), err)
+		}
+	})
+
+	t.Run("malformed JSON is terminal", func(t *testing.T) {
+		t.Parallel()
+		var calls atomic.Int32
+		client := testRetryClient(func(request *http.Request) (*http.Response, error) {
+			calls.Add(1)
+			return jwtMappingTestResponse(request, http.StatusOK, []byte(`{"id":`), nil), nil
+		})
+		_, err := readJWTKeyMapping(context.Background(), client, jwtMappingID1)
+		if err == nil || calls.Load() != 1 || ClassifyHTTPFailure(err).Kind != HTTPFailureContractOrLocal {
+			t.Fatalf("calls=%d classification=%#v err=%v", calls.Load(), ClassifyHTTPFailure(err), err)
+		}
+	})
+
+	t.Run("identity mismatch is terminal", func(t *testing.T) {
+		t.Parallel()
+		var calls atomic.Int32
+		mismatchBody := jwtMappingTestBody(t, jwtMappingID2)
+		client := testRetryClient(func(request *http.Request) (*http.Response, error) {
+			calls.Add(1)
+			return jwtMappingTestResponse(request, http.StatusOK, mismatchBody, nil), nil
+		})
+		_, err := readJWTKeyMapping(context.Background(), client, jwtMappingID1)
+		if err == nil || calls.Load() != 1 {
+			t.Fatalf("calls=%d err=%v", calls.Load(), err)
+		}
+	})
+
+	t.Run("terminal TLS failure is not retried", func(t *testing.T) {
+		t.Parallel()
+		var calls atomic.Int32
+		client := testRetryClient(func(*http.Request) (*http.Response, error) {
+			calls.Add(1)
+			return nil, x509.UnknownAuthorityError{}
+		})
+		_, err := readJWTKeyMapping(context.Background(), client, jwtMappingID1)
+		if err == nil || calls.Load() != 1 || ClassifyHTTPFailure(err).Kind != HTTPFailureContractOrLocal {
+			t.Fatalf("calls=%d classification=%#v err=%v", calls.Load(), ClassifyHTTPFailure(err), err)
+		}
+	})
+
+	t.Run("invalid local configuration does not dispatch", func(t *testing.T) {
+		t.Parallel()
+		var calls atomic.Int32
+		client := &Client{APIBase: "://invalid", APIKey: "admin", HTTPClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			calls.Add(1)
+			return nil, errors.New("unexpected dispatch")
+		})}}
+		_, err := readJWTKeyMapping(context.Background(), client, jwtMappingID1)
+		if err == nil || calls.Load() != 0 || ClassifyHTTPFailure(err).Kind != HTTPFailureContractOrLocal {
+			t.Fatalf("calls=%d classification=%#v err=%v", calls.Load(), ClassifyHTTPFailure(err), err)
+		}
+	})
+}
+
+func TestJWTKeyMappingRetryAfterIsBoundedWithInjectedTiming(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	var slept time.Duration
+	body := jwtMappingTestBody(t, jwtMappingID1)
+	client := testRetryClient(func(request *http.Request) (*http.Response, error) {
+		if calls.Add(1) == 1 {
+			return jwtMappingTestResponse(request, http.StatusTooManyRequests, []byte(`{"detail":"rate limited"}`), http.Header{"Retry-After": []string{"30"}}), nil
+		}
+		return jwtMappingTestResponse(request, http.StatusOK, body, nil), nil
+	})
+	policy := testReadPolicy(3)
+	policy.maxRetryAfter = 2 * time.Second
+	hooks := noWaitRetryHooks()
+	hooks.sleep = func(_ context.Context, delay time.Duration) error {
+		slept = delay
+		return nil
+	}
+	mapping, err := readJWTKeyMappingWithTestPolicy(context.Background(), client, jwtMappingID1, policy, hooks)
+	if err != nil || mapping.ID != jwtMappingID1 || calls.Load() != 2 || slept != policy.maxRetryAfter {
+		t.Fatalf("mapping=%#v calls=%d slept=%s err=%v", mapping, calls.Load(), slept, err)
+	}
+}
+
+func TestJWTKeyMappingSafeReadCancellationAndDeadlinePrecedence(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name     string
+		context  func() (context.Context, context.CancelFunc)
+		wantKind HTTPFailureKind
+	}{
+		{
+			name: "cancellation",
+			context: func() (context.Context, context.CancelFunc) {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx, func() {}
+			},
+			wantKind: HTTPFailureCanceled,
+		},
+		{
+			name: "deadline",
+			context: func() (context.Context, context.CancelFunc) {
+				return context.WithDeadline(context.Background(), time.Unix(1, 0))
+			},
+			wantKind: HTTPFailureDeadline,
+		},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			var calls atomic.Int32
+			client := testRetryClient(func(request *http.Request) (*http.Response, error) {
+				calls.Add(1)
+				return jwtMappingTestResponse(request, http.StatusOK, jwtMappingTestBody(t, jwtMappingID1), nil), nil
+			})
+			ctx, cancel := test.context()
+			defer cancel()
+			_, err := readJWTKeyMapping(ctx, client, jwtMappingID1)
+			if ClassifyHTTPFailure(err).Kind != test.wantKind || calls.Load() != 0 {
+				t.Fatalf("calls=%d classification=%#v err=%v", calls.Load(), ClassifyHTTPFailure(err), err)
+			}
+		})
+	}
+}
+
+func TestJWTKeyMappingRetryTimingIsRaceIsolatedPerRead(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	calls := map[string]int{}
+	bodyByID := map[string][]byte{jwtMappingID1: jwtMappingTestBody(t, jwtMappingID1), jwtMappingID2: jwtMappingTestBody(t, jwtMappingID2)}
+	client := testRetryClient(func(request *http.Request) (*http.Response, error) {
+		id := request.URL.Query().Get("id")
+		mu.Lock()
+		calls[id]++
+		attempt := calls[id]
+		mu.Unlock()
+		if attempt == 1 {
+			retryAfter := "1"
+			if id == jwtMappingID2 {
+				retryAfter = "3"
+			}
+			return jwtMappingTestResponse(request, http.StatusTooManyRequests, []byte(`{"detail":"retry"}`), http.Header{"Retry-After": []string{retryAfter}}), nil
+		}
+		return jwtMappingTestResponse(request, http.StatusOK, bodyByID[id], nil), nil
+	})
+
+	type result struct {
+		id    string
+		slept time.Duration
+		err   error
+	}
+	results := make(chan result, 2)
+	for _, id := range []string{jwtMappingID1, jwtMappingID2} {
+		id := id
+		go func() {
+			var slept time.Duration
+			hooks := noWaitRetryHooks()
+			hooks.sleep = func(_ context.Context, delay time.Duration) error { slept = delay; return nil }
+			mapping, err := readJWTKeyMappingWithTestPolicy(context.Background(), client, id, testReadPolicy(3), hooks)
+			if err == nil && mapping.ID != id {
+				err = errors.New("mapping identity changed")
+			}
+			results <- result{id: id, slept: slept, err: err}
+		}()
+	}
+	for range 2 {
+		result := <-results
+		want := time.Second
+		if result.id == jwtMappingID2 {
+			want = 3 * time.Second
+		}
+		if result.err != nil || result.slept != want {
+			t.Fatalf("id=%s slept=%s want=%s err=%v", result.id, result.slept, want, result.err)
+		}
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if calls[jwtMappingID1] != 2 || calls[jwtMappingID2] != 2 {
+		t.Fatalf("calls=%v", calls)
+	}
+}
+
+func TestJWTKeyMappingFreshListAndMutationPathsRemainSingleAttempt(t *testing.T) {
+	t.Parallel()
+
+	var freshCalls, listCalls atomic.Int32
+	mutationCalls := map[string]int{}
+	var mutationMu sync.Mutex
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		switch request.URL.Path {
+		case jwtKeyMappingInfoPath:
+			freshCalls.Add(1)
+		case jwtKeyMappingListPath:
+			listCalls.Add(1)
+		default:
+			mutationMu.Lock()
+			mutationCalls[request.Method+" "+request.URL.Path]++
+			mutationMu.Unlock()
+		}
+		writer.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = writer.Write([]byte(`{"detail":"temporary"}`))
+	}))
+	defer server.Close()
+	client := &Client{APIBase: server.URL, APIKey: "admin", HTTPClient: server.Client()}
+
+	if _, err := readFreshJWTKeyMapping(context.Background(), client, jwtMappingID1); !IsAPIErrorStatus(err, http.StatusServiceUnavailable) || freshCalls.Load() != 1 {
+		t.Fatalf("fresh calls=%d err=%v", freshCalls.Load(), err)
+	}
+	if _, err := listJWTKeyMappings(context.Background(), client); !IsAPIErrorStatus(err, http.StatusServiceUnavailable) || listCalls.Load() != 1 {
+		t.Fatalf("list calls=%d err=%v", listCalls.Load(), err)
+	}
+	for _, mutation := range []struct {
+		method string
+		path   string
+	}{
+		{http.MethodPost, jwtKeyMappingCreatePath},
+		{http.MethodPost, jwtKeyMappingUpdatePath},
+		{http.MethodPost, jwtKeyMappingDeletePath},
+	} {
+		var raw json.RawMessage
+		err := client.DoRequestWithResponse(context.Background(), mutation.method, mutation.path, map[string]string{"value": "secret"}, &raw)
+		if !IsAPIErrorStatus(err, http.StatusServiceUnavailable) {
+			t.Fatalf("%s %s err=%v", mutation.method, mutation.path, err)
+		}
+	}
+	mutationMu.Lock()
+	defer mutationMu.Unlock()
+	for _, mutation := range []struct {
+		method string
+		path   string
+	}{
+		{http.MethodPost, jwtKeyMappingCreatePath},
+		{http.MethodPost, jwtKeyMappingUpdatePath},
+		{http.MethodPost, jwtKeyMappingDeletePath},
+	} {
+		key := mutation.method + " " + mutation.path
+		if mutationCalls[key] != 1 {
+			t.Fatalf("%s calls=%d", key, mutationCalls[key])
+		}
+	}
+}

--- a/internal/provider/safe_read_retry.go
+++ b/internal/provider/safe_read_retry.go
@@ -54,8 +54,8 @@ func defaultSafeReadRetryHooks() safeReadRetryHooks {
 
 // DoReadWithResponse performs a bounded, cancellable retry of a GET or HEAD
 // request. It retries only safe transient transport failures and exact HTTP
-// 408, 429, or 5xx responses. Existing resource and data-source reads continue
-// to use the single-attempt API until a later issue #202 migration phase.
+// 408, 429, or 5xx responses. Resource and data-source reads use this API only
+// after a deliberately scoped issue #202 migration.
 func (c *Client) DoReadWithResponse(ctx context.Context, method, requestPath string, body interface{}, result interface{}) error {
 	return c.doReadWithResponsePolicy(ctx, method, requestPath, body, result, defaultSafeReadRetryPolicy, defaultSafeReadRetryHooks())
 }

--- a/internal_testing/upgrade_matrix/README.md
+++ b/internal_testing/upgrade_matrix/README.md
@@ -66,7 +66,7 @@ sh internal_testing/upgrade_matrix/run.sh local
 internal_testing/compose.sh down -v
 ```
 
-The runtime-parity gate retains digest-bound exceptions for the reviewed #210, #217, #213, and #222 provider patches from their exact integration bases and exact path sets; a different path or patch byte fails, and each exception is inert once its change is in the event base. Repository-owned non-PR workflow jobs execute this lane against a new local backend with all four pinned CLIs. Pull requests and forks run assembly only. Tag releases run all four full lanes against the exact tagged SHA before GPG import, build, or signing; each gate job has read-only contents permission and a wall timeout. There is no workflow-enabled remote mutation lane; adding one requires a separate future gate and reviewed scenario allowlist.
+The runtime-parity gate retains digest-bound exceptions for the reviewed #210, #217, #213, #222, and #202 Phase 2 provider patches from their exact integration bases and exact path sets; a different path or patch byte fails, and each exception is inert once its change is in the event base. Repository-owned non-PR workflow jobs execute this lane against a new local backend with all four pinned CLIs. Pull requests and forks run assembly only. Tag releases run all four full lanes against the exact tagged SHA before GPG import, build, or signing; each gate job has read-only contents permission and a wall timeout. There is no workflow-enabled remote mutation lane; adding one requires a separate future gate and reviewed scenario allowlist.
 
 ## Import ownership
 

--- a/internal_testing/upgrade_matrix/verify_runtime_parity.py
+++ b/internal_testing/upgrade_matrix/verify_runtime_parity.py
@@ -107,6 +107,16 @@ REVIEWED_ISSUE222_PATHS = (
 REVIEWED_ISSUE222_RUNTIME_DIFF_SHA256 = (
     "4842dbb53f7277f4e20a09a35e2f12d5c419c6bdd7d177af5eb623649c6db34c"
 )
+REVIEWED_ISSUE202_PHASE2_BASE = "5f1b3a9c5889f552bd5227aed724e85b853d3db1"
+REVIEWED_ISSUE202_PHASE2_PATHS = (
+    "internal/provider/jwt_key_mapping_api.go",
+    "internal/provider/jwt_key_mapping_safe_read_protocol_test.go",
+    "internal/provider/jwt_key_mapping_safe_read_test.go",
+    "internal/provider/safe_read_retry.go",
+)
+REVIEWED_ISSUE202_PHASE2_RUNTIME_DIFF_SHA256 = (
+    "76315bef756afdc23bc2aaf69c46bb18b4dfc7b8eaa1696667a2233ee9a7b63e"
+)
 
 
 def git(*args: str) -> str:
@@ -178,6 +188,12 @@ def main() -> int:
             and digest == REVIEWED_ISSUE222_RUNTIME_DIFF_SHA256
         ):
             reviewed = "issue222"
+        elif (
+            comparison == REVIEWED_ISSUE202_PHASE2_BASE
+            and changed_paths == REVIEWED_ISSUE202_PHASE2_PATHS
+            and digest == REVIEWED_ISSUE202_PHASE2_RUNTIME_DIFF_SHA256
+        ):
+            reviewed = "issue202-phase2"
         if reviewed is not None:
             print(
                 f"Provider runtime parity verified: reviewed={reviewed} "


### PR DESCRIPTION
### Summary

Continues #202 with the first Phase 2 call-site migration. The ordinary database-authoritative JWT key-mapping `GET /jwt/key/mapping/info?id={uuid}` now uses the bounded safe-read policy for transient transport failures, 408, 429, and 5xx responses while complete 404 responses remain terminal and authoritative.

Fresh post-mutation confirmation reads, collection reads, and every mutation remain single-attempt. Public schema, state, import identity, HCL, and diagnostics remain unchanged.

### Validation

Validated with focused unit and protocol coverage for retry bounds, cancellation, `Retry-After`, transient response-body failures, complete/incomplete 404 handling, diagnostic privacy, and mutation/list/fresh-read non-retry guarantees; full Go tests, race, vet, pinned-source contracts, and runtime-evidence safety checks passed. Pinned LiteLLM v1.98 apply/read/no-drift/destroy and external-delete refresh removal passed, and independent code and runtime-evidence reviews returned **SHIP**.

Reviewer focus: the deliberately narrow call-site scope and the terminal complete-404 boundary.

### Diff size

**Docs** — 1 file · `+1 / -1`

Extends the runtime-evidence scope note for this reviewed incremental patch.

**Implementation** — 3 files · `+19 / -3`

Migrates one singular read call site and binds the exact four-path runtime patch to its integration base and binary digest. The shared helper change is comment-only clarification of the retry boundary.

**Tests** — 2 files · `+582 / -0`

Adds exhaustive bounded-retry and protocol regression coverage because retry safety depends on status completeness, request class, cancellation, and mutation/readback distinctions.
